### PR TITLE
Fix docker-compose.yaml and set up env.example that both local develo…

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,1 +1,29 @@
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/appdb
+# =============================================================================
+# Environment Configuration Template
+# =============================================================================
+# Copy this file to `.env` and fill in your values.
+
+# -----------------------------------------------------------------------------
+# Database
+#
+# Local development
+#   Docker Compose maps the Postgres container port to 5433 on the host,
+#   so use localhost:5433 here.
+#
+# Docker / CI (backend running inside a container):
+#   The docker-compose.yml overrides DATABASE_URL automatically to use the
+#   internal `db:5432` address, so you don't need to change this file.
+# -----------------------------------------------------------------------------
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5433/appdb
+
+# -----------------------------------------------------------------------------
+# CORS
+# JSON array of origins the browser is allowed to call from.
+# -----------------------------------------------------------------------------
+CORS_ALLOWED_ORIGINS=["http://localhost:3000"]
+
+# -----------------------------------------------------------------------------
+# LLM
+# API key for the language model provider used by the analysis pipeline.
+# -----------------------------------------------------------------------------
+LLM_API_KEY=<your_api_key_here>

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       context: .
       target: runtime
     env_file: .env
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/appdb
     ports:
       - "${APP_PORT:-8000}:8000"
     depends_on:
@@ -37,6 +39,8 @@ services:
       context: .
       target: test
     env_file: .env
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/appdb
     volumes:
       - ./htmlcov:/app/htmlcov
     depends_on:


### PR DESCRIPTION
Fix docker-compose.yaml and set up env.example that both local development and run with docker works independantly for best dev experience.
Because with postgresql+asyncpg://postgres:postgres@db:5432/appdb uvicorn app.main:app fails. To this and also docker build works set localhost in env and overwrite it during docker build. 