### PR TITLE
85 export codebook

### DIFF
--- a/Frontend/tests/test_codebook_controller.py
+++ b/Frontend/tests/test_codebook_controller.py
@@ -328,3 +328,47 @@ def test_success_renders_saved_details(client, fake_codebook_backend):
     assert b"Success Codebook" in resp.data
     assert b"Theme A" in resp.data
     assert fake_codebook_backend.last_fetched_id == "e2f1ad9a-6ab3-4df4-a3f2-c3a2f8b5a002"
+
+# ---------------------------------------------------------------------------
+# GET /codebooks/<codebook_id>/export
+# ---------------------------------------------------------------------------
+
+def test_export_codebook_success(client, fake_codebook_backend):
+    fake_codebook_backend.get_codebook_result = {
+        "id": "e2f1ad9a-6ab3-4df4-a3f2-c3a2f8b5a002",
+        "name": "Export Codebook",
+        "version": 1,
+        "themes": [
+            {
+                "node_type": "THEME",
+                "name": "Theme A",
+                "description": "Desc A",
+                "children": [
+                    {
+                        "node_type": "SUBTHEME",
+                        "name": "Sub A1",
+                        "description": "Desc A1",
+                        "children": []
+                    }
+                ]
+            }
+        ]
+    }
+
+    resp = client.get("/codebooks/e2f1ad9a-6ab3-4df4-a3f2-c3a2f8b5a002/export")
+
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/csv"
+    assert "attachment; filename=Export_Codebook_v1.csv" in resp.headers["Content-Disposition"]
+    
+    # Check CSV contents
+    csv_data = resp.data.decode("utf-8")
+    assert "Node Type,Name,Description,Parent Name" in csv_data
+    assert "THEME,Theme A,Desc A," in csv_data
+    assert "SUBTHEME,Sub A1,Desc A1,Theme A" in csv_data
+
+def test_export_codebook_not_found(client, fake_codebook_backend):
+    fake_codebook_backend.raise_on = "get_codebook"
+    resp = client.get("/codebooks/unknown-id/export")
+    assert resp.status_code == 302
+    assert "/codebooks/" in resp.headers["Location"]

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, flash, render_template, request, redirect, url_for, current_app
+import csv
+import io
+from flask import Blueprint, flash, render_template, request, redirect, url_for, current_app, Response
 
 from web.services.backend_client import (
     BackendError,
@@ -60,6 +62,50 @@ def codebook_themes(codebook_id: str) -> str:
         frequencies=frequencies,
         tree=tree,
     )
+
+@bp.get("/<codebook_id>/export")
+def export_codebook(codebook_id: str) -> Response | str:
+    """Export a codebook and its hierarchical themes as a CSV file."""
+    try:
+        client = _backend()
+        codebook = client.get_codebook(codebook_id)
+        themes = codebook.get("themes", [])
+
+        flat_rows = []
+
+        def traverse(node: dict, parent_name: str) -> None:
+            flat_rows.append({
+                "Node Type": node.get("node_type", "THEME"),
+                "Name": node.get("name", ""),
+                "Description": node.get("description", ""),
+                "Parent Name": parent_name,
+            })
+            for child in node.get("children", []):
+                traverse(child, node.get("name", ""))
+
+        for t in themes:
+            traverse(t, "")
+
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=["Node Type", "Name", "Description", "Parent Name"])
+        writer.writeheader()
+        writer.writerows(flat_rows)
+
+        csv_data = output.getvalue()
+        filename = f"{codebook.get('name', 'codebook').replace(' ', '_')}_v{codebook.get('version', 1)}.csv"
+
+        return Response(
+            csv_data,
+            mimetype="text/csv",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+    except BackendNotFoundError:
+        flash("That codebook couldn't be found. It may have been deleted.", "danger")
+        return redirect(url_for("codebooks.list_codebooks"))
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return redirect(url_for("codebooks.list_codebooks"))
+
 
 @bp.get("/upload")
 def upload_form() -> str:

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -12,7 +12,6 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
   {% block head_extra %}{% endblock %}
 </head>
-<<<<<<< HEAD
 <body class="bg-light site-body">
 
   <nav class="navbar navbar-expand-md navbar-dark bg-dark">
@@ -47,11 +46,11 @@
                href="{{ url_for('ingestion.transcripts_landing') }}">Transcripts</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('codebooks.') %}active{% endif %}"
+            <a class="nav-link {% if request.endpoint in ('codebooks.list_codebooks', 'codebooks.codebook_themes', 'codebooks.export_codebook', 'codebooks.success') %}active{% endif %}"
                href="{{ url_for('codebooks.list_codebooks') }}">Codebooks</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('codebooks.') %}active{% endif %}"
+            <a class="nav-link {% if request.endpoint in ('codebooks.upload_form', 'codebooks.upload_submit', 'codebooks.manual_form', 'codebooks.confirm_submit') %}active{% endif %}"
                href="{{ url_for('codebooks.upload_form') }}">Upload Codebook</a>
           </li>
           <li class="nav-item">

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -31,6 +31,10 @@
                      href="{{ url_for('codebooks.codebook_themes', codebook_id=cb.id, name=cb.name, version=cb.version) }}">
                     View themes
                   </a>
+                  <a class="btn btn-sm btn-outline-secondary ms-1"
+                     href="{{ url_for('codebooks.export_codebook', codebook_id=cb.id) }}">
+                    Export
+                  </a>
                 </td>
               </tr>
             {% endfor %}

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -23,9 +23,14 @@
         <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Theme Browser</p>
         <h1 class="h3 text-white mb-0">{{ name or 'Codebook Themes' }}</h1>
       </div>
-      {% if version %}
-        <span class="theme-version-badge align-self-start">v{{ version }}</span>
-      {% endif %}
+      <div class="d-flex align-items-center gap-2">
+        {% if version %}
+          <span class="theme-version-badge">v{{ version }}</span>
+        {% endif %}
+        <a href="{{ url_for('codebooks.export_codebook', codebook_id=codebook_id) }}" class="btn btn-sm btn-outline-light ms-2">
+          Export CSV
+        </a>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
This PR introduces the ability to export a persisted Codebook (and its nested themes) to a standard CSV file directly from the browser

It is built as a dependent branch off of 9-upload-predefined-codebook to utilize the new 4-column schema (Node Type, Name, Description, Parent Name)


changes:
* Frontend Export Route
* CSV Download
* UI Integrations with button
* UI Bugfixes (<<<<<<< HEAD merge conflict marker from base.html and navbar)
* Testing

testing:
Ensure the stack is running.
Navigate to the Codebooks page,
Click Export on any codebook (or from within its Theme Browser).
Verify the downloaded .csv file contains the Node Type, Name, Description, and Parent Name columns.
(Optional) Try re-uploading the downloaded CSV via the "Upload Codebook" page to verify complete format compatibility.