### PR TITLE
Close CodeQL open-redirect alert in 413 handler

### DIFF
--- a/Frontend/tests/test_error_handlers.py
+++ b/Frontend/tests/test_error_handlers.py
@@ -45,6 +45,8 @@ def test_413_always_redirects_to_home_ignoring_referrer(client, fake_backend, ap
     application home page regardless of any Referer header the request carried.
     We never pass user-controlled values to redirect() so the dataflow CodeQL
     looks for (request.referrer / Host → redirect) doesn't exist."""
+    from flask import url_for
+
     max_bytes = app.config["MAX_CONTENT_LENGTH"]
     body = b"x" * (max_bytes + 1024)
     resp = client.post(
@@ -55,11 +57,14 @@ def test_413_always_redirects_to_home_ignoring_referrer(client, fake_backend, ap
         follow_redirects=False,
     )
     assert resp.status_code == 303
-    location = resp.headers["Location"]
-    # Strict check: the target must equal the home page URL — `endswith("/")`
-    # would also accept e.g. "/transcripts/", silently hiding a regression
-    # where the handler started redirecting somewhere unexpected.
-    assert location in {"/", "http://localhost/"}
+
+    # Derive the expected target from url_for so the test stays correct if
+    # the home route ever moves or APPLICATION_ROOT changes. Werkzeug may
+    # emit either the relative or absolute form, so accept both.
+    with app.test_request_context():
+        expected_relative = url_for("main.index")
+        expected_absolute = url_for("main.index", _external=True)
+    assert resp.headers["Location"] in {expected_relative, expected_absolute}
 
 
 # Generic Exception handler

--- a/Frontend/tests/test_error_handlers.py
+++ b/Frontend/tests/test_error_handlers.py
@@ -40,9 +40,11 @@ def test_413_when_request_body_exceeds_max_content_length(client, fake_backend, 
     assert resp.status_code == 303
 
 
-def test_413_does_not_open_redirect_to_external_referrer(client, fake_backend, app):
-    """Open Redirect guard: an external Referer header must NOT be followed
-    after a 413; the handler must fall back to the home page (CWE-601)."""
+def test_413_always_redirects_to_home_ignoring_referrer(client, fake_backend, app):
+    """Open Redirect guard (CWE-601): the 413 handler must redirect to the
+    application home page regardless of any Referer header the request carried.
+    We never pass user-controlled values to redirect() so the dataflow CodeQL
+    looks for (request.referrer / Host → redirect) doesn't exist."""
     max_bytes = app.config["MAX_CONTENT_LENGTH"]
     body = b"x" * (max_bytes + 1024)
     resp = client.post(
@@ -53,9 +55,12 @@ def test_413_does_not_open_redirect_to_external_referrer(client, fake_backend, a
         follow_redirects=False,
     )
     assert resp.status_code == 303
-    # Redirect target must be our home page, NOT the attacker's domain.
-    assert "attacker.example.com" not in resp.headers["Location"]
-    assert resp.headers["Location"].endswith("/")
+    location = resp.headers["Location"]
+    # Target must be our home page, never the attacker's domain.
+    assert "attacker.example.com" not in location
+    # Location should point at the index route ("/") — either absolute on our
+    # test host or relative depending on Werkzeug version.
+    assert location.endswith("/") or location.rstrip("/").endswith("localhost")
 
 
 # Generic Exception handler

--- a/Frontend/tests/test_error_handlers.py
+++ b/Frontend/tests/test_error_handlers.py
@@ -56,11 +56,10 @@ def test_413_always_redirects_to_home_ignoring_referrer(client, fake_backend, ap
     )
     assert resp.status_code == 303
     location = resp.headers["Location"]
-    # Target must be our home page, never the attacker's domain.
-    assert "attacker.example.com" not in location
-    # Location should point at the index route ("/") — either absolute on our
-    # test host or relative depending on Werkzeug version.
-    assert location.endswith("/") or location.rstrip("/").endswith("localhost")
+    # Strict check: the target must equal the home page URL — `endswith("/")`
+    # would also accept e.g. "/transcripts/", silently hiding a regression
+    # where the handler started redirecting somewhere unexpected.
+    assert location in {"/", "http://localhost/"}
 
 
 # Generic Exception handler

--- a/Frontend/web/__init__.py
+++ b/Frontend/web/__init__.py
@@ -66,8 +66,10 @@ def _register_error_handlers(app: Flask) -> None:
         # 303 forces a GET on the redirect, so the browser doesn't try to re-POST.
         # Always redirect to home — never to a user-controlled value (e.g.
         # request.referrer) — to eliminate the open-redirect risk (CWE-601).
-        # CodeQL's py/url-redirection rule only recognises hardcoded targets
-        # or strict allowlists as sanitizers, not netloc/host comparisons.
+        # CodeQL's py/url-redirection rule recognises only a small set of
+        # sanitiser patterns (strict allowlist, empty-netloc-and-scheme
+        # relative URLs, Django's url_has_allowed_host_and_scheme). A
+        # hardcoded url_for() target sidesteps the dataflow entirely.
         return redirect(url_for("main.index")), 303
 
     @app.errorhandler(Exception)

--- a/Frontend/web/__init__.py
+++ b/Frontend/web/__init__.py
@@ -1,28 +1,10 @@
 import atexit
 import logging
-from urllib.parse import urlparse
 
-from flask import Flask, current_app, flash, redirect, render_template, request, url_for
+from flask import Flask, current_app, flash, redirect, render_template, url_for
 
 from web.config import Config, get_config
 from web.services.backend_client import BackendClient
-
-
-def _safe_referrer() -> str | None:
-    """Return `request.referrer` only when it points back to our own host.
-
-    The Referer header is browser-supplied and attacker-controllable, so
-    redirecting to it unconditionally creates an Open Redirect (CWE-601)
-    — a phishing primitive. Same-origin referrers are safe because they
-    can only target our own routes.
-    """
-    ref = request.referrer
-    if not ref:
-        return None
-    parsed = urlparse(ref)
-    if parsed.netloc and parsed.netloc != request.host:
-        return None
-    return ref
 
 
 def create_app(config: Config | None = None) -> Flask:
@@ -82,8 +64,11 @@ def _register_error_handlers(app: Flask) -> None:
             "danger",
         )
         # 303 forces a GET on the redirect, so the browser doesn't try to re-POST.
-        # `_safe_referrer()` blocks open-redirects via the Referer header.
-        return redirect(_safe_referrer() or url_for("main.index")), 303
+        # Always redirect to home — never to a user-controlled value (e.g.
+        # request.referrer) — to eliminate the open-redirect risk (CWE-601).
+        # CodeQL's py/url-redirection rule only recognises hardcoded targets
+        # or strict allowlists as sanitizers, not netloc/host comparisons.
+        return redirect(url_for("main.index")), 303
 
     @app.errorhandler(Exception)
     def unhandled(exc):


### PR DESCRIPTION
### Description
Follow-up to #77 — closes CodeQL alert #15 (`py/url-redirection`).

The merged version of PR #77 included an earlier attempt at the open-redirect fix that used a `_safe_referrer()` helper with a netloc-vs-request.host comparison. CodeQL's `py/url-redirection` rule only recognises three sanitizer patterns (strict allowlist, relative-URL-only via empty netloc *and* scheme, or Django's `url_has_allowed_host_and_scheme`) netloc comparison against `request.host` isn't one of them, so the alert kept firing.

### Fix
Remove `_safe_referrer()` entirely; always redirect to `url_for("main.index")` after a 413. No user-controlled value flows into `redirect()` anymore, so the dataflow CodeQL flags doesn't exist.

UX impact: after a >100 MB upload (the 413 threshold), the user lands on the home page instead of being bounced back to the upload form. The flash message tells them what happened. Acceptable trade-off for an edge case that's also the standard phishing primitive.

### Testing
- `pytest` — 37 tests passing
- `test_413_always_redirects_to_home_ignoring_referrer` asserts an attacker-controlled `Referer` header is ignored

CodeQL alert #15 should auto-close on next scan after merge.