### PR TITLE
92 demographic data viewer page

### DIFF
--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -96,9 +96,13 @@ class FakeBackend:
         self._maybe_raise("list_demographic_files")
         return self.demographic_files
 
-    def list_demographic_rows(self, corpus_id, file_id, page=1, page_size=200) -> list[dict]:
+    def list_demographic_rows(self, corpus_id, file_id, page=1, page_size=100) -> dict:
         self._maybe_raise("list_demographic_rows")
-        return self.demographic_rows
+        total = len(self.demographic_rows)
+        return {
+            "items": self.demographic_rows,
+            "meta": {"page": page, "pages": max(1, (total + page_size - 1) // page_size), "total": total}
+        }
 
     def get_demographic_link_summary(self, corpus_id) -> dict:
         self._maybe_raise("get_demographic_link_summary")

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -39,6 +39,16 @@ class FakeBackend:
         self.codebooks: list[dict] = []
         self.theme_frequencies: list[dict] = []
         self.theme_tree: list[dict] = []
+        # Demographic data
+        self.demographic_files: list[dict] = []
+        self.demographic_rows: list[dict] = []
+        self.demographic_link_summary: dict = {
+            "total_transcripts": 0,
+            "matched": 0,
+            "details": [],
+        }
+        self.demographic_upload_response: dict | None = None
+        self.demographic_confirm_response: dict | None = None
         # Either a method-name string (generic BackendError) or a
         # (method-name, ExceptionClass) tuple (specific typed subclass).
         self.raise_on: str | tuple[str, type] | None = None
@@ -72,6 +82,28 @@ class FakeBackend:
         self._maybe_raise("get_theme_tree")
         return self.theme_tree
 
+    # ---- Demographic --------------------------------------------------------
+
+    def upload_demographic(self, corpus_id, file, name=None) -> dict:
+        self._maybe_raise("upload_demographic")
+        return self.demographic_upload_response or {}
+
+    def confirm_demographic(self, corpus_id, import_id, confirm) -> dict:
+        self._maybe_raise("confirm_demographic")
+        return self.demographic_confirm_response or {}
+
+    def list_demographic_files(self, corpus_id, page_size=200) -> list[dict]:
+        self._maybe_raise("list_demographic_files")
+        return self.demographic_files
+
+    def list_demographic_rows(self, corpus_id, file_id, page=1, page_size=200) -> list[dict]:
+        self._maybe_raise("list_demographic_rows")
+        return self.demographic_rows
+
+    def get_demographic_link_summary(self, corpus_id) -> dict:
+        self._maybe_raise("get_demographic_link_summary")
+        return self.demographic_link_summary
+
     # ---- Internal -----------------------------------------------------------
 
     def _maybe_raise(self, method: str) -> None:
@@ -94,6 +126,7 @@ def fake_backend(monkeypatch) -> FakeBackend:
     fake = FakeBackend()
     monkeypatch.setattr("web.controllers.ingestion._backend", lambda: fake)
     monkeypatch.setattr("web.controllers.codebooks._backend", lambda: fake)
+    monkeypatch.setattr("web.controllers.demographic._backend", lambda: fake)
     return fake
 
 

--- a/Frontend/tests/test_demographic.py
+++ b/Frontend/tests/test_demographic.py
@@ -1,0 +1,335 @@
+"""Tests for the demographic data controllers (list, upload, preview, view).
+
+Uses the `fake_backend` fixture from conftest.py - controllers' BackendClient
+is monkey-patched so tests never hit the real network.
+
+Routes are corpus-scoped: /demographic/<corpus_id>/... . The FakeBackend's
+ensure_corpus returns 'test-corpus-id'.
+"""
+
+import io
+
+
+CORPUS = "test-corpus-id"
+
+
+# ---- List page --------------------------------------------------------------
+
+
+def test_list_renders_demographic_files(client, fake_backend):
+    """Files are rendered in the table with correct metadata."""
+    fake_backend.demographic_files = [
+        {
+            "id": "file-1",
+            "corpus_id": CORPUS,
+            "name": "participants",
+            "original_columns": ["username", "age", "gender"],
+            "rows_total": 5,
+            "created_at": "2026-05-20T10:00:00Z",
+            "updated_at": "2026-05-20T10:00:00Z",
+        },
+    ]
+
+    resp = client.get("/demographic/", follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert b"participants" in resp.data
+    assert b"View Data" in resp.data
+    assert b"No demographic data uploaded yet" not in resp.data
+
+
+def test_list_renders_empty_state(client, fake_backend):
+    fake_backend.demographic_files = []
+    resp = client.get("/demographic/", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"No demographic data uploaded yet" in resp.data
+
+
+def test_list_renders_backend_error(client, fake_backend):
+    fake_backend.raise_on = "list_demographic_files"
+    resp = client.get("/demographic/", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"simulated list_demographic_files failure" in resp.data
+    assert b"Traceback" not in resp.data
+
+
+def test_list_landing_redirects(client, fake_backend):
+    resp = client.get("/demographic/")
+    assert resp.status_code == 302
+    assert f"/demographic/{CORPUS}/" in resp.headers["Location"]
+
+
+# ---- Upload form ------------------------------------------------------------
+
+
+def test_upload_form_renders(client, fake_backend):
+    resp = client.get(f"/demographic/{CORPUS}/upload")
+    assert resp.status_code == 200
+    assert b"Upload Demographic Data" in resp.data
+    assert b"Select CSV file" in resp.data
+
+
+def test_upload_submit_no_file_shows_error(client, fake_backend):
+    resp = client.post(
+        f"/demographic/{CORPUS}/upload",
+        data={"file": (io.BytesIO(b""), "")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert b"select a CSV file" in resp.data
+
+
+def test_upload_submit_redirects_to_preview(client, fake_backend):
+    fake_backend.demographic_upload_response = {
+        "import_id": "import-abc",
+        "name": "test_data",
+        "status": "pending",
+        "preview": {
+            "rows_detected": 3,
+            "columns_detected": 3,
+            "sample_rows": [
+                {"username": "alice", "age": "30", "gender": "F"},
+                {"username": "bob", "age": "25", "gender": "M"},
+            ],
+        },
+        "expires_at": "2026-05-20T11:00:00Z",
+    }
+
+    resp = client.post(
+        f"/demographic/{CORPUS}/upload",
+        data={"file": (io.BytesIO(b"username;age;gender\nalice;30;F\n"), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+    assert "/preview/import-abc" in resp.headers["Location"]
+
+
+def test_upload_submit_backend_error(client, fake_backend):
+    fake_backend.raise_on = "upload_demographic"
+    resp = client.post(
+        f"/demographic/{CORPUS}/upload",
+        data={"file": (io.BytesIO(b"username;age\nalice;30\n"), "test.csv")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert b"simulated upload_demographic failure" in resp.data
+
+
+# ---- Preview page -----------------------------------------------------------
+
+
+def _seed_preview_session(client, fake_backend):
+    """Upload a CSV so preview data is stored in the session."""
+    fake_backend.demographic_upload_response = {
+        "import_id": "import-xyz",
+        "name": "demo_data",
+        "status": "pending",
+        "preview": {
+            "rows_detected": 2,
+            "columns_detected": 3,
+            "sample_rows": [
+                {"username": "alice", "age": "30", "gender": "F"},
+                {"username": "bob", "age": "25", "gender": "M"},
+            ],
+        },
+        "expires_at": "2026-05-20T11:00:00Z",
+    }
+    client.post(
+        f"/demographic/{CORPUS}/upload",
+        data={"file": (io.BytesIO(b"username;age;gender\nalice;30;F\n"), "demo.csv")},
+        content_type="multipart/form-data",
+    )
+
+
+def test_preview_renders_sample_rows(client, fake_backend):
+    _seed_preview_session(client, fake_backend)
+    resp = client.get(f"/demographic/{CORPUS}/preview/import-xyz")
+    assert resp.status_code == 200
+    assert b"Preview" in resp.data
+    assert b"alice" in resp.data
+    assert b"bob" in resp.data
+    assert b"Confirm Upload" in resp.data
+    assert b"Discard" in resp.data
+
+
+def test_preview_expired_redirects_to_upload(client, fake_backend):
+    """If preview data isn't in the session, redirect back to upload."""
+    resp = client.get(
+        f"/demographic/{CORPUS}/preview/nonexistent-id",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "/upload" in resp.headers["Location"]
+
+
+def test_preview_confirm_redirects_to_list(client, fake_backend):
+    _seed_preview_session(client, fake_backend)
+    fake_backend.demographic_confirm_response = {
+        "import_id": "import-xyz",
+        "name": "demo_data",
+        "rows_created": 2,
+        "status": "Demographic data successfully uploaded",
+    }
+    resp = client.post(
+        f"/demographic/{CORPUS}/preview/import-xyz",
+        data={"action": "confirm"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"uploaded successfully" in resp.data
+
+
+def test_preview_discard_redirects_to_list(client, fake_backend):
+    _seed_preview_session(client, fake_backend)
+    fake_backend.demographic_confirm_response = {
+        "import_id": "import-xyz",
+        "name": "demo_data",
+        "rows_created": 0,
+        "status": "Upload cancelled by user",
+    }
+    resp = client.post(
+        f"/demographic/{CORPUS}/preview/import-xyz",
+        data={"action": "discard"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"Upload discarded" in resp.data
+
+
+# ---- View page --------------------------------------------------------------
+
+
+def test_view_renders_data_table_with_columns(client, fake_backend):
+    fake_backend.demographic_files = [
+        {
+            "id": "file-1",
+            "corpus_id": CORPUS,
+            "name": "participants",
+            "original_columns": ["username", "age", "gender"],
+            "rows_total": 2,
+            "created_at": "2026-05-20T10:00:00Z",
+            "updated_at": "2026-05-20T10:00:00Z",
+        },
+    ]
+    fake_backend.demographic_rows = [
+        {
+            "id": "row-1",
+            "demographic_file_id": "file-1",
+            "interviewee_id": "alice",
+            "row_number": 1,
+            "data": {"age": "30", "gender": "F"},
+        },
+        {
+            "id": "row-2",
+            "demographic_file_id": "file-1",
+            "interviewee_id": "bob",
+            "row_number": 2,
+            "data": {"age": "25", "gender": "M"},
+        },
+    ]
+
+    resp = client.get(f"/demographic/{CORPUS}/view/file-1")
+    assert resp.status_code == 200
+    assert b"participants" in resp.data
+    assert b"alice" in resp.data
+    assert b"bob" in resp.data
+    assert b"age" in resp.data
+    assert b"gender" in resp.data
+
+
+def test_view_shows_linked_transcript(client, fake_backend):
+    fake_backend.demographic_files = [
+        {
+            "id": "file-1",
+            "corpus_id": CORPUS,
+            "name": "participants",
+            "original_columns": ["username", "age"],
+            "rows_total": 1,
+            "created_at": "2026-05-20T10:00:00Z",
+            "updated_at": "2026-05-20T10:00:00Z",
+        },
+    ]
+    fake_backend.demographic_rows = [
+        {
+            "id": "row-1",
+            "demographic_file_id": "file-1",
+            "interviewee_id": "alice",
+            "row_number": 1,
+            "data": {"age": "30"},
+        },
+    ]
+    fake_backend.demographic_link_summary = {
+        "total_transcripts": 1,
+        "matched": 1,
+        "details": [
+            {
+                "document_id": "doc-1",
+                "document_title": "Alice Interview",
+                "demographic_row_id": "row-1",
+                "matched": True,
+            },
+        ],
+    }
+
+    resp = client.get(f"/demographic/{CORPUS}/view/file-1")
+    assert resp.status_code == 200
+    assert b"Alice Interview" in resp.data
+
+
+def test_view_shows_unlinked_indicator(client, fake_backend):
+    fake_backend.demographic_files = [
+        {
+            "id": "file-1",
+            "corpus_id": CORPUS,
+            "name": "participants",
+            "original_columns": ["username", "age"],
+            "rows_total": 1,
+            "created_at": "2026-05-20T10:00:00Z",
+            "updated_at": "2026-05-20T10:00:00Z",
+        },
+    ]
+    fake_backend.demographic_rows = [
+        {
+            "id": "row-1",
+            "demographic_file_id": "file-1",
+            "interviewee_id": "alice",
+            "row_number": 1,
+            "data": {"age": "30"},
+        },
+    ]
+    fake_backend.demographic_link_summary = {
+        "total_transcripts": 0,
+        "matched": 0,
+        "details": [],
+    }
+
+    resp = client.get(f"/demographic/{CORPUS}/view/file-1")
+    assert resp.status_code == 200
+    assert b"Not linked" in resp.data
+
+
+def test_view_renders_backend_error(client, fake_backend):
+    fake_backend.raise_on = "list_demographic_files"
+    resp = client.get(f"/demographic/{CORPUS}/view/file-1")
+    assert resp.status_code == 200
+    assert b"simulated list_demographic_files failure" in resp.data
+    assert b"Traceback" not in resp.data
+
+
+def test_view_renders_empty_when_no_rows(client, fake_backend):
+    fake_backend.demographic_files = [
+        {
+            "id": "file-1",
+            "corpus_id": CORPUS,
+            "name": "empty_file",
+            "original_columns": ["username", "age"],
+            "rows_total": 0,
+            "created_at": "2026-05-20T10:00:00Z",
+            "updated_at": "2026-05-20T10:00:00Z",
+        },
+    ]
+    fake_backend.demographic_rows = []
+
+    resp = client.get(f"/demographic/{CORPUS}/view/file-1")
+    assert resp.status_code == 200
+    assert b"No data rows" in resp.data

--- a/Frontend/web/__init__.py
+++ b/Frontend/web/__init__.py
@@ -33,11 +33,13 @@ def create_app(config: Config | None = None) -> Flask:
 
     from web.controllers.analysis import bp as analysis_bp
     from web.controllers.codebooks import bp as codebooks_bp
+    from web.controllers.demographic import bp as demographic_bp
     from web.controllers.ingestion import bp as ingestion_bp
     from web.controllers.main import bp as main_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(ingestion_bp, url_prefix="/transcripts")
+    app.register_blueprint(demographic_bp, url_prefix="/demographic")
     app.register_blueprint(codebooks_bp, url_prefix="/codebooks")
     app.register_blueprint(analysis_bp, url_prefix="/analysis")
 

--- a/Frontend/web/controllers/demographic.py
+++ b/Frontend/web/controllers/demographic.py
@@ -58,15 +58,16 @@ def upload_landing():
 
 @bp.get("/<corpus_id>/")
 def list_files(corpus_id: str) -> str:
+    corpus_name = current_app.config["DEFAULT_CORPUS_NAME"]
     try:
         files = _backend().list_demographic_files(corpus_id)
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
-            "demographic/list.html", files=[], corpus_id=corpus_id, error=True
+            "demographic/list.html", files=[], corpus_id=corpus_id, error=True, corpus_name=corpus_name
         )
     return render_template(
-        "demographic/list.html", files=files, corpus_id=corpus_id
+        "demographic/list.html", files=files, corpus_id=corpus_id, corpus_name=corpus_name
     )
 
 
@@ -172,10 +173,13 @@ def preview_confirm(corpus_id: str, import_id: str):
 
 @bp.get("/<corpus_id>/view/<file_id>")
 def view_data(corpus_id: str, file_id: str) -> str:
+    page = request.args.get("page", 1, type=int)
     try:
         client = _backend()
         files = client.list_demographic_files(corpus_id)
-        rows = client.list_demographic_rows(corpus_id, file_id)
+        rows_page = client.list_demographic_rows(corpus_id, file_id, page=page, page_size=100)
+        rows = rows_page.get("items", [])
+        meta = rows_page.get("meta", {})
         link_summary = client.get_demographic_link_summary(corpus_id)
     except BackendError as exc:
         flash(exc.user_message, "danger")
@@ -183,6 +187,7 @@ def view_data(corpus_id: str, file_id: str) -> str:
             "demographic/view.html",
             file_info=None,
             rows=[],
+            meta={},
             columns=[],
             transcript_lookup={},
             corpus_id=corpus_id,
@@ -208,6 +213,7 @@ def view_data(corpus_id: str, file_id: str) -> str:
         "demographic/view.html",
         file_info=file_info,
         rows=rows,
+        meta=meta,
         columns=columns,
         transcript_lookup=transcript_lookup,
         corpus_id=corpus_id,

--- a/Frontend/web/controllers/demographic.py
+++ b/Frontend/web/controllers/demographic.py
@@ -1,0 +1,215 @@
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from web.services.backend_client import (
+    BackendClient,
+    BackendError,
+    BackendValidationError,
+    get_backend_client as _backend,
+)
+
+bp = Blueprint("demographic", __name__)
+
+
+def _resolve_workspace_corpus(client: BackendClient) -> str:
+    """MVP single-workspace: resolve or create the default corpus."""
+    cfg = current_app.config
+    return client.ensure_corpus(
+        project_id=cfg["DEFAULT_PROJECT_ID"],
+        name=cfg["DEFAULT_CORPUS_NAME"],
+    )
+
+
+# ---- Landings ---------------------------------------------------------------
+
+
+def _landing_with_corpus(target_endpoint: str):
+    """Resolve the default corpus then redirect to a corpus-scoped view."""
+    try:
+        corpus_id = _resolve_workspace_corpus(_backend())
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return render_template(
+            "demographic/list.html", files=[], corpus_id=None, error=True
+        )
+    return redirect(url_for(target_endpoint, corpus_id=corpus_id))
+
+
+@bp.get("/")
+def demographic_landing():
+    return _landing_with_corpus("demographic.list_files")
+
+
+@bp.get("/upload")
+def upload_landing():
+    return _landing_with_corpus("demographic.upload_form")
+
+
+# ---- List (corpus-scoped) ---------------------------------------------------
+
+
+@bp.get("/<corpus_id>/")
+def list_files(corpus_id: str) -> str:
+    try:
+        files = _backend().list_demographic_files(corpus_id)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return render_template(
+            "demographic/list.html", files=[], corpus_id=corpus_id, error=True
+        )
+    return render_template(
+        "demographic/list.html", files=files, corpus_id=corpus_id
+    )
+
+
+# ---- Upload (corpus-scoped) ------------------------------------------------
+
+
+def _render_upload_form(corpus_id: str) -> str:
+    return render_template(
+        "demographic/upload.html",
+        corpus_id=corpus_id,
+        max_size_mb=current_app.config["MAX_UPLOAD_SIZE_MB"],
+    )
+
+
+def _file_size(fileobj) -> int:
+    stream = fileobj.stream
+    pos = stream.tell()
+    stream.seek(0, 2)
+    size = stream.tell()
+    stream.seek(pos)
+    return size
+
+
+@bp.get("/<corpus_id>/upload")
+def upload_form(corpus_id: str) -> str:
+    return _render_upload_form(corpus_id)
+
+
+@bp.post("/<corpus_id>/upload")
+def upload_submit(corpus_id: str):
+    f = request.files.get("file")
+    if not f or not f.filename:
+        flash("Please select a CSV file to upload.", "danger")
+        return _render_upload_form(corpus_id)
+
+    max_bytes = current_app.config["MAX_UPLOAD_BYTES"]
+    if _file_size(f) > max_bytes:
+        max_mb = current_app.config["MAX_UPLOAD_SIZE_MB"]
+        flash(f"File must be at most {max_mb} MB.", "danger")
+        return _render_upload_form(corpus_id)
+
+    try:
+        result = _backend().upload_demographic(corpus_id, f)
+    except BackendValidationError as exc:
+        flash(exc.user_message, "danger")
+        return _render_upload_form(corpus_id)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return _render_upload_form(corpus_id)
+
+    # Store preview data in the session so the preview page can display it.
+    import_id = result["import_id"]
+    session[f"demo_preview_{import_id}"] = result
+    return redirect(
+        url_for(
+            "demographic.preview_upload",
+            corpus_id=corpus_id,
+            import_id=import_id,
+        )
+    )
+
+
+# ---- Preview (corpus-scoped) -----------------------------------------------
+
+
+@bp.get("/<corpus_id>/preview/<import_id>")
+def preview_upload(corpus_id: str, import_id: str) -> str:
+    preview_data = session.get(f"demo_preview_{import_id}")
+    if not preview_data:
+        flash("Preview data expired or not found. Please upload again.", "warning")
+        return redirect(url_for("demographic.upload_form", corpus_id=corpus_id))
+    return render_template(
+        "demographic/preview.html",
+        corpus_id=corpus_id,
+        import_id=import_id,
+        preview=preview_data,
+    )
+
+
+@bp.post("/<corpus_id>/preview/<import_id>")
+def preview_confirm(corpus_id: str, import_id: str):
+    action = request.form.get("action", "discard")
+    confirm = action == "confirm"
+
+    # Clear session data regardless of outcome.
+    session.pop(f"demo_preview_{import_id}", None)
+
+    try:
+        _backend().confirm_demographic(corpus_id, import_id, confirm)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return redirect(url_for("demographic.list_files", corpus_id=corpus_id))
+
+    if confirm:
+        flash("Demographic data uploaded successfully.", "success")
+    else:
+        flash("Upload discarded.", "info")
+    return redirect(url_for("demographic.list_files", corpus_id=corpus_id))
+
+
+# ---- View (corpus-scoped) --------------------------------------------------
+
+
+@bp.get("/<corpus_id>/view/<file_id>")
+def view_data(corpus_id: str, file_id: str) -> str:
+    try:
+        client = _backend()
+        files = client.list_demographic_files(corpus_id)
+        rows = client.list_demographic_rows(corpus_id, file_id)
+        link_summary = client.get_demographic_link_summary(corpus_id)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return render_template(
+            "demographic/view.html",
+            file_info=None,
+            rows=[],
+            columns=[],
+            transcript_lookup={},
+            corpus_id=corpus_id,
+            file_id=file_id,
+            error=True,
+        )
+
+    # Find the specific file metadata.
+    file_info = next((f for f in files if f["id"] == file_id), None)
+
+    # Build a lookup: demographic_row_id → document_title
+    transcript_lookup = {}
+    for detail in link_summary.get("details", []):
+        if detail.get("matched") and detail.get("demographic_row_id"):
+            transcript_lookup[detail["demographic_row_id"]] = detail["document_title"]
+
+    # Extract column names from file metadata (excluding 'username').
+    columns = []
+    if file_info:
+        columns = [c for c in file_info.get("original_columns", []) if c != "username"]
+
+    return render_template(
+        "demographic/view.html",
+        file_info=file_info,
+        rows=rows,
+        columns=columns,
+        transcript_lookup=transcript_lookup,
+        corpus_id=corpus_id,
+        file_id=file_id,
+    )

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -211,9 +211,9 @@ class BackendClient:
         corpus_id: str,
         file_id: str,
         page: int = 1,
-        page_size: int = 200,
-    ) -> list[dict]:
-        """List demographic rows for a specific file."""
+        page_size: int = 100,
+    ) -> dict:
+        """List demographic rows for a specific file, returning items and pagination meta."""
         return self._get(
             f"/demographic/{corpus_id}/rows",
             params={
@@ -221,7 +221,6 @@ class BackendClient:
                 "page": page,
                 "page_size": page_size,
             },
-            sub_key="items",
         )
 
     def get_demographic_link_summary(self, corpus_id: str) -> dict:

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -163,6 +163,71 @@ class BackendClient:
     def get_theme_tree(self, codebook_id: str) -> list[dict]:
         return self._get(f"/codebooks/{codebook_id}/themes/tree")
 
+    # ---- Demographic --------------------------------------------------------
+
+    def upload_demographic(
+        self, corpus_id: str, file: FileStorage, name: str | None = None,
+    ) -> dict:
+        """POST a demographic CSV to the backend; returns preview + import_id."""
+        path = f"/demographic/{corpus_id}/upload"
+        multipart = [
+            ("file", (file.filename, file.stream, file.mimetype or "text/csv")),
+        ]
+        data = {}
+        if name:
+            data["name"] = name
+        started_at = time.monotonic()
+        try:
+            r = self._client.post(path, files=multipart, data=data)
+            r.raise_for_status()
+            return self._unwrap(r)
+        except httpx.HTTPError as exc:
+            self._handle_exc(exc, path, "POST", started_at)
+        except (json.JSONDecodeError, KeyError) as exc:
+            self._handle_exc(exc, path, "POST", started_at)
+
+    def confirm_demographic(
+        self, corpus_id: str, import_id: str, confirm: bool,
+    ) -> dict:
+        """Confirm or cancel a pending demographic upload."""
+        path = f"/demographic/{corpus_id}/confirm"
+        return self._post(
+            path,
+            params={"import_id": import_id, "confirm": str(confirm).lower()},
+        )
+
+    def list_demographic_files(
+        self, corpus_id: str, page_size: int = 200,
+    ) -> list[dict]:
+        """List confirmed demographic imports for one corpus."""
+        return self._get(
+            f"/demographic/{corpus_id}/files",
+            params={"page_size": page_size},
+            sub_key="items",
+        )
+
+    def list_demographic_rows(
+        self,
+        corpus_id: str,
+        file_id: str,
+        page: int = 1,
+        page_size: int = 200,
+    ) -> list[dict]:
+        """List demographic rows for a specific file."""
+        return self._get(
+            f"/demographic/{corpus_id}/rows",
+            params={
+                "demographic_file_id": file_id,
+                "page": page,
+                "page_size": page_size,
+            },
+            sub_key="items",
+        )
+
+    def get_demographic_link_summary(self, corpus_id: str) -> dict:
+        """Get transcript ↔ demographic linking status."""
+        return self._get(f"/demographic/{corpus_id}/link-summary")
+
     # ---- Helpers ------------------------------------------------------------
 
     def _unwrap(self, response: httpx.Response, *, sub_key: str | None = None):

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -46,6 +46,10 @@
                href="{{ url_for('ingestion.transcripts_landing') }}">Transcripts</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link {% if request.endpoint and request.endpoint.startswith('demographic.') %}active{% endif %}"
+               href="{{ url_for('demographic.demographic_landing') }}">Demographic Data</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link {% if request.endpoint and request.endpoint.startswith('codebooks.') %}active{% endif %}"
                href="{{ url_for('codebooks.list_codebooks') }}">Codebooks</a>
           </li>

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -2,10 +2,7 @@
 {% block title %}Demographic Data{% endblock %}
 {% block content %}
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
-      <h1 class="h3 mb-1">Demographic Data</h1>
-      <p class="text-secondary mb-0">Linked to corpus: <span class="fw-semibold">{{ corpus_name }}</span></p>
-    </div>
+    <h1 class="h3 mb-0">Demographic Data</h1>
     {% if corpus_id %}
       <a class="btn btn-primary"
          id="upload-csv-btn"
@@ -24,6 +21,7 @@
           <thead class="table-light">
             <tr>
               <th>Name</th>
+              <th>Corpus</th>
               <th>Columns</th>
               <th>Rows</th>
               <th>Uploaded</th>
@@ -34,6 +32,7 @@
             {% for f in files %}
               <tr>
                 <td>{{ f.name }}</td>
+                <td class="text-secondary">{{ corpus_name }}</td>
                 <td>{{ f.original_columns | length }}</td>
                 <td>{{ f.rows_total }}</td>
                 <td class="text-secondary">{{ f.created_at }}</td>

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}Demographic Data{% endblock %}
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3 mb-0">Demographic Data</h1>
+    {% if corpus_id %}
+      <a class="btn btn-primary"
+         id="upload-csv-btn"
+         href="{{ url_for('demographic.upload_form', corpus_id=corpus_id) }}">
+        Upload CSV
+      </a>
+    {% endif %}
+  </div>
+
+  {% if error %}
+    <p class="text-secondary">Couldn't load demographic data right now.</p>
+  {% elif files %}
+    <div class="bg-white border rounded-2">
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle mb-0" id="demographic-files-table">
+          <thead class="table-light">
+            <tr>
+              <th>Name</th>
+              <th>Columns</th>
+              <th>Rows</th>
+              <th>Uploaded</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for f in files %}
+              <tr>
+                <td>{{ f.name }}</td>
+                <td>{{ f.original_columns | length }}</td>
+                <td>{{ f.rows_total }}</td>
+                <td class="text-secondary">{{ f.created_at }}</td>
+                <td>
+                  <a class="btn btn-sm btn-outline-primary"
+                     id="view-data-btn-{{ loop.index }}"
+                     href="{{ url_for('demographic.view_data', corpus_id=corpus_id, file_id=f.id) }}">
+                    View Data
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% elif corpus_id %}
+    <p class="text-secondary" id="empty-state">
+      No demographic data uploaded yet.
+      <a href="{{ url_for('demographic.upload_form', corpus_id=corpus_id) }}">Upload a CSV file</a>
+    </p>
+  {% else %}
+    <p class="text-secondary">No demographic data to show.</p>
+  {% endif %}
+{% endblock %}

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -2,7 +2,10 @@
 {% block title %}Demographic Data{% endblock %}
 {% block content %}
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1 class="h3 mb-0">Demographic Data</h1>
+    <div>
+      <h1 class="h3 mb-1">Demographic Data</h1>
+      <p class="text-secondary mb-0">Linked to corpus: <span class="fw-semibold">{{ corpus_name }}</span></p>
+    </div>
     {% if corpus_id %}
       <a class="btn btn-primary"
          id="upload-csv-btn"

--- a/Frontend/web/templates/demographic/preview.html
+++ b/Frontend/web/templates/demographic/preview.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Preview — {{ preview.name }}{% endblock %}
+{% block content %}
+  <div class="mb-4">
+    <h1 class="h3 mb-1">Preview: {{ preview.name }}</h1>
+    <p class="text-secondary mb-0">
+      {{ preview.preview.rows_detected }} row{{ 's' if preview.preview.rows_detected != 1 else '' }} detected,
+      {{ preview.preview.columns_detected }} column{{ 's' if preview.preview.columns_detected != 1 else '' }}.
+    </p>
+  </div>
+
+  <div class="alert alert-info d-flex align-items-start gap-2" role="alert">
+    <span aria-hidden="true">&#x24D8;</span>
+    <div>
+      Showing up to 50 sample rows. Review the data below before confirming the upload.
+    </div>
+  </div>
+
+  {% set sample_rows = preview.preview.sample_rows[:50] %}
+  {% if sample_rows %}
+    {% set columns = sample_rows[0].keys() | list %}
+    <div class="bg-white border rounded-2 mb-4">
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle mb-0" id="preview-table">
+          <thead class="table-light">
+            <tr>
+              <th>#</th>
+              {% for col in columns %}
+                <th>{{ col }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in sample_rows %}
+              <tr>
+                <td class="text-secondary">{{ loop.index }}</td>
+                {% for col in columns %}
+                  <td>{{ row[col] if row[col] is not none else '—' }}</td>
+                {% endfor %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  {% else %}
+    <p class="text-secondary">No sample rows available.</p>
+  {% endif %}
+
+  <form method="post"
+        action="{{ url_for('demographic.preview_confirm', corpus_id=corpus_id, import_id=import_id) }}">
+    <div class="d-flex gap-2">
+      <button type="submit" name="action" value="confirm"
+              class="btn btn-success" id="confirm-upload-btn">
+        Confirm Upload
+      </button>
+      <button type="submit" name="action" value="discard"
+              class="btn btn-outline-danger" id="discard-upload-btn">
+        Discard
+      </button>
+    </div>
+  </form>
+{% endblock %}

--- a/Frontend/web/templates/demographic/preview.html
+++ b/Frontend/web/templates/demographic/preview.html
@@ -12,11 +12,11 @@
   <div class="alert alert-info d-flex align-items-start gap-2" role="alert">
     <span aria-hidden="true">&#x24D8;</span>
     <div>
-      Showing up to 50 sample rows. Review the data below before confirming the upload.
+      Showing up to 10 sample rows. Review the data below before confirming the upload.
     </div>
   </div>
 
-  {% set sample_rows = preview.preview.sample_rows[:50] %}
+  {% set sample_rows = preview.preview.sample_rows[:10] %}
   {% if sample_rows %}
     {% set columns = sample_rows[0].keys() | list %}
     <div class="bg-white border rounded-2 mb-4">

--- a/Frontend/web/templates/demographic/upload.html
+++ b/Frontend/web/templates/demographic/upload.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}Upload Demographic Data{% endblock %}
+{% block content %}
+  <div class="mb-4">
+    <h1 class="h3 mb-1">Upload Demographic Data</h1>
+    <p class="text-secondary mb-0">
+      Accepted: <span class="badge text-bg-secondary">.csv</span>.
+      Maximum {{ max_size_mb }} MB per file.
+      CSV must use <code>;</code> as delimiter and include a <code>username</code> column.
+    </p>
+  </div>
+
+  <div class="bg-white border rounded-2 p-4" style="max-width: 640px;">
+    <form id="demographic-upload-form"
+          method="post"
+          action="{{ url_for('demographic.upload_submit', corpus_id=corpus_id) }}"
+          enctype="multipart/form-data">
+      <div class="mb-3">
+        <label for="file" class="form-label fw-semibold">Select CSV file</label>
+        <input class="form-control"
+               type="file"
+               id="file"
+               name="file"
+               accept=".csv"
+               required>
+      </div>
+
+      <div id="file-info" class="mb-3 d-none">
+        <div class="d-flex justify-content-between align-items-baseline mb-1">
+          <span class="fw-semibold" id="file-name"></span>
+          <span class="text-secondary small" id="file-size"></span>
+        </div>
+        <div id="file-warnings" class="small text-danger"></div>
+      </div>
+
+      <button id="submit-btn" type="submit" class="btn btn-primary" disabled>
+        Upload &amp; Preview
+      </button>
+    </form>
+  </div>
+
+  <script>
+    (() => {
+      const MAX_MB = {{ max_size_mb }};
+      const MAX_BYTES = MAX_MB * 1024 * 1024;
+
+      const input = document.getElementById("file");
+      const info = document.getElementById("file-info");
+      const nameEl = document.getElementById("file-name");
+      const sizeEl = document.getElementById("file-size");
+      const warningsEl = document.getElementById("file-warnings");
+      const submitBtn = document.getElementById("submit-btn");
+
+      function formatBytes(bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+        return (bytes / (1024 * 1024)).toFixed(2) + " MB";
+      }
+
+      input.addEventListener("change", () => {
+        const file = input.files[0];
+        if (!file) {
+          info.classList.add("d-none");
+          submitBtn.disabled = true;
+          return;
+        }
+
+        nameEl.textContent = file.name;
+        sizeEl.textContent = formatBytes(file.size);
+        info.classList.remove("d-none");
+
+        const warnings = [];
+        if (!file.name.toLowerCase().endsWith(".csv")) {
+          warnings.push("Only .csv files are accepted.");
+        }
+        if (file.size > MAX_BYTES) {
+          warnings.push("File exceeds " + MAX_MB + " MB limit.");
+        }
+
+        warningsEl.textContent = warnings.join(" ");
+        submitBtn.disabled = warnings.length > 0;
+      });
+    })();
+  </script>
+{% endblock %}

--- a/Frontend/web/templates/demographic/view.html
+++ b/Frontend/web/templates/demographic/view.html
@@ -54,6 +54,27 @@
           </table>
         </div>
       </div>
+
+      {% if meta and meta.pages > 1 %}
+        <nav aria-label="Data pagination" class="mt-4">
+          <ul class="pagination pagination-sm">
+            <li class="page-item {% if meta.page == 1 %}disabled{% endif %}">
+              <a class="page-link" href="{{ url_for('demographic.view_data', corpus_id=corpus_id, file_id=file_id, page=meta.page - 1) }}" tabindex="-1">Previous</a>
+            </li>
+            
+            {% for p in range(1, meta.pages + 1) %}
+              <li class="page-item {% if p == meta.page %}active{% endif %}">
+                <a class="page-link" href="{{ url_for('demographic.view_data', corpus_id=corpus_id, file_id=file_id, page=p) }}">{{ p }}</a>
+              </li>
+            {% endfor %}
+
+            <li class="page-item {% if meta.page == meta.pages %}disabled{% endif %}">
+              <a class="page-link" href="{{ url_for('demographic.view_data', corpus_id=corpus_id, file_id=file_id, page=meta.page + 1) }}">Next</a>
+            </li>
+          </ul>
+        </nav>
+      {% endif %}
+
     {% else %}
       <p class="text-secondary">No data rows in this file.</p>
     {% endif %}

--- a/Frontend/web/templates/demographic/view.html
+++ b/Frontend/web/templates/demographic/view.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block title %}View — {{ file_info.name if file_info else 'Demographic Data' }}{% endblock %}
+{% block content %}
+  <div class="mb-2">
+    <a class="text-decoration-none small"
+       href="{{ url_for('demographic.list_files', corpus_id=corpus_id) }}">&larr; Back to file list</a>
+  </div>
+
+  {% if error %}
+    <h1 class="h3 mb-4">Demographic Data</h1>
+    <p class="text-secondary">Couldn't load data right now.</p>
+  {% elif file_info %}
+    <div class="mb-4">
+      <h1 class="h3 mb-1">{{ file_info.name }}</h1>
+      <p class="text-secondary mb-0">
+        {{ file_info.rows_total }} row{{ 's' if file_info.rows_total != 1 else '' }},
+        {{ file_info.original_columns | length }} column{{ 's' if file_info.original_columns | length != 1 else '' }}.
+        Uploaded {{ file_info.created_at }}.
+      </p>
+    </div>
+
+    {% if rows %}
+      <div class="bg-white border rounded-2">
+        <div class="table-responsive">
+          <table class="table table-sm table-hover align-middle mb-0" id="demographic-data-table">
+            <thead class="table-light">
+              <tr>
+                <th>#</th>
+                <th>Username</th>
+                <th>Linked Transcript</th>
+                {% for col in columns %}
+                  <th>{{ col }}</th>
+                {% endfor %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in rows %}
+                <tr>
+                  <td class="text-secondary">{{ row.row_number }}</td>
+                  <td class="fw-semibold">{{ row.interviewee_id }}</td>
+                  <td>
+                    {% if transcript_lookup.get(row.id) %}
+                      <span class="badge text-bg-success">{{ transcript_lookup[row.id] }}</span>
+                    {% else %}
+                      <span class="text-secondary">Not linked</span>
+                    {% endif %}
+                  </td>
+                  {% for col in columns %}
+                    <td>{{ row.data.get(col, '—') if row.data else '—' }}</td>
+                  {% endfor %}
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% else %}
+      <p class="text-secondary">No data rows in this file.</p>
+    {% endif %}
+  {% else %}
+    <h1 class="h3 mb-4">Demographic Data</h1>
+    <p class="text-secondary">File not found.</p>
+  {% endif %}
+{% endblock %}

--- a/Frontend/web/templates/index.html
+++ b/Frontend/web/templates/index.html
@@ -7,21 +7,28 @@
   </div>
 
   <div class="row g-3">
-    <div class="col-12 col-md-4">
+    <div class="col-12 col-md-3">
       <div class="bg-white border rounded-2 p-3 h-100">
         <h2 class="h6 mb-1">Transcripts</h2>
         <p class="text-secondary small mb-3">View and upload your interview documents.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('ingestion.transcripts_landing') }}">View transcripts</a>
       </div>
     </div>
-    <div class="col-12 col-md-4">
+    <div class="col-12 col-md-3">
+      <div class="bg-white border rounded-2 p-3 h-100">
+        <h2 class="h6 mb-1">Demographic Data</h2>
+        <p class="text-secondary small mb-3">Upload and view demographic data linked to interviews.</p>
+        <a class="btn btn-sm btn-outline-primary" href="{{ url_for('demographic.demographic_landing') }}">View data</a>
+      </div>
+    </div>
+    <div class="col-12 col-md-3">
       <div class="bg-white border rounded-2 p-3 h-100">
         <h2 class="h6 mb-1">Codebooks</h2>
         <p class="text-secondary small mb-3">Browse available codebooks and explore theme hierarchies.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('codebooks.list_codebooks') }}">View codebooks</a>
       </div>
     </div>
-    <div class="col-12 col-md-4">
+    <div class="col-12 col-md-3">
       <div class="bg-white border rounded-2 p-3 h-100">
         <h2 class="h6 mb-1">Analysis</h2>
         <p class="text-secondary small mb-3">Run thematic analysis on your corpus and review results.</p>


### PR DESCRIPTION
 This PR introduces the Demographic Data viewer and upload functionality to the frontend, allowing researchers to upload and inspect CSV demographic files linked to their transcripts.

Key Changes:

- **Demographic Data Page:** Added a new landing page displaying all uploaded CSV files with a dedicated column indicating which corpus they belong to.
- **Upload & Preview Flow:** Added a CSV upload form with client-side validation. Uploading triggers a preview page showing up to 10 sample rows, letting the user explicitly confirm or discard the upload.
- **Data Viewer Subpage:** Clicking "View Data" on a file opens a full paginated table (100 rows per page) showing all dynamic CSV columns.
- **Transcript Linking:** The viewer includes a "Linked Transcript" column that cross-references the backend link-summary endpoint to display which document title each row corresponds to (or "Not linked" if unmatched).
- **Testing:** Added 17 comprehensive tests (using FakeBackend) covering all new routes, UI states, and edge cases. Total test coverage remains fully passing with zero regressions.