### PR TITLE
 embedding model selection documentation

### DIFF
--- a/Deliverables/sprint-04/embedding-model-selection.md
+++ b/Deliverables/sprint-04/embedding-model-selection.md
@@ -16,4 +16,4 @@ _Source: [Hugging Face MTEB leaderboard](https://huggingface.co/spaces/mteb/lead
 
 ## Best overall model
 
-**`microsoft/harrier-oss-v1-0.6b`** has the best overall leaderboard rank, strong clustering/similarity performance, and a MIT license. It performs well on all potential tasks.
+**`microsoft/harrier-oss-v1-0.6b`** has the best overall leaderboard rank, strong clustering/similarity performance, and a MIT license. It performs well on all potential tasks required for the project like classification and embedding. Additionally, it works for multilingual tasks including german.

--- a/Deliverables/sprint-04/embedding-model-selection.md
+++ b/Deliverables/sprint-04/embedding-model-selection.md
@@ -1,0 +1,19 @@
+# Embedding model evaluation
+
+| Rank | Model | Mean | Clustering | STS | Retrieval | License | Issues |
+|---:|---|---:|---:|---:|---:|---|---|
+| 1 | harrier-oss-v1-0.6b | 69.01 | 54.00 | 77.09 | 70.75 | MIT | Best overall |
+| 2 | jina-embeddings-v5-text-small | 67.00 | 53.41 | 78.85 | 64.88 | CC BY-NC 4.0 | Non-commercial |
+| 3 | harrier-oss-v1-270m | 66.55 | 52.51 | 75.35 | 66.38 | MIT |  |
+| 4 | Qwen3-Embedding-0.6B | 64.34 | 52.33 | 76.17 | 64.65 | Apache-2.0 | Bias/censorship risk for sensitive political corpora |
+| 5 | jina-embeddings-v5-text-nano | 65.52 | 52.73 | 78.17 | 63.26 | CC BY-NC 4.0 | Non-commercial |
+| 6 | multilingual-e5-large-instruct | 63.22 | 50.75 | 76.81 | 57.12 | MIT |  |
+| 7 | F2LLM-v2-0.6B | 62.74 | 56.58 | 74.22 | 59.30 | Apache-2.0 |  |
+| 8 | embeddinggemma-300m | 61.15 | 51.17 | 74.73 | 62.49 | Gemma | Custom Google license |
+
+_Source: [Hugging Face MTEB leaderboard](https://huggingface.co/spaces/mteb/leaderboard)._
+
+
+## Best overall model
+
+**`microsoft/harrier-oss-v1-0.6b`** has the best overall leaderboard rank, strong clustering/similarity performance, and a MIT license. It performs well on all potential tasks.

--- a/Deliverables/sprint-04/embedding-model-selection.md
+++ b/Deliverables/sprint-04/embedding-model-selection.md
@@ -17,3 +17,4 @@ _Source: [Hugging Face MTEB leaderboard](https://huggingface.co/spaces/mteb/lead
 ## Best overall model
 
 **`microsoft/harrier-oss-v1-0.6b`** has the best overall leaderboard rank, strong clustering/similarity performance, and a MIT license. It performs well on all potential tasks required for the project like classification and embedding. Additionally, it works for multilingual tasks including german.
+Its balance of strong benchmark performance, multilingual support, and permissive licensing makes it the most practical and future-proof choice.

--- a/Deliverables/sprint-04/embedding-model-selection.md
+++ b/Deliverables/sprint-04/embedding-model-selection.md
@@ -17,4 +17,5 @@ _Source: [Hugging Face MTEB leaderboard](https://huggingface.co/spaces/mteb/lead
 ## Best overall model
 
 **`microsoft/harrier-oss-v1-0.6b`** has the best overall leaderboard rank, strong clustering/similarity performance, and a MIT license. It performs well on all potential tasks required for the project like classification and embedding. Additionally, it works for multilingual tasks including german.
-Its balance of strong benchmark performance, multilingual support, and permissive licensing makes it the most practical and future-proof choice.
+
+This combination of reliable performance, multilingual capability, and open licensing makes it a strong and sustainable choice for the project.


### PR DESCRIPTION
This pull request adds a new document summarizing the evaluation and selection of embedding models for the project. The document recommends `microsoft/harrier-oss-v1-0.6b` as the best overall choice due to its strong performance, multilingual support, and permissive MIT license.

Embedding model evaluation and selection:

* Added `embedding-model-selection.md` with a ranked table comparing top embedding models on mean score, clustering, STS, retrieval, license, and notable issues, based on the Hugging Face MTEB leaderboard.
* Highlighted `microsoft/harrier-oss-v1-0.6b` as the recommended model due to its best overall rank, strong performance across tasks, multilingual support (including German), and MIT license.