### PR TITLE
Add one-command bootstrap scripts for automated build process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Enforce LF line endings for shell scripts on all platforms.
+# This prevents Windows Git from checking out .sh files with CRLF,
+# which would break the bash shebang line.
+*.sh    text eol=lf
+*.sh    diff

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -4,6 +4,8 @@ FastAPI backend — async SQLAlchemy 2.x, Pydantic v2, Loguru.
 
 ## Quick Start
 
+> **One-command setup:** From the repository root, run `./setup.sh` (Linux/macOS/Git Bash) or `.\setup.ps1` (Windows PowerShell). It handles everything below automatically. See the [root README](../README.md) for details.
+
 ### Prerequisites
 - Python 3.11+
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip

--- a/README.md
+++ b/README.md
@@ -32,27 +32,58 @@ The recommended way to start the application is via Docker.
    cd amos2026ss02-automated-thematic-analysis
    ```
 
-2. **Set up configuration:**
-   Navigate to the `Backend` folder and prepare your environment variables.
+2. **Run the bootstrap script:**
 
+   **Linux / macOS / Git Bash (Windows):**
    ```bash
-   cd Backend
-   cp .env.example .env
-   # Update .env if necessary with specific credentials
+   chmod +x setup.sh
+   ./setup.sh
    ```
 
-3. **Start the application:**
-   Launch the FastAPI backend and the PostgreSQL database container.
-
-   ```bash
-   docker compose up --build
+   **Windows (PowerShell / Windows Terminal):**
+   ```powershell
+   .\setup.ps1
    ```
+
+   The script will:
+   - Verify Docker and Docker Compose v2 are installed and running
+   - Create `Backend/.env` from the template (if it does not exist yet)
+   - Build the Docker images and start the stack
+   - Wait until the API health check passes, then print the service URLs
+
+3. **Set your LLM API key** (required for analysis features):
+
+   Open `Backend/.env` and replace the placeholder value for `LLM_API_KEY`.
 
 4. **Access the API:**
 
    - **API Server:** [http://localhost:8000](http://localhost:8000)
    - **Interactive API Docs (Swagger):** [http://localhost:8000/docs](http://localhost:8000/docs)
    - The application also serves a Demo UI and Codebook Selection templates to visually interact with the thematic graph.
+
+#### Common commands
+
+| Task | Linux/macOS | Windows PowerShell |
+|------|-------------|-------------------|
+| Start stack | `./setup.sh` | `.\setup.ps1` |
+| Start (foreground logs) | `./setup.sh -f` | `.\setup.ps1 -Foreground` |
+| Run tests | `./setup.sh --test` | `.\setup.ps1 -Test` |
+| Stop stack | `./setup.sh --down` | `.\setup.ps1 -Down` |
+| Stop + delete data | `./setup.sh --down-volumes` | `.\setup.ps1 -DownVolumes` |
+
+Run `./setup.sh --help` or `Get-Help .\setup.ps1` for the full option reference.
+
+<details>
+<summary>Manual setup (fallback)</summary>
+
+```bash
+cd Backend
+cp .env.example .env
+# Edit .env with your credentials
+docker compose up --build
+```
+
+</details>
 
 ## Further Documentation
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared helpers — must be sourced, not executed directly.
+# Requires: SCRIPT_DIR to be set in the sourcing script.
+
+# ── Colors ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+if [[ ! -t 1 ]] || [[ -n "${NO_COLOR:-}" ]]; then
+  RED='' GREEN='' YELLOW='' BLUE='' BOLD='' RESET=''
+fi
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log_info()    { printf "${BLUE}[INFO]${RESET}    %s\n"    "$*"; }
+log_success() { printf "${GREEN}[OK]${RESET}      %s\n"   "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${RESET}    %s\n"  "$*" >&2; }
+log_error()   { printf "${RED}[ERROR]${RESET}   %s\n"    "$*" >&2; }
+
+die() {
+  log_error "$*"
+  exit 1
+}
+
+on_error() {
+  local exit_code=$1 line=$2
+  log_error "Script failed (exit $exit_code) at line $line"
+}
+
+# ── wait_for_http <url> [max_seconds] ─────────────────────────────────────────
+# Polls <url> every 3 seconds until HTTP 200 is returned or <max_seconds> elapses.
+# Falls back through curl → wget → python3 for portability.
+wait_for_http() {
+  local url=$1 max_seconds=${2:-60}
+  local elapsed=0 interval=3 status
+
+  while (( elapsed < max_seconds )); do
+    status=""
+
+    if command -v curl &>/dev/null; then
+      status=$(curl -o /dev/null -s -w "%{http_code}" --connect-timeout 3 "$url" 2>/dev/null || true)
+
+    elif command -v wget &>/dev/null; then
+      status=$(wget -qO- --server-response "$url" 2>&1 \
+        | awk '/^  HTTP\//{print $2}' | tail -1 || true)
+
+    else
+      status=$(python3 - "$url" <<'EOF' 2>/dev/null || echo 0
+import sys, urllib.request
+try:
+    r = urllib.request.urlopen(sys.argv[1], timeout=3)
+    print(r.status)
+except Exception:
+    print(0)
+EOF
+      )
+    fi
+
+    [[ "$status" == "200" ]] && return 0
+
+    sleep "$interval"
+    (( elapsed += interval ))
+  done
+
+  return 1
+}

--- a/scripts/lib/env.sh
+++ b/scripts/lib/env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# .env bootstrap helpers — must be sourced after common.sh.
+# Relies on $SCRIPT_DIR being set in the sourcing script.
+
+ensure_env_file() {
+  local env_file="$SCRIPT_DIR/Backend/.env"
+  local env_example="$SCRIPT_DIR/Backend/.env.example"
+
+  if [[ -f "$env_file" ]]; then
+    log_info ".env already exists — skipping copy"
+    return 0
+  fi
+
+  [[ -f "$env_example" ]] \
+    || die "Template $env_example not found. Is the repository fully checked out?"
+
+  cp "$env_example" "$env_file"
+  log_success "Created Backend/.env from Backend/.env.example"
+  log_warn  "Set LLM_API_KEY in Backend/.env before using LLM-dependent features"
+}
+
+scan_env_placeholders() {
+  local env_file="$SCRIPT_DIR/Backend/.env"
+
+  if grep -qF '<your_api_key_here>' "$env_file" 2>/dev/null; then
+    log_warn "LLM_API_KEY is still the placeholder value in Backend/.env"
+    log_warn "LLM-dependent endpoints will return errors until a real key is set"
+  fi
+}

--- a/scripts/lib/prereqs.sh
+++ b/scripts/lib/prereqs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Prerequisite checks — must be sourced after common.sh.
+
+require_docker() {
+  if ! command -v docker &>/dev/null; then
+    die "Docker is not installed. Get it at: https://docs.docker.com/get-docker/"
+  fi
+
+  if ! docker version &>/dev/null 2>&1; then
+    die "Docker daemon is not running. Start Docker Desktop or run: sudo systemctl start docker"
+  fi
+
+  log_success "Docker is available"
+}
+
+require_compose_v2() {
+  if ! docker compose version &>/dev/null 2>&1; then
+    die "Docker Compose v2 (the 'docker compose' subcommand) is required. Update Docker Desktop or see: https://docs.docker.com/compose/install/"
+  fi
+
+  log_success "Docker Compose v2 is available"
+}

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,281 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  One-command bootstrap for the Automated Thematic Analysis stack (Windows).
+
+.DESCRIPTION
+  Verifies prerequisites (Docker, Docker Compose v2), creates Backend\.env from
+  the template if it does not exist, builds Docker images, starts the stack, and
+  polls the API health endpoint until ready.
+
+  Run this script from the repository root in PowerShell or Windows Terminal.
+
+.PARAMETER Test
+  Run the pytest test suite inside Docker.
+
+.PARAMETER Down
+  Stop and remove containers (data volumes are preserved).
+
+.PARAMETER DownVolumes
+  Stop and remove containers AND the Postgres data volume.
+
+.PARAMETER Foreground
+  Stream container output to the terminal instead of running detached.
+
+.PARAMETER NoBuild
+  Skip rebuilding images (use whatever is cached locally).
+
+.PARAMETER Rebuild
+  Force a full image rebuild with --no-cache.
+
+.PARAMETER Yes
+  Skip all confirmation prompts (use with -DownVolumes).
+
+.EXAMPLE
+  .\setup.ps1
+  .\setup.ps1 -Test
+  .\setup.ps1 -Down
+  .\setup.ps1 -DownVolumes -Yes
+  .\setup.ps1 -Foreground
+#>
+[CmdletBinding()]
+param(
+  [switch]$Test,
+  [switch]$Down,
+  [switch]$DownVolumes,
+  [switch]$Foreground,
+  [switch]$NoBuild,
+  [switch]$Rebuild,
+  [switch]$Yes,
+  [Parameter(ValueFromRemainingArguments)]
+  [string[]]$ExtraArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir   = $PSScriptRoot
+$ComposeDir  = Join-Path $ScriptDir 'Backend'
+$AppPort     = if ($env:APP_PORT) { $env:APP_PORT } else { '8000' }
+$EnvFile     = Join-Path $ComposeDir '.env'
+$EnvExample  = Join-Path $ComposeDir '.env.example'
+
+# ── Logging helpers ───────────────────────────────────────────────────────────
+function Write-Info    { param([string]$Msg) Write-Host "[INFO]  $Msg" -ForegroundColor Cyan }
+function Write-Ok      { param([string]$Msg) Write-Host "[OK]    $Msg" -ForegroundColor Green }
+function Write-Warning { param([string]$Msg) Write-Host "[WARN]  $Msg" -ForegroundColor Yellow }
+function Write-Err     { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
+
+function Exit-WithError {
+  param([string]$Msg)
+  Write-Err $Msg
+  exit 1
+}
+
+# ── Prerequisite checks ───────────────────────────────────────────────────────
+function Assert-Docker {
+  if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Exit-WithError "Docker is not installed. Get it at: https://docs.docker.com/get-docker/"
+  }
+
+  $null = docker version 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    Exit-WithError "Docker daemon is not running. Start Docker Desktop and try again."
+  }
+
+  Write-Ok "Docker is available"
+}
+
+function Assert-ComposeV2 {
+  $null = docker compose version 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    Exit-WithError "Docker Compose v2 (the 'docker compose' subcommand) is required. Update Docker Desktop or see: https://docs.docker.com/compose/install/"
+  }
+
+  Write-Ok "Docker Compose v2 is available"
+}
+
+# ── .env bootstrap ────────────────────────────────────────────────────────────
+function Ensure-EnvFile {
+  if (Test-Path $EnvFile) {
+    Write-Info ".env already exists — skipping copy"
+    return
+  }
+
+  if (-not (Test-Path $EnvExample)) {
+    Exit-WithError "Template $EnvExample not found. Is the repository fully checked out?"
+  }
+
+  Copy-Item $EnvExample $EnvFile
+  Write-Ok   "Created Backend\.env from Backend\.env.example"
+  Write-Warning "Set LLM_API_KEY in Backend\.env before using LLM-dependent features"
+}
+
+function Test-EnvPlaceholders {
+  if (Test-Path $EnvFile) {
+    $content = Get-Content $EnvFile -Raw
+    if ($content -match '<your_api_key_here>') {
+      Write-Warning "LLM_API_KEY is still the placeholder value in Backend\.env"
+      Write-Warning "LLM-dependent endpoints will return errors until a real key is set"
+    }
+  }
+}
+
+# ── HTTP readiness poll ───────────────────────────────────────────────────────
+function Wait-ForHttp {
+  param(
+    [string]$Url,
+    [int]$MaxSeconds = 60
+  )
+
+  $elapsed  = 0
+  $interval = 3
+
+  while ($elapsed -lt $MaxSeconds) {
+    try {
+      $response = Invoke-WebRequest -Uri $Url -TimeoutSec 3 -UseBasicParsing `
+                    -ErrorAction Stop
+      if ($response.StatusCode -eq 200) { return $true }
+    }
+    catch {
+      # Connection refused or non-200 — keep waiting
+    }
+
+    Start-Sleep -Seconds $interval
+    $elapsed += $interval
+  }
+
+  return $false
+}
+
+# ── Compose wrapper ───────────────────────────────────────────────────────────
+# NOTE: $Args is a PowerShell automatic variable — do NOT use it as a param name.
+function Invoke-Compose {
+  param([string[]]$ComposeArgs)
+  Push-Location $ComposeDir
+  try {
+    & docker compose @ComposeArgs
+    if ($LASTEXITCODE -ne 0) {
+      Exit-WithError "docker compose exited with code $LASTEXITCODE"
+    }
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+# ── Mode: down ────────────────────────────────────────────────────────────────
+function Invoke-Down {
+  param([bool]$RemoveVolumes)
+
+  Write-Info "Stopping containers..."
+
+  if ($RemoveVolumes) {
+    if (-not $Yes) {
+      $answer = Read-Host "[WARN]  This will DELETE the Postgres data volume. Continue? [y/N]"
+      if ($answer -notmatch '^[Yy]$') {
+        Write-Info "Aborted — no changes made."
+        exit 0
+      }
+    }
+    Invoke-Compose @('down', '-v')
+    Write-Ok "Containers stopped and data volumes removed"
+  }
+  else {
+    Invoke-Compose @('down')
+    Write-Ok "Containers stopped (data volumes preserved)"
+  }
+}
+
+# ── Mode: test ────────────────────────────────────────────────────────────────
+function Invoke-Test {
+  Write-Info "Running test suite inside Docker..."
+
+  $pytestArgs = @(
+    '--profile', 'test', 'run', '--rm', 'api-test',
+    'pytest', '--cov=app', '--cov-report=term-missing', '--cov-report=html'
+  )
+
+  if ($ExtraArgs) { $pytestArgs += $ExtraArgs }
+
+  Invoke-Compose $pytestArgs
+  Write-Ok "Tests complete. Open Backend\htmlcov\index.html for the coverage report."
+}
+
+# ── Mode: up ──────────────────────────────────────────────────────────────────
+function Invoke-Up {
+  Write-Info "Starting the stack..."
+
+  $upFlags = @()
+  if (-not $Foreground) { $upFlags += '-d' }
+  if ($Rebuild)         { $upFlags += '--build'; $upFlags += '--no-cache' }
+  elseif (-not $NoBuild){ $upFlags += '--build' }
+
+  if (-not $NoBuild) {
+    Write-Info "Building images — first run can take 3-5 minutes..."
+  }
+
+  Invoke-Compose (@('up') + $upFlags)
+
+  # In foreground mode, Compose streams until Ctrl+C — nothing more to do.
+  if ($Foreground) { return }
+
+  Write-Info "Waiting for API to become ready (up to 60s)..."
+  $healthUrl = "http://localhost:${AppPort}/api/v1/health/ready"
+
+  if (Wait-ForHttp -Url $healthUrl -MaxSeconds 60) {
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════╗" -ForegroundColor Green
+    Write-Host "║        Stack is up and healthy!              ║" -ForegroundColor Green
+    Write-Host "╚══════════════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  API server   http://localhost:${AppPort}"      -ForegroundColor White
+    Write-Host "  API docs     http://localhost:${AppPort}/docs"  -ForegroundColor White
+    Write-Host "  Postgres     localhost:5433"                    -ForegroundColor White
+    Write-Host ""
+    Write-Host "Next steps:"
+    Write-Host "  Tail logs    docker compose logs -f api  (run from Backend\ directory)"
+    Write-Host "  Run tests    .\setup.ps1 -Test"
+    Write-Host "  Stop stack   .\setup.ps1 -Down"
+    Write-Host ""
+  }
+  else {
+    Push-Location $ComposeDir
+    $running = & docker compose ps --status running --quiet api 2>$null
+    Pop-Location
+
+    if ([string]::IsNullOrWhiteSpace($running)) {
+      Write-Err "The 'api' container exited unexpectedly."
+    }
+    else {
+      Write-Err "API container is running but health check timed out (60s)."
+    }
+    Write-Err "Inspect logs with: docker compose logs api  (run from the Backend\ directory)"
+    exit 1
+  }
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+Write-Host "Automated Thematic Analysis — bootstrap" -ForegroundColor White
+Write-Host ""
+
+Assert-Docker
+Assert-ComposeV2
+Write-Host ""
+
+Ensure-EnvFile
+Test-EnvPlaceholders
+Write-Host ""
+
+if ($DownVolumes) {
+  Invoke-Down -RemoveVolumes $true
+}
+elseif ($Down) {
+  Invoke-Down -RemoveVolumes $false
+}
+elseif ($Test) {
+  Invoke-Test
+}
+else {
+  Invoke-Up
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_DIR="$SCRIPT_DIR/Backend"
+APP_PORT="${APP_PORT:-8000}"
+
+# shellcheck source=scripts/lib/common.sh
+source "$SCRIPT_DIR/scripts/lib/common.sh"
+# shellcheck source=scripts/lib/prereqs.sh
+source "$SCRIPT_DIR/scripts/lib/prereqs.sh"
+# shellcheck source=scripts/lib/env.sh
+source "$SCRIPT_DIR/scripts/lib/env.sh"
+
+trap 'on_error $? $LINENO' ERR
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+MODE="up"
+BUILD=true
+REBUILD=false
+DETACH=true
+CONFIRM_YES=false
+EXTRA_ARGS=()
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [-- EXTRA_PYTEST_ARGS...]
+
+One-command bootstrap for the Automated Thematic Analysis stack.
+
+OPTIONS
+  -h, --help           Show this help and exit
+  -d, --detach         Run containers in the background (default)
+  -f, --foreground     Stream container logs to the terminal
+      --no-build       Skip image rebuild (use cached images)
+      --rebuild        Force full image rebuild (--no-cache)
+      --test           Run the pytest test suite inside Docker
+      --down           Stop and remove containers (keep data volumes)
+      --down-volumes   Stop and remove containers AND data volumes
+  -y, --yes            Skip confirmation prompts (use with --down-volumes)
+
+ENVIRONMENT
+  APP_PORT             Override the API host port (default: 8000)
+
+EXAMPLES
+  ./setup.sh                       Build and start the full stack
+  ./setup.sh --foreground          Start and tail logs in the terminal
+  ./setup.sh --no-build            Start without rebuilding images
+  ./setup.sh --test                Run the full pytest suite
+  ./setup.sh --test -- -k health   Run only tests matching 'health'
+  ./setup.sh --down                Stop containers (keep data)
+  ./setup.sh --down-volumes -y     Stop containers and delete Postgres data
+EOF
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+PARSING_MAIN=true
+for arg in "$@"; do
+  if $PARSING_MAIN; then
+    case "$arg" in
+      -h|--help)        usage; exit 0 ;;
+      -d|--detach)      DETACH=true ;;
+      -f|--foreground)  DETACH=false ;;
+      --no-build)       BUILD=false ;;
+      --rebuild)        REBUILD=true ;;
+      --test)           MODE="test" ;;
+      --down)           MODE="down" ;;
+      --down-volumes)   MODE="down-volumes" ;;
+      -y|--yes)         CONFIRM_YES=true ;;
+      --)               PARSING_MAIN=false ;;
+      *)                log_error "Unknown option: $arg"; printf "\n"; usage; exit 1 ;;
+    esac
+  else
+    EXTRA_ARGS+=("$arg")
+  fi
+done
+
+# ── Compose wrapper ───────────────────────────────────────────────────────────
+# All mode functions run after `cd "$COMPOSE_DIR"`, so docker compose
+# picks up docker-compose.yml from Backend/ automatically.
+run_compose() {
+  docker compose "$@"
+}
+
+# ── Mode: down ────────────────────────────────────────────────────────────────
+mode_down() {
+  local remove_volumes=${1:-false}
+
+  log_info "Stopping containers..."
+
+  if $remove_volumes; then
+    if ! $CONFIRM_YES; then
+      printf "${YELLOW}[WARN]${RESET}    This will DELETE the Postgres data volume. Continue? [y/N] "
+      read -r answer
+      [[ "$answer" =~ ^[Yy]$ ]] || { log_info "Aborted — no changes made."; exit 0; }
+    fi
+    run_compose down -v
+    log_success "Containers stopped and data volumes removed"
+  else
+    run_compose down
+    log_success "Containers stopped (data volumes preserved)"
+  fi
+}
+
+# ── Mode: test ────────────────────────────────────────────────────────────────
+mode_test() {
+  log_info "Running test suite inside Docker..."
+
+  local pytest_cmd=(pytest --cov=app --cov-report=term-missing --cov-report=html)
+  (( ${#EXTRA_ARGS[@]} > 0 )) && pytest_cmd+=("${EXTRA_ARGS[@]}")
+
+  run_compose --profile test run --rm api-test "${pytest_cmd[@]}"
+  log_success "Tests complete. Open Backend/htmlcov/index.html for the coverage report."
+}
+
+# ── Mode: up ──────────────────────────────────────────────────────────────────
+mode_up() {
+  log_info "Starting the stack..."
+
+  local up_flags=()
+  $DETACH && up_flags+=("-d")
+  if $REBUILD; then
+    up_flags+=(--build --no-cache)
+  elif $BUILD; then
+    up_flags+=(--build)
+  fi
+
+  if $BUILD || $REBUILD; then
+    log_info "Building images — first run can take 3–5 minutes..."
+  fi
+
+  run_compose up "${up_flags[@]}"
+
+  # In foreground mode Compose streams logs until Ctrl+C; nothing more to do.
+  $DETACH || return 0
+
+  log_info "Waiting for API to become ready (up to 60s)..."
+  local health_url="http://localhost:${APP_PORT}/api/v1/health/ready"
+
+  if wait_for_http "$health_url" 60; then
+    print_success_banner
+  else
+    # Diagnose: distinguish exited container vs slow startup
+    local running
+    running=$(run_compose ps --status running --quiet api 2>/dev/null || true)
+    if [[ -z "$running" ]]; then
+      log_error "The 'api' container exited unexpectedly."
+    else
+      log_error "API container is running but health check timed out (60s)."
+    fi
+    log_error "Inspect logs with: docker compose logs api  (run from the Backend/ directory)"
+    exit 1
+  fi
+}
+
+print_success_banner() {
+  printf "\n"
+  printf "${GREEN}${BOLD}╔══════════════════════════════════════════════╗${RESET}\n"
+  printf "${GREEN}${BOLD}║        Stack is up and healthy!              ║${RESET}\n"
+  printf "${GREEN}${BOLD}╚══════════════════════════════════════════════╝${RESET}\n"
+  printf "\n"
+  printf "  API server   ${BOLD}http://localhost:${APP_PORT}${RESET}\n"
+  printf "  API docs     ${BOLD}http://localhost:${APP_PORT}/docs${RESET}\n"
+  printf "  Postgres     ${BOLD}localhost:5433${RESET}\n"
+  printf "\n"
+  printf "Next steps:\n"
+  printf "  Tail logs    ${BOLD}docker compose logs -f api${RESET}   (from Backend/ directory)\n"
+  printf "  Run tests    ${BOLD}./setup.sh --test${RESET}\n"
+  printf "  Stop stack   ${BOLD}./setup.sh --down${RESET}\n"
+  printf "\n"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+main() {
+  printf "${BOLD}Automated Thematic Analysis — bootstrap${RESET}\n\n"
+
+  require_docker
+  require_compose_v2
+  printf "\n"
+
+  ensure_env_file
+  scan_env_placeholders
+  printf "\n"
+
+  cd "$COMPOSE_DIR"
+
+  case "$MODE" in
+    up)           mode_up ;;
+    test)         mode_test ;;
+    down)         mode_down false ;;
+    down-volumes) mode_down true ;;
+  esac
+}
+
+main

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Convenience wrapper — equivalent to: ./setup.sh --down
+# Pass -y / --yes to also skip the confirmation prompt.
+# Pass --down-volumes to remove data volumes as well.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/setup.sh" --down "$@"


### PR DESCRIPTION
 Implements the automated build process user story. A single command from
  the repo root verifies prerequisites, creates Backend/.env from the
  template if missing, builds Docker images, starts the stack, and polls
  the API readiness endpoint before printing service URLs.

  - setup.sh — Linux/macOS/Git Bash entry point with full flag support (--test, --down, --down-volumes, --foreground, --no-build, --rebuild)
  - setup.ps1 — Windows PowerShell equivalent with matching parameters
  - teardown.sh — convenience wrapper for ./setup.sh --down
  - scripts/lib/common.sh — colored logging, wait_for_http helper
  - scripts/lib/prereqs.sh — Docker and Compose v2 prerequisite checks
  - scripts/lib/env.sh — .env bootstrap with placeholder warning
  - .gitattributes — enforce LF line endings on .sh files
  - README.md / Backend/README.md — updated with one-command quick start