### PR TITLE
Fixed issue in startup scripts which doesnt rebuild the test docker container

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -191,6 +191,15 @@ function Invoke-Down {
 function Invoke-Test {
   Write-Info "Running test suite inside Docker..."
 
+  if ($Rebuild) {
+    Write-Info "Rebuilding api-test image with --no-cache..."
+    Invoke-Compose @('--profile', 'test', 'build', '--no-cache', 'api-test')
+  }
+  elseif (-not $NoBuild) {
+    Write-Info "Ensuring api-test image is up to date..."
+    Invoke-Compose @('--profile', 'test', 'build', 'api-test')
+  }
+
   $pytestArgs = @(
     '--profile', 'test', 'run', '--rm', 'api-test',
     'pytest', '--cov=app', '--cov-report=term-missing', '--cov-report=html'

--- a/setup.sh
+++ b/setup.sh
@@ -107,6 +107,14 @@ mode_down() {
 mode_test() {
   log_info "Running test suite inside Docker..."
 
+  if $REBUILD; then
+    log_info "Rebuilding api-test image with --no-cache..."
+    run_compose --profile test build --no-cache api-test
+  elif $BUILD; then
+    log_info "Ensuring api-test image is up to date..."
+    run_compose --profile test build api-test
+  fi
+
   local pytest_cmd=(pytest --cov=app --cov-report=term-missing --cov-report=html)
   (( ${#EXTRA_ARGS[@]} > 0 )) && pytest_cmd+=("${EXTRA_ARGS[@]}")
 


### PR DESCRIPTION
This pull request improves the test execution process in both the PowerShell (`setup.ps1`) and Bash (`setup.sh`) setup scripts by adding logic to control when the Docker `api-test` image is rebuilt or updated before running the test suite. 