### PR TITLE
Feature/86 implement automatic codebook generation

### DIFF
--- a/Backend/app/database.py
+++ b/Backend/app/database.py
@@ -33,6 +33,10 @@ def _get_session_factory() -> async_sessionmaker[AsyncSession]:
     )
 
 
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    return _get_session_factory()
+
+
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     factory = _get_session_factory() # Get the session factory using the cached function to avoid creating multiple factories
     async with factory() as session:

--- a/Backend/app/llm/pipelines.py
+++ b/Backend/app/llm/pipelines.py
@@ -2,8 +2,12 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.output_parsers import JsonOutputParser, StrOutputParser
 
 from app.llm.client import build_chat_model
-from app.llm.prompts import build_codebook_application_prompt, build_thematic_analysis_prompt
-from app.schemas.llm import InterviewAnalysisResult
+from app.llm.prompts import (
+    build_codebook_application_prompt,
+    build_codebook_generation_prompt,
+    build_thematic_analysis_prompt,
+)
+from app.schemas.llm import InterviewAnalysisResult, PassageCodebookGeneration
 
 
 # Run a single-shot thematic analysis over a transcript.
@@ -39,4 +43,20 @@ def apply_codebook_to_interview(
     chain = build_codebook_application_prompt() | chat_model | parser
     raw_result = chain.invoke({"transcript": transcript, "codebook": codebook_context})
     return InterviewAnalysisResult(**raw_result)
+
+
+# Generate candidate themes/subthemes/codes for a single transcript passage.
+def generate_codebook_for_passage(
+    passage: str,
+    *,
+    model: BaseChatModel | None = None,
+) -> PassageCodebookGeneration:
+    if not passage.strip():
+        raise ValueError("Passage is empty.")
+
+    chat_model = model or build_chat_model()
+    parser = JsonOutputParser(pydantic_object=PassageCodebookGeneration)
+    chain = build_codebook_generation_prompt() | chat_model | parser
+    raw_result = chain.invoke({"passage": passage})
+    return PassageCodebookGeneration(**raw_result)
 

--- a/Backend/app/llm/prompts.py
+++ b/Backend/app/llm/prompts.py
@@ -125,23 +125,23 @@ Rules:
 - If nothing meaningful is present, return empty arrays for both themes and codes.
 
 Return JSON with this exact shape:
-{
+{{
   "themes": [
-    {
+    {{
       "path": [
-        {"label": "Theme label", "description": "Optional short description"},
-        {"label": "Subtheme label", "description": "Optional short description"}
+        {{"label": "Theme label", "description": "Optional short description"}},
+        {{"label": "Subtheme label", "description": "Optional short description"}}
       ]
-    }
+    }}
   ],
   "codes": [
-    {
+    {{
       "label": "Code label",
       "description": "Optional short description",
       "theme_path": ["Theme label", "Subtheme label"]
-    }
+    }}
   ]
-}"""
+}}"""
 
 GENERATE_CODEBOOK_USER_INSTRUCTION = """Generate candidate themes, subthemes, and codes for this passage.
 

--- a/Backend/app/llm/prompts.py
+++ b/Backend/app/llm/prompts.py
@@ -110,3 +110,51 @@ def build_codebook_application_prompt() -> ChatPromptTemplate:
         ]
     )
 
+
+GENERATE_CODEBOOK_SYSTEM_PROMPT = """You are an experienced qualitative researcher.
+You receive one transcript passage at a time and must propose candidate themes,
+subthemes, and codes grounded in the exact passage text.
+
+Rules:
+- Stay close to participant wording; do not invent facts.
+- Return only themes/subthemes that are actually present in this passage.
+- Return concise, specific labels (avoid generic labels).
+- Return valid JSON only (no markdown, no comments).
+- The same path can contain multiple depths (theme -> subtheme -> subsubtheme, etc.).
+- Every code must reference one theme_path that exists in your output.
+- If nothing meaningful is present, return empty arrays for both themes and codes.
+
+Return JSON with this exact shape:
+{
+  "themes": [
+    {
+      "path": [
+        {"label": "Theme label", "description": "Optional short description"},
+        {"label": "Subtheme label", "description": "Optional short description"}
+      ]
+    }
+  ],
+  "codes": [
+    {
+      "label": "Code label",
+      "description": "Optional short description",
+      "theme_path": ["Theme label", "Subtheme label"]
+    }
+  ]
+}"""
+
+GENERATE_CODEBOOK_USER_INSTRUCTION = """Generate candidate themes, subthemes, and codes for this passage.
+
+--- PASSAGE START ---
+{passage}
+--- PASSAGE END ---"""
+
+
+def build_codebook_generation_prompt() -> ChatPromptTemplate:
+    return ChatPromptTemplate.from_messages(
+        [
+            ("system", GENERATE_CODEBOOK_SYSTEM_PROMPT),
+            ("user", GENERATE_CODEBOOK_USER_INSTRUCTION),
+        ]
+    )
+

--- a/Backend/app/main.py
+++ b/Backend/app/main.py
@@ -13,6 +13,7 @@ from app.exceptions import register_exception_handlers
 from app.logging_config import configure_logging
 from app.middleware import register_middleware
 from app.routers import register_routers
+from app.services.codebook_generation_jobs import codebook_generation_job_runner
 from app.services.upload_cleanup import run_upload_cleanup_loop
 
 
@@ -35,10 +36,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             interval_seconds=settings.UPLOAD_CLEANUP_INTERVAL_SECONDS,
         )
     )
+    await codebook_generation_job_runner.start()
 
     try:
         yield
     finally:
+        await codebook_generation_job_runner.stop()
         cleanup_task.cancel()
         try:
             await cleanup_task

--- a/Backend/app/models/__init__.py
+++ b/Backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.analysis import DocumentAnalysis, ThemeOccurrence
 from app.models.base import Base, IdMixin, TimestampMixin
+from app.models.code import Code, CodebookCodeRelationship
 from app.models.codebook import Codebook
 from app.models.demographic import DemographicFiles, DemographicRow
 from app.models.ingestion import (
@@ -17,7 +18,9 @@ __all__ = [
     "Base",
     "IdMixin",
     "TimestampMixin",
+    "Code",
     "Codebook",
+    "CodebookCodeRelationship",
     "CodebookThemeRelationship",
     "Theme",
     "ThemeHierarchyRelationship",

--- a/Backend/app/models/__init__.py
+++ b/Backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.analysis import DocumentAnalysis, ThemeOccurrence
 from app.models.base import Base, IdMixin, TimestampMixin
 from app.models.code import Code, CodebookCodeRelationship
 from app.models.codebook import Codebook
+from app.models.codebook_generation_job import CodebookGenerationJob
 from app.models.demographic import DemographicFiles, DemographicRow
 from app.models.ingestion import (
     Corpus,
@@ -20,6 +21,7 @@ __all__ = [
     "TimestampMixin",
     "Code",
     "Codebook",
+    "CodebookGenerationJob",
     "CodebookCodeRelationship",
     "CodebookThemeRelationship",
     "Theme",

--- a/Backend/app/models/code.py
+++ b/Backend/app/models/code.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class Code(Base, TimestampMixin):
+    """Simplified code artifact."""
+
+    __tablename__ = "codes"
+    __table_args__ = (
+        UniqueConstraint("codebook_id", "label", name="uq_code_codebook_label"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    codebook_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("codebooks.id", ondelete="CASCADE"), index=True
+    )
+    label: Mapped[str] = mapped_column(String(255), index=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean(), default=True)
+
+
+class CodebookCodeRelationship(Base, TimestampMixin):
+    """Membership link between a codebook and a code."""
+
+    __tablename__ = "codebook_code_relationships"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    codebook_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("codebooks.id", ondelete="CASCADE"), index=True
+    )
+    code_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("codes.id", ondelete="CASCADE"), index=True
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean(), default=True)

--- a/Backend/app/models/codebook_generation_job.py
+++ b/Backend/app/models/codebook_generation_job.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class CodebookGenerationJob(Base, TimestampMixin):
+    __tablename__ = "codebook_generation_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    status: Mapped[str] = mapped_column(String(32), index=True, default="queued")
+    codebook_name: Mapped[str] = mapped_column(String(255))
+    corpus_id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), index=True)
+    transcript_document_ids_json: Mapped[str] = mapped_column(Text())
+    cancel_requested: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    codebook_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True), nullable=True)
+    passages_total: Mapped[int] = mapped_column(Integer, default=0)
+    passages_done: Mapped[int] = mapped_column(Integer, default=0)
+    transcripts_processed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    passages_processed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    themes_created: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    codes_created: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text(), nullable=True)
+
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=False), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=False), nullable=True)

--- a/Backend/app/models/themes.py
+++ b/Backend/app/models/themes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy import Boolean, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -14,8 +14,14 @@ class Theme(Base, TimestampMixin):
     """TODO: Unfinished placeholder model; feel free to change whatever you want. Versioning is intentionally not implemented."""
 
     __tablename__ = "themes"
+    __table_args__ = (
+        UniqueConstraint("codebook_id", "label", name="uq_theme_codebook_label"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    codebook_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("codebooks.id", ondelete="CASCADE"), index=True
+    )
     label: Mapped[str] = mapped_column(String(255), index=True)
     description: Mapped[str | None] = mapped_column(Text(), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean(), default=True)

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -1,20 +1,61 @@
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.dependencies import DbSession
-from app.models import Codebook
+from app.exceptions import NotFoundError, UnprocessableError
+from app.models import Codebook, CodebookGenerationJob
 from app.schemas.codebook import (
     CodebookGenerateRequest,
+    CodebookGenerationJobCreateRequest,
+    CodebookGenerationJobSchema,
     CodebookSchema,
     GeneratedCodebookResponse,
 )
 from app.schemas.common import ResponseEnvelope
 from app.services.codebook_generation import CodebookGenerationService
+from app.services.codebook_generation_jobs import codebook_generation_job_runner
 
 router = APIRouter(prefix="/codebooks", tags=["codebooks"])
+
+
+def _serialize_document_ids(document_ids: list[UUID]) -> str:
+    return json.dumps([str(document_id) for document_id in document_ids])
+
+
+def _deserialize_document_ids(document_ids_json: str) -> list[UUID]:
+    raw_ids = json.loads(document_ids_json)
+    return [UUID(raw_id) for raw_id in raw_ids]
+
+
+def _to_job_schema(job: CodebookGenerationJob) -> CodebookGenerationJobSchema:
+    return CodebookGenerationJobSchema(
+        id=job.id,
+        status=job.status,
+        codebook_name=job.codebook_name,
+        corpus_id=job.corpus_id,
+        transcript_document_ids=_deserialize_document_ids(job.transcript_document_ids_json),
+        cancel_requested=job.cancel_requested,
+        codebook_id=job.codebook_id,
+        passages_total=job.passages_total,
+        passages_done=job.passages_done,
+        transcripts_processed=job.transcripts_processed,
+        passages_processed=job.passages_processed,
+        themes_created=job.themes_created,
+        codes_created=job.codes_created,
+        error_message=job.error_message,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+        started_at=job.started_at,
+        finished_at=job.finished_at,
+    )
 
 
 @router.get("/", response_model=ResponseEnvelope[list[CodebookSchema]])
@@ -48,4 +89,87 @@ async def generate_codebook(
     return JSONResponse(
         status_code=201,
         content=ResponseEnvelope.ok(generated_codebook).model_dump(mode="json"),
+    )
+
+
+@router.post(
+    "/generate-jobs",
+    response_model=ResponseEnvelope[CodebookGenerationJobSchema],
+    status_code=202,
+)
+async def create_generate_codebook_job(
+    payload: CodebookGenerationJobCreateRequest,
+    session: DbSession,
+) -> JSONResponse:
+    job = CodebookGenerationJob(
+        id=uuid4(),
+        status="queued",
+        codebook_name=payload.codebook_name,
+        corpus_id=payload.corpus_id,
+        transcript_document_ids_json=_serialize_document_ids(payload.transcript_document_ids),
+        cancel_requested=False,
+        passages_total=0,
+        passages_done=0,
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+
+    bind = session.bind
+    if bind is None:
+        raise UnprocessableError("Database bind is unavailable for job execution")
+    job_session_factory = async_sessionmaker(
+        bind=bind,
+        expire_on_commit=False,
+        class_=AsyncSession,
+    )
+
+    await codebook_generation_job_runner.start()
+    await codebook_generation_job_runner.enqueue(job.id, session_factory=job_session_factory)
+    return JSONResponse(
+        status_code=202,
+        content=ResponseEnvelope.ok(_to_job_schema(job)).model_dump(mode="json"),
+    )
+
+
+@router.get(
+    "/generate-jobs/{job_id}",
+    response_model=ResponseEnvelope[CodebookGenerationJobSchema],
+)
+async def get_generate_codebook_job(
+    job_id: UUID,
+    session: DbSession,
+) -> JSONResponse:
+    job = await session.get(CodebookGenerationJob, job_id)
+    if job is None:
+        raise NotFoundError(f"Codebook generation job '{job_id}' not found")
+    return JSONResponse(content=ResponseEnvelope.ok(_to_job_schema(job)).model_dump(mode="json"))
+
+
+@router.post(
+    "/generate-jobs/{job_id}/cancel",
+    response_model=ResponseEnvelope[CodebookGenerationJobSchema],
+    status_code=202,
+)
+async def cancel_generate_codebook_job(
+    job_id: UUID,
+    session: DbSession,
+) -> JSONResponse:
+    job = await session.get(CodebookGenerationJob, job_id)
+    if job is None:
+        raise NotFoundError(f"Codebook generation job '{job_id}' not found")
+
+    if job.status in {"succeeded", "failed", "cancelled"}:
+        raise UnprocessableError(f"Job '{job_id}' is already finished with status '{job.status}'")
+
+    job.cancel_requested = True
+    if job.status == "queued":
+        job.status = "cancelled"
+        job.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    await session.commit()
+    await session.refresh(job)
+
+    return JSONResponse(
+        status_code=202,
+        content=ResponseEnvelope.ok(_to_job_schema(job)).model_dump(mode="json"),
     )

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -6,8 +6,13 @@ from sqlalchemy import desc, select
 
 from app.dependencies import DbSession
 from app.models import Codebook
-from app.schemas.codebook import CodebookSchema
+from app.schemas.codebook import (
+    CodebookGenerateRequest,
+    CodebookSchema,
+    GeneratedCodebookResponse,
+)
 from app.schemas.common import ResponseEnvelope
+from app.services.codebook_generation import CodebookGenerationService
 
 router = APIRouter(prefix="/codebooks", tags=["codebooks"])
 
@@ -23,3 +28,24 @@ async def get_codebooks(
     codebooks = list((await session.scalars(stmt)).all())
     payload = [CodebookSchema.model_validate(codebook) for codebook in codebooks]
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
+
+
+@router.post(
+    "/generate",
+    response_model=ResponseEnvelope[GeneratedCodebookResponse],
+    status_code=201,
+)
+async def generate_codebook(
+    payload: CodebookGenerateRequest,
+    session: DbSession,
+) -> JSONResponse:
+    service = CodebookGenerationService(session)
+    generated_codebook = await service.generate_codebook(
+        codebook_name=payload.codebook_name,
+        corpus_id=payload.corpus_id,
+        transcript_document_ids=payload.transcript_document_ids,
+    )
+    return JSONResponse(
+        status_code=201,
+        content=ResponseEnvelope.ok(generated_codebook).model_dump(mode="json"),
+    )

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter
@@ -191,7 +191,7 @@ async def cancel_generate_codebook_job(
     job.cancel_requested = True
     if job.status == "queued":
         job.status = "cancelled"
-        job.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        job.finished_at = datetime.now(UTC).replace(tzinfo=None)
     await session.commit()
     await session.refresh(job)
 

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -26,7 +26,9 @@ from app.services.codebook_generation_jobs import codebook_generation_job_runner
 router = APIRouter(prefix="/codebooks", tags=["codebooks"])
 
 
-def _serialize_document_ids(document_ids: list[UUID]) -> str:
+def _serialize_document_ids(document_ids: list[UUID] | None) -> str:
+    if not document_ids:
+        return "[]"
     return json.dumps([str(document_id) for document_id in document_ids])
 
 
@@ -58,7 +60,12 @@ def _to_job_schema(job: CodebookGenerationJob) -> CodebookGenerationJobSchema:
     )
 
 
-@router.get("/", response_model=ResponseEnvelope[list[CodebookSchema]])
+@router.get(
+    "/",
+    response_model=ResponseEnvelope[list[CodebookSchema]],
+    summary="List codebooks",
+    description="Return all codebooks ordered by project id and descending version.",
+)
 async def get_codebooks(
     session: DbSession,
 ) -> JSONResponse:
@@ -75,6 +82,12 @@ async def get_codebooks(
     "/generate",
     response_model=ResponseEnvelope[GeneratedCodebookResponse],
     status_code=201,
+    summary="Generate codebook (synchronous)",
+    description=(
+        "Generate and persist a codebook immediately. "
+        "If `transcript_document_ids` is provided, only those documents are used. "
+        "If omitted or empty, all documents in the selected corpus are used."
+    ),
 )
 async def generate_codebook(
     payload: CodebookGenerateRequest,
@@ -96,6 +109,12 @@ async def generate_codebook(
     "/generate-jobs",
     response_model=ResponseEnvelope[CodebookGenerationJobSchema],
     status_code=202,
+    summary="Create codebook generation job",
+    description=(
+        "Create an asynchronous codebook generation job and return immediately. "
+        "If `transcript_document_ids` is provided, only those documents are used. "
+        "If omitted or empty, all documents in the selected corpus are used."
+    ),
 )
 async def create_generate_codebook_job(
     payload: CodebookGenerationJobCreateRequest,
@@ -135,6 +154,8 @@ async def create_generate_codebook_job(
 @router.get(
     "/generate-jobs/{job_id}",
     response_model=ResponseEnvelope[CodebookGenerationJobSchema],
+    summary="Get codebook generation job",
+    description="Return the current status, progress, and result metadata of a generation job.",
 )
 async def get_generate_codebook_job(
     job_id: UUID,
@@ -150,6 +171,11 @@ async def get_generate_codebook_job(
     "/generate-jobs/{job_id}/cancel",
     response_model=ResponseEnvelope[CodebookGenerationJobSchema],
     status_code=202,
+    summary="Cancel codebook generation job",
+    description=(
+        "Request cancellation for a queued or running codebook generation job. "
+        "Queued jobs are cancelled immediately; running jobs are cancelled when the worker observes the request."
+    ),
 )
 async def cancel_generate_codebook_job(
     job_id: UUID,

--- a/Backend/app/schemas/__init__.py
+++ b/Backend/app/schemas/__init__.py
@@ -1,4 +1,8 @@
-from app.schemas.codebook import CodebookSchema
+from app.schemas.codebook import (
+    CodebookGenerateRequest,
+    CodebookSchema,
+    GeneratedCodebookResponse,
+)
 from app.schemas.common import (
     BaseSchema,
     HealthResponse,
@@ -41,6 +45,7 @@ __all__ = [
     "BaseSchema",
     "BulkDocumentIngestRequest",
     "CodebookSchema",
+    "CodebookGenerateRequest",
     "CorpusChunkSchema",
     "CorpusCreate",
     "CorpusDocumentSchema",
@@ -54,6 +59,7 @@ __all__ = [
     "ImportDemographicResponse",
     "InterviewMessage",
     "InterviewTranscript",
+    "GeneratedCodebookResponse",
     "Page",
     "PageMeta",
     "PaginationParams",

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+from pydantic import Field, field_validator
+
 from app.schemas.common import BaseSchema
 
 
@@ -12,3 +14,32 @@ class CodebookSchema(BaseSchema):
     description: str | None = None
     version: int
     created_by: str
+
+
+class CodebookGenerateRequest(BaseSchema):
+    codebook_name: str = Field(min_length=1, max_length=255)
+    corpus_id: UUID
+    transcript_document_ids: list[UUID]
+
+    @field_validator("codebook_name")
+    @classmethod
+    def normalize_codebook_name(cls, value: str) -> str:
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("codebook_name must not be empty")
+        return normalized
+
+    @field_validator("transcript_document_ids")
+    @classmethod
+    def validate_transcript_document_ids(cls, values: list[UUID]) -> list[UUID]:
+        if not values:
+            raise ValueError("transcript_document_ids must contain at least one document id")
+        return values
+
+
+class GeneratedCodebookResponse(BaseSchema):
+    codebook: CodebookSchema
+    transcripts_processed: int
+    passages_processed: int
+    themes_created: int
+    codes_created: int

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -1,7 +1,6 @@
-from uuid import UUID
-
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 from pydantic import Field, field_validator
 

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -42,11 +42,19 @@ class CodebookGenerateRequest(BaseSchema):
 
 
 class GeneratedCodebookResponse(BaseSchema):
+    class PassageFailure(BaseSchema):
+        passage_index: int
+        passage_excerpt: str
+        error: str
+        attempts: int
+
     codebook: CodebookSchema
     transcripts_processed: int
     passages_processed: int
     themes_created: int
     codes_created: int
+    passages_failed: int = 0
+    failed_passages: list[PassageFailure] = Field(default_factory=list)
 
 
 JobStatus = Literal["queued", "running", "succeeded", "failed", "cancelled"]

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -1,5 +1,8 @@
 from uuid import UUID
 
+from datetime import datetime
+from typing import Literal
+
 from pydantic import Field, field_validator
 
 from app.schemas.common import BaseSchema
@@ -43,3 +46,33 @@ class GeneratedCodebookResponse(BaseSchema):
     passages_processed: int
     themes_created: int
     codes_created: int
+
+
+JobStatus = Literal["queued", "running", "succeeded", "failed", "cancelled"]
+
+
+class CodebookGenerationJobCreateRequest(CodebookGenerateRequest):
+    pass
+
+
+class CodebookGenerationJobSchema(BaseSchema):
+    id: UUID
+    status: JobStatus
+    codebook_name: str
+    corpus_id: UUID
+    transcript_document_ids: list[UUID]
+    cancel_requested: bool
+
+    codebook_id: UUID | None = None
+    passages_total: int
+    passages_done: int
+    transcripts_processed: int | None = None
+    passages_processed: int | None = None
+    themes_created: int | None = None
+    codes_created: int | None = None
+    error_message: str | None = None
+
+    created_at: datetime
+    updated_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -22,7 +22,7 @@ class CodebookSchema(BaseSchema):
 class CodebookGenerateRequest(BaseSchema):
     codebook_name: str = Field(min_length=1, max_length=255)
     corpus_id: UUID
-    transcript_document_ids: list[UUID]
+    transcript_document_ids: list[UUID] | None = None
 
     @field_validator("codebook_name")
     @classmethod
@@ -34,9 +34,11 @@ class CodebookGenerateRequest(BaseSchema):
 
     @field_validator("transcript_document_ids")
     @classmethod
-    def validate_transcript_document_ids(cls, values: list[UUID]) -> list[UUID]:
+    def normalize_transcript_document_ids(cls, values: list[UUID] | None) -> list[UUID] | None:
+        if values is None:
+            return None
         if not values:
-            raise ValueError("transcript_document_ids must contain at least one document id")
+            return None
         return values
 
 

--- a/Backend/app/schemas/llm.py
+++ b/Backend/app/schemas/llm.py
@@ -11,3 +11,34 @@ class InterviewAnalysisResult(BaseModel):
     themes: list[ThemePresence] = Field(description="The list of themes evaluated against the transcript.")
     summary: str | None = Field(None, description="A 2-3 sentence orientation to what the interview is about.")
     researcher_notes: str | None = Field(None, description="Anything ambiguous, contradictory, or worth a follow-up interview question.")
+
+
+class GeneratedThemeNode(BaseModel):
+    label: str = Field(description="Theme node label, e.g., a theme or subtheme name.")
+    description: str | None = Field(
+        None,
+        description="Optional short description for this node.",
+    )
+
+
+class GeneratedThemePath(BaseModel):
+    path: list[GeneratedThemeNode] = Field(
+        description="Ordered theme path from root theme to deepest subtheme.",
+    )
+
+
+class GeneratedCodeSuggestion(BaseModel):
+    label: str = Field(description="Code label.")
+    description: str | None = Field(None, description="Optional short code description.")
+    theme_path: list[str] = Field(
+        description="Theme path (root -> ... -> leaf theme) this code belongs to.",
+    )
+
+
+class PassageCodebookGeneration(BaseModel):
+    themes: list[GeneratedThemePath] = Field(
+        description="Theme/subtheme paths identified in one passage.",
+    )
+    codes: list[GeneratedCodeSuggestion] = Field(
+        description="Codes identified in one passage.",
+    )

--- a/Backend/app/schemas/theme.py
+++ b/Backend/app/schemas/theme.py
@@ -5,6 +5,7 @@ from app.schemas.common import BaseSchema
 
 class ThemeSchema(BaseSchema):
     id: UUID
+    codebook_id: UUID
     label: str
     description: str | None = None
     is_active: bool

--- a/Backend/app/services/__init__.py
+++ b/Backend/app/services/__init__.py
@@ -7,6 +7,7 @@ from app.schemas.theme_graph import (
     ThemeNodeView,
     ThemeTreeNode,
 )
+from app.services.codebook_generation import CodebookGenerationService
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import (
     ThemeGraphError,
@@ -28,4 +29,5 @@ __all__ = [
     "ThemeValidationError",
     "ThemeFrequencyService",
     "ThemeReadService",
+    "CodebookGenerationService",
 ]

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from langchain_core.exceptions import OutputParserException
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -216,7 +217,7 @@ class CodebookGenerationService:
             await on_progress(0, total)
 
         for index, passage in enumerate(passages, start=1):
-            parse_error: OutputParserException | None = None
+            parse_error: OutputParserException | ValidationError | None = None
             attempts = 3
             for attempt in range(1, attempts + 1):
                 if should_cancel is not None and await should_cancel():
@@ -227,6 +228,10 @@ class CodebookGenerationService:
                     parse_error = None
                     break
                 except OutputParserException as exc:
+                    parse_error = exc
+                    if attempt < attempts:
+                        continue
+                except ValidationError as exc:
                     parse_error = exc
                     if attempt < attempts:
                         continue

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from uuid import UUID
 
+from langchain_core.exceptions import OutputParserException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -80,14 +81,17 @@ class CodebookGenerationService:
         # does not keep a checked-out DB connection during inference.
         await self._session.rollback()
 
-        generation_results = await self._generate_per_passage(
+        generation_results, failed_passages = await self._generate_per_passage(
             passages,
             on_progress=on_progress,
             should_cancel=should_cancel,
         )
         theme_nodes, code_nodes, hierarchy_edges = self._deduplicate_generation(generation_results)
         if not theme_nodes:
-            raise UnprocessableError("Codebook generation produced no themes from selected passages")
+            raise UnprocessableError(
+                "Codebook generation produced no themes from selected passages "
+                f"(failed passages: {len(failed_passages)})"
+            )
 
         created_codebook, themes_created, codes_created = await self._persist_generated_codebook(
             codebook_name=codebook_name,
@@ -102,6 +106,8 @@ class CodebookGenerationService:
             passages_processed=len(passages),
             themes_created=themes_created,
             codes_created=codes_created,
+            passages_failed=len(failed_passages),
+            failed_passages=failed_passages,
         )
 
     @staticmethod
@@ -202,25 +208,45 @@ class CodebookGenerationService:
         *,
         on_progress: Callable[[int, int], Awaitable[None]] | None = None,
         should_cancel: Callable[[], Awaitable[bool]] | None = None,
-    ) -> list[PassageCodebookGeneration]:
+    ) -> tuple[list[PassageCodebookGeneration], list[GeneratedCodebookResponse.PassageFailure]]:
         results: list[PassageCodebookGeneration] = []
+        failures: list[GeneratedCodebookResponse.PassageFailure] = []
         total = len(passages)
         if on_progress is not None:
             await on_progress(0, total)
 
         for index, passage in enumerate(passages, start=1):
-            if should_cancel is not None and await should_cancel():
-                raise CodebookGenerationCancelledError("Codebook generation was cancelled")
-            try:
-                generation = await asyncio.to_thread(generate_codebook_for_passage, passage)
-                results.append(generation)
-                if on_progress is not None:
-                    await on_progress(index, total)
-            except CodebookGenerationCancelledError:
-                raise
-            except Exception as exc:
-                raise UnprocessableError(f"Codebook generation failed: {exc}") from exc
-        return results
+            parse_error: OutputParserException | None = None
+            attempts = 3
+            for attempt in range(1, attempts + 1):
+                if should_cancel is not None and await should_cancel():
+                    raise CodebookGenerationCancelledError("Codebook generation was cancelled")
+                try:
+                    generation = await asyncio.to_thread(generate_codebook_for_passage, passage)
+                    results.append(generation)
+                    parse_error = None
+                    break
+                except OutputParserException as exc:
+                    parse_error = exc
+                    if attempt < attempts:
+                        continue
+                except CodebookGenerationCancelledError:
+                    raise
+                except Exception as exc:
+                    raise UnprocessableError(f"Codebook generation failed: {exc}") from exc
+
+            if parse_error is not None:
+                failures.append(
+                    GeneratedCodebookResponse.PassageFailure(
+                        passage_index=index,
+                        passage_excerpt=passage[:240],
+                        error=str(parse_error),
+                        attempts=attempts,
+                    )
+                )
+            if on_progress is not None:
+                await on_progress(index, total)
+        return results, failures
 
     @staticmethod
     def _normalize_label(value: str) -> str:
@@ -354,6 +380,7 @@ class CodebookGenerationService:
                 created_by="system-llm",
             )
             self._session.add(codebook)
+            await self._session.flush()
 
             ordered_theme_nodes = sorted(theme_nodes.values(), key=lambda node: (len(node.key), node.key))
             theme_id_by_key: dict[tuple[str, ...], UUID] = {}
@@ -373,6 +400,7 @@ class CodebookGenerationService:
                     is_active=True,
                 )
                 self._session.add(theme)
+                await self._session.flush()
                 theme_id_by_key[node.key] = theme.id
                 theme_id_by_label[label_key] = theme.id
                 self._session.add(
@@ -422,6 +450,7 @@ class CodebookGenerationService:
                     is_active=True,
                 )
                 self._session.add(code)
+                await self._session.flush()
                 self._session.add(
                     CodebookCodeRelationship(
                         id=uuid.uuid4(),

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -55,19 +55,19 @@ class CodebookGenerationService:
         *,
         codebook_name: str,
         corpus_id: UUID,
-        transcript_document_ids: list[UUID],
+        transcript_document_ids: list[UUID] | None,
         on_progress: Callable[[int, int], Awaitable[None]] | None = None,
         should_cancel: Callable[[], Awaitable[bool]] | None = None,
     ) -> GeneratedCodebookResponse:
         normalized_document_ids = self._deduplicate_document_ids(transcript_document_ids)
-        if not normalized_document_ids:
-            raise UnprocessableError("transcript_document_ids must contain at least one document id")
 
         corpus = await self._load_corpus(corpus_id)
         documents = await self._load_documents(
             corpus_id=corpus_id,
             transcript_document_ids=normalized_document_ids,
         )
+        if not documents:
+            raise UnprocessableError("No documents found in the selected corpus")
         passages = await self._load_passages(
             corpus_id=corpus_id,
             transcript_document_ids=[document.id for document in documents],
@@ -80,7 +80,7 @@ class CodebookGenerationService:
             on_progress=on_progress,
             should_cancel=should_cancel,
         )
-        theme_nodes, code_nodes = self._deduplicate_generation(generation_results)
+        theme_nodes, code_nodes, hierarchy_edges = self._deduplicate_generation(generation_results)
         if not theme_nodes:
             raise UnprocessableError("Codebook generation produced no themes from selected passages")
 
@@ -89,6 +89,7 @@ class CodebookGenerationService:
             project_id=str(corpus.project_id),
             theme_nodes=theme_nodes,
             code_nodes=code_nodes,
+            hierarchy_edges=hierarchy_edges,
         )
         return GeneratedCodebookResponse(
             codebook=CodebookSchema.model_validate(created_codebook),
@@ -99,7 +100,9 @@ class CodebookGenerationService:
         )
 
     @staticmethod
-    def _deduplicate_document_ids(document_ids: list[UUID]) -> list[UUID]:
+    def _deduplicate_document_ids(document_ids: list[UUID] | None) -> list[UUID]:
+        if not document_ids:
+            return []
         ordered_unique: list[UUID] = []
         seen: set[UUID] = set()
         for document_id in document_ids:
@@ -125,6 +128,17 @@ class CodebookGenerationService:
         corpus_id: UUID,
         transcript_document_ids: list[UUID],
     ) -> list[CorpusDocument]:
+        if not transcript_document_ids:
+            return list(
+                (
+                    await self._session.scalars(
+                        select(CorpusDocument)
+                        .where(CorpusDocument.corpus_id == corpus_id)
+                        .order_by(CorpusDocument.id)
+                    )
+                ).all()
+            )
+
         documents = list(
             (
                 await self._session.scalars(
@@ -197,6 +211,8 @@ class CodebookGenerationService:
                 results.append(generation)
                 if on_progress is not None:
                     await on_progress(index, total)
+            except CodebookGenerationCancelledError:
+                raise
             except Exception as exc:
                 raise UnprocessableError(f"Codebook generation failed: {exc}") from exc
         return results
@@ -209,9 +225,10 @@ class CodebookGenerationService:
     def _deduplicate_generation(
         cls,
         generation_results: list[PassageCodebookGeneration],
-    ) -> tuple[dict[tuple[str, ...], _ThemeNodeDraft], list[_CodeDraft]]:
+    ) -> tuple[dict[tuple[str, ...], _ThemeNodeDraft], list[_CodeDraft], list[tuple[tuple[str, ...], tuple[str, ...]]]]:
         theme_nodes_by_key: dict[tuple[str, ...], _ThemeNodeDraft] = {}
         codes_by_key: dict[str, _CodeDraft] = {}
+        raw_edges: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
 
         for result in generation_results:
             for generated_path in result.themes:
@@ -232,6 +249,8 @@ class CodebookGenerationService:
                         )
                     elif not existing.description and description and description.strip():
                         existing.description = description.strip()
+                    if index > 1:
+                        raw_edges.append((tuple(part.lower() for part in normalized_labels[: index - 1]), key))
 
             for generated_code in result.codes:
                 normalized_code_label = cls._normalize_label(generated_code.label)
@@ -268,7 +287,47 @@ class CodebookGenerationService:
             codes_by_key.values(),
             key=lambda code: code.label.lower(),
         )
-        return theme_nodes_by_key, sorted_codes
+        canonical_key_by_label: dict[str, tuple[str, ...]] = {}
+        for key in sorted(theme_nodes_by_key.keys(), key=lambda item: (len(item), item)):
+            label_key = theme_nodes_by_key[key].label.lower()
+            canonical_key_by_label.setdefault(label_key, key)
+
+        canonical_theme_nodes: dict[tuple[str, ...], _ThemeNodeDraft] = {}
+        canonical_key_by_original: dict[tuple[str, ...], tuple[str, ...]] = {}
+        for key, node in theme_nodes_by_key.items():
+            canonical_key = canonical_key_by_label[node.label.lower()]
+            canonical_key_by_original[key] = canonical_key
+            canonical_node = canonical_theme_nodes.get(canonical_key)
+            if canonical_node is None:
+                canonical_theme_nodes[canonical_key] = _ThemeNodeDraft(
+                    key=canonical_key,
+                    label=theme_nodes_by_key[canonical_key].label,
+                    description=node.description,
+                )
+            elif not canonical_node.description and node.description:
+                canonical_node.description = node.description
+
+        canonical_edges: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+        child_parent: dict[tuple[str, ...], tuple[str, ...]] = {}
+        seen_edges: set[tuple[tuple[str, ...], tuple[str, ...]]] = set()
+        for parent, child in sorted(raw_edges, key=lambda pair: (len(pair[0]), pair[0], len(pair[1]), pair[1])):
+            canonical_parent = canonical_key_by_original.get(parent)
+            canonical_child = canonical_key_by_original.get(child)
+            if canonical_parent is None or canonical_child is None:
+                continue
+            if canonical_parent == canonical_child:
+                continue
+            existing_parent = child_parent.get(canonical_child)
+            if existing_parent is not None and existing_parent != canonical_parent:
+                continue
+            edge = (canonical_parent, canonical_child)
+            if edge in seen_edges:
+                continue
+            seen_edges.add(edge)
+            child_parent[canonical_child] = canonical_parent
+            canonical_edges.append(edge)
+
+        return canonical_theme_nodes, sorted_codes, canonical_edges
 
     async def _persist_generated_codebook(
         self,
@@ -277,6 +336,7 @@ class CodebookGenerationService:
         project_id: str,
         theme_nodes: dict[tuple[str, ...], _ThemeNodeDraft],
         code_nodes: list[_CodeDraft],
+        hierarchy_edges: list[tuple[tuple[str, ...], tuple[str, ...]]],
     ) -> tuple[Codebook, int, int]:
         try:
             version = await self._next_codebook_version(project_id=project_id)
@@ -293,7 +353,14 @@ class CodebookGenerationService:
 
             ordered_theme_nodes = sorted(theme_nodes.values(), key=lambda node: (len(node.key), node.key))
             theme_id_by_key: dict[tuple[str, ...], UUID] = {}
+            theme_id_by_label: dict[str, UUID] = {}
             for node in ordered_theme_nodes:
+                label_key = node.label.lower()
+                existing_theme_id = theme_id_by_label.get(label_key)
+                if existing_theme_id is not None:
+                    theme_id_by_key[node.key] = existing_theme_id
+                    continue
+
                 theme = Theme(
                     id=uuid.uuid4(),
                     codebook_id=codebook.id,
@@ -304,6 +371,7 @@ class CodebookGenerationService:
                 self._session.add(theme)
                 await self._session.flush()
                 theme_id_by_key[node.key] = theme.id
+                theme_id_by_label[label_key] = theme.id
                 self._session.add(
                     CodebookThemeRelationship(
                         id=uuid.uuid4(),
@@ -313,13 +381,21 @@ class CodebookGenerationService:
                     )
                 )
 
-            for node in ordered_theme_nodes:
-                if len(node.key) <= 1:
-                    continue
-                parent_key = node.key[:-1]
+            parent_by_child: dict[UUID, UUID] = {}
+            added_edges: set[tuple[UUID, UUID]] = set()
+            for parent_key, child_key in hierarchy_edges:
                 parent_theme_id = theme_id_by_key.get(parent_key)
-                child_theme_id = theme_id_by_key.get(node.key)
+                child_theme_id = theme_id_by_key.get(child_key)
                 if parent_theme_id is None or child_theme_id is None:
+                    continue
+                if parent_theme_id == child_theme_id:
+                    continue
+                existing_parent = parent_by_child.get(child_theme_id)
+                if existing_parent is not None and existing_parent != parent_theme_id:
+                    # A label-merged child already has a parent in this codebook; keep first parent.
+                    continue
+                edge_key = (parent_theme_id, child_theme_id)
+                if edge_key in added_edges:
                     continue
                 self._session.add(
                     ThemeHierarchyRelationship(
@@ -330,6 +406,8 @@ class CodebookGenerationService:
                         is_active=True,
                     )
                 )
+                parent_by_child[child_theme_id] = parent_theme_id
+                added_edges.add(edge_key)
 
             codes_created = 0
             for code_node in code_nodes:
@@ -359,7 +437,7 @@ class CodebookGenerationService:
 
             await self._session.commit()
             await self._session.refresh(codebook)
-            return codebook, len(theme_id_by_key), codes_created
+            return codebook, len(theme_id_by_label), codes_created
         except Exception:
             await self._session.rollback()
             raise

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -38,6 +40,10 @@ class _CodeDraft:
     description: str | None
 
 
+class CodebookGenerationCancelledError(Exception):
+    pass
+
+
 class CodebookGenerationService:
     """Generate and persist a new codebook from selected transcript chunks."""
 
@@ -50,6 +56,8 @@ class CodebookGenerationService:
         codebook_name: str,
         corpus_id: UUID,
         transcript_document_ids: list[UUID],
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+        should_cancel: Callable[[], Awaitable[bool]] | None = None,
     ) -> GeneratedCodebookResponse:
         normalized_document_ids = self._deduplicate_document_ids(transcript_document_ids)
         if not normalized_document_ids:
@@ -67,7 +75,11 @@ class CodebookGenerationService:
         if not passages:
             raise UnprocessableError("No transcript passages found for selected transcript_document_ids")
 
-        generation_results = self._generate_per_passage(passages)
+        generation_results = await self._generate_per_passage(
+            passages,
+            on_progress=on_progress,
+            should_cancel=should_cancel,
+        )
         theme_nodes, code_nodes = self._deduplicate_generation(generation_results)
         if not theme_nodes:
             raise UnprocessableError("Codebook generation produced no themes from selected passages")
@@ -166,11 +178,25 @@ class CodebookGenerationService:
         return passages
 
     @staticmethod
-    def _generate_per_passage(passages: list[str]) -> list[PassageCodebookGeneration]:
+    async def _generate_per_passage(
+        passages: list[str],
+        *,
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+        should_cancel: Callable[[], Awaitable[bool]] | None = None,
+    ) -> list[PassageCodebookGeneration]:
         results: list[PassageCodebookGeneration] = []
-        for passage in passages:
+        total = len(passages)
+        if on_progress is not None:
+            await on_progress(0, total)
+
+        for index, passage in enumerate(passages, start=1):
+            if should_cancel is not None and await should_cancel():
+                raise CodebookGenerationCancelledError("Codebook generation was cancelled")
             try:
-                results.append(generate_codebook_for_passage(passage))
+                generation = await asyncio.to_thread(generate_codebook_for_passage, passage)
+                results.append(generation)
+                if on_progress is not None:
+                    await on_progress(index, total)
             except Exception as exc:
                 raise UnprocessableError(f"Codebook generation failed: {exc}") from exc
         return results

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -62,6 +62,7 @@ class CodebookGenerationService:
         normalized_document_ids = self._deduplicate_document_ids(transcript_document_ids)
 
         corpus = await self._load_corpus(corpus_id)
+        project_id = str(corpus.project_id)
         documents = await self._load_documents(
             corpus_id=corpus_id,
             transcript_document_ids=normalized_document_ids,
@@ -75,6 +76,10 @@ class CodebookGenerationService:
         if not passages:
             raise UnprocessableError("No transcript passages found for selected transcript_document_ids")
 
+        # End the read transaction before long-running LLM calls so the session
+        # does not keep a checked-out DB connection during inference.
+        await self._session.rollback()
+
         generation_results = await self._generate_per_passage(
             passages,
             on_progress=on_progress,
@@ -86,7 +91,7 @@ class CodebookGenerationService:
 
         created_codebook, themes_created, codes_created = await self._persist_generated_codebook(
             codebook_name=codebook_name,
-            project_id=str(corpus.project_id),
+            project_id=project_id,
             theme_nodes=theme_nodes,
             code_nodes=code_nodes,
             hierarchy_edges=hierarchy_edges,
@@ -349,7 +354,6 @@ class CodebookGenerationService:
                 created_by="system-llm",
             )
             self._session.add(codebook)
-            await self._session.flush()
 
             ordered_theme_nodes = sorted(theme_nodes.values(), key=lambda node: (len(node.key), node.key))
             theme_id_by_key: dict[tuple[str, ...], UUID] = {}
@@ -369,7 +373,6 @@ class CodebookGenerationService:
                     is_active=True,
                 )
                 self._session.add(theme)
-                await self._session.flush()
                 theme_id_by_key[node.key] = theme.id
                 theme_id_by_label[label_key] = theme.id
                 self._session.add(
@@ -419,7 +422,6 @@ class CodebookGenerationService:
                     is_active=True,
                 )
                 self._session.add(code)
-                await self._session.flush()
                 self._session.add(
                     CodebookCodeRelationship(
                         id=uuid.uuid4(),

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import NotFoundError, UnprocessableError
+from app.llm.pipelines import generate_codebook_for_passage
+from app.models import (
+    Code,
+    Codebook,
+    CodebookCodeRelationship,
+    CodebookThemeRelationship,
+    Corpus,
+    CorpusChunk,
+    CorpusDocument,
+    Theme,
+    ThemeHierarchyRelationship,
+)
+from app.schemas.codebook import CodebookSchema, GeneratedCodebookResponse
+from app.schemas.llm import PassageCodebookGeneration
+from app.services.theme_graph import ThemeGraphService
+
+
+@dataclass
+class _ThemeNodeDraft:
+    key: tuple[str, ...]
+    label: str
+    description: str | None = None
+
+
+@dataclass
+class _CodeDraft:
+    label: str
+    description: str | None
+
+
+class CodebookGenerationService:
+    """Generate and persist a new codebook from selected transcript chunks."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def generate_codebook(
+        self,
+        *,
+        codebook_name: str,
+        corpus_id: UUID,
+        transcript_document_ids: list[UUID],
+    ) -> GeneratedCodebookResponse:
+        normalized_document_ids = self._deduplicate_document_ids(transcript_document_ids)
+        if not normalized_document_ids:
+            raise UnprocessableError("transcript_document_ids must contain at least one document id")
+
+        corpus = await self._load_corpus(corpus_id)
+        documents = await self._load_documents(
+            corpus_id=corpus_id,
+            transcript_document_ids=normalized_document_ids,
+        )
+        passages = await self._load_passages(
+            corpus_id=corpus_id,
+            transcript_document_ids=[document.id for document in documents],
+        )
+        if not passages:
+            raise UnprocessableError("No transcript passages found for selected transcript_document_ids")
+
+        generation_results = self._generate_per_passage(passages)
+        theme_nodes, code_nodes = self._deduplicate_generation(generation_results)
+        if not theme_nodes:
+            raise UnprocessableError("Codebook generation produced no themes from selected passages")
+
+        created_codebook, themes_created, codes_created = await self._persist_generated_codebook(
+            codebook_name=codebook_name,
+            project_id=str(corpus.project_id),
+            theme_nodes=theme_nodes,
+            code_nodes=code_nodes,
+        )
+        return GeneratedCodebookResponse(
+            codebook=CodebookSchema.model_validate(created_codebook),
+            transcripts_processed=len(documents),
+            passages_processed=len(passages),
+            themes_created=themes_created,
+            codes_created=codes_created,
+        )
+
+    @staticmethod
+    def _deduplicate_document_ids(document_ids: list[UUID]) -> list[UUID]:
+        ordered_unique: list[UUID] = []
+        seen: set[UUID] = set()
+        for document_id in document_ids:
+            if document_id in seen:
+                continue
+            seen.add(document_id)
+            ordered_unique.append(document_id)
+        return ordered_unique
+
+    async def _load_corpus(self, corpus_id: UUID) -> Corpus:
+        corpus = (
+            await self._session.execute(
+                select(Corpus).where(Corpus.id == corpus_id)
+            )
+        ).scalar_one_or_none()
+        if corpus is None:
+            raise NotFoundError(f"Corpus '{corpus_id}' not found")
+        return corpus
+
+    async def _load_documents(
+        self,
+        *,
+        corpus_id: UUID,
+        transcript_document_ids: list[UUID],
+    ) -> list[CorpusDocument]:
+        documents = list(
+            (
+                await self._session.scalars(
+                    select(CorpusDocument).where(
+                        CorpusDocument.corpus_id == corpus_id,
+                        CorpusDocument.id.in_(transcript_document_ids),
+                    )
+                )
+            ).all()
+        )
+        documents_by_id = {document.id: document for document in documents}
+        missing = [document_id for document_id in transcript_document_ids if document_id not in documents_by_id]
+        if missing:
+            missing_str = ", ".join(str(document_id) for document_id in missing)
+            raise UnprocessableError(
+                "Some transcript_document_ids were not found in the selected corpus: "
+                f"{missing_str}"
+            )
+        return [documents_by_id[document_id] for document_id in transcript_document_ids]
+
+    async def _load_passages(
+        self,
+        *,
+        corpus_id: UUID,
+        transcript_document_ids: list[UUID],
+    ) -> list[str]:
+        chunk_rows = list(
+            (
+                await self._session.execute(
+                    select(CorpusChunk.document_id, CorpusChunk.text, CorpusChunk.chunk_index)
+                    .join(CorpusDocument, CorpusChunk.document_id == CorpusDocument.id)
+                    .where(
+                        CorpusDocument.corpus_id == corpus_id,
+                        CorpusChunk.document_id.in_(transcript_document_ids),
+                    )
+                    .order_by(CorpusChunk.document_id, CorpusChunk.chunk_index)
+                )
+            ).all()
+        )
+        if not chunk_rows:
+            return []
+
+        chunks_by_document: dict[UUID, list[tuple[int, str]]] = {document_id: [] for document_id in transcript_document_ids}
+        for document_id, text, chunk_index in chunk_rows:
+            chunks_by_document[document_id].append((chunk_index, text))
+
+        passages: list[str] = []
+        for document_id in transcript_document_ids:
+            ordered_chunks = sorted(chunks_by_document.get(document_id, []), key=lambda row: row[0])
+            passages.extend(text.strip() for _, text in ordered_chunks if text and text.strip())
+        return passages
+
+    @staticmethod
+    def _generate_per_passage(passages: list[str]) -> list[PassageCodebookGeneration]:
+        results: list[PassageCodebookGeneration] = []
+        for passage in passages:
+            try:
+                results.append(generate_codebook_for_passage(passage))
+            except Exception as exc:
+                raise UnprocessableError(f"Codebook generation failed: {exc}") from exc
+        return results
+
+    @staticmethod
+    def _normalize_label(value: str) -> str:
+        return " ".join(value.split()).strip()
+
+    @classmethod
+    def _deduplicate_generation(
+        cls,
+        generation_results: list[PassageCodebookGeneration],
+    ) -> tuple[dict[tuple[str, ...], _ThemeNodeDraft], list[_CodeDraft]]:
+        theme_nodes_by_key: dict[tuple[str, ...], _ThemeNodeDraft] = {}
+        codes_by_key: dict[str, _CodeDraft] = {}
+
+        for result in generation_results:
+            for generated_path in result.themes:
+                normalized_labels = [cls._normalize_label(node.label) for node in generated_path.path]
+                normalized_labels = [label for label in normalized_labels if label]
+                if not normalized_labels:
+                    continue
+
+                for index, label in enumerate(normalized_labels, start=1):
+                    key = tuple(part.lower() for part in normalized_labels[:index])
+                    description = generated_path.path[index - 1].description
+                    existing = theme_nodes_by_key.get(key)
+                    if existing is None:
+                        theme_nodes_by_key[key] = _ThemeNodeDraft(
+                            key=key,
+                            label=label,
+                            description=description.strip() if description else None,
+                        )
+                    elif not existing.description and description and description.strip():
+                        existing.description = description.strip()
+
+            for generated_code in result.codes:
+                normalized_code_label = cls._normalize_label(generated_code.label)
+                normalized_theme_path = [
+                    cls._normalize_label(path_item) for path_item in generated_code.theme_path
+                ]
+                normalized_theme_path = [item for item in normalized_theme_path if item]
+                if not normalized_code_label or not normalized_theme_path:
+                    continue
+
+                theme_key: tuple[str, ...] = ()
+                for index, label in enumerate(normalized_theme_path, start=1):
+                    theme_key = tuple(part.lower() for part in normalized_theme_path[:index])
+                    if theme_key not in theme_nodes_by_key:
+                        theme_nodes_by_key[theme_key] = _ThemeNodeDraft(
+                            key=theme_key,
+                            label=label,
+                            description=None,
+                        )
+
+                code_key = normalized_code_label.lower()
+                existing_code = codes_by_key.get(code_key)
+                if existing_code is None:
+                    codes_by_key[code_key] = _CodeDraft(
+                        label=normalized_code_label,
+                        description=generated_code.description.strip() if generated_code.description else None,
+                    )
+                elif not existing_code.description and generated_code.description:
+                    description = generated_code.description.strip()
+                    if description:
+                        existing_code.description = description
+
+        sorted_codes = sorted(
+            codes_by_key.values(),
+            key=lambda code: code.label.lower(),
+        )
+        return theme_nodes_by_key, sorted_codes
+
+    async def _persist_generated_codebook(
+        self,
+        *,
+        codebook_name: str,
+        project_id: str,
+        theme_nodes: dict[tuple[str, ...], _ThemeNodeDraft],
+        code_nodes: list[_CodeDraft],
+    ) -> tuple[Codebook, int, int]:
+        try:
+            version = await self._next_codebook_version(project_id=project_id)
+            codebook = Codebook(
+                id=uuid.uuid4(),
+                project_id=project_id,
+                name=codebook_name,
+                description="LLM-generated codebook",
+                version=version,
+                created_by="system-llm",
+            )
+            self._session.add(codebook)
+            await self._session.flush()
+
+            ordered_theme_nodes = sorted(theme_nodes.values(), key=lambda node: (len(node.key), node.key))
+            theme_id_by_key: dict[tuple[str, ...], UUID] = {}
+            for node in ordered_theme_nodes:
+                theme = Theme(
+                    id=uuid.uuid4(),
+                    codebook_id=codebook.id,
+                    label=node.label,
+                    description=node.description,
+                    is_active=True,
+                )
+                self._session.add(theme)
+                await self._session.flush()
+                theme_id_by_key[node.key] = theme.id
+                self._session.add(
+                    CodebookThemeRelationship(
+                        id=uuid.uuid4(),
+                        codebook_id=codebook.id,
+                        theme_id=theme.id,
+                        is_active=True,
+                    )
+                )
+
+            for node in ordered_theme_nodes:
+                if len(node.key) <= 1:
+                    continue
+                parent_key = node.key[:-1]
+                parent_theme_id = theme_id_by_key.get(parent_key)
+                child_theme_id = theme_id_by_key.get(node.key)
+                if parent_theme_id is None or child_theme_id is None:
+                    continue
+                self._session.add(
+                    ThemeHierarchyRelationship(
+                        id=uuid.uuid4(),
+                        codebook_id=codebook.id,
+                        parent_theme_id=parent_theme_id,
+                        child_theme_id=child_theme_id,
+                        is_active=True,
+                    )
+                )
+
+            codes_created = 0
+            for code_node in code_nodes:
+                code = Code(
+                    id=uuid.uuid4(),
+                    codebook_id=codebook.id,
+                    label=code_node.label,
+                    description=code_node.description,
+                    is_active=True,
+                )
+                self._session.add(code)
+                await self._session.flush()
+                self._session.add(
+                    CodebookCodeRelationship(
+                        id=uuid.uuid4(),
+                        codebook_id=codebook.id,
+                        code_id=code.id,
+                        is_active=True,
+                    )
+                )
+                codes_created += 1
+
+            validation = await ThemeGraphService(self._session).validate_theme_dag(codebook_id=codebook.id)
+            if not validation.is_valid:
+                violations = "; ".join(validation.violations)
+                raise UnprocessableError(f"Generated hierarchy is invalid: {violations}")
+
+            await self._session.commit()
+            await self._session.refresh(codebook)
+            return codebook, len(theme_id_by_key), codes_created
+        except Exception:
+            await self._session.rollback()
+            raise
+
+    async def _next_codebook_version(self, *, project_id: str) -> int:
+        latest_version = (
+            await self._session.execute(
+                select(func.max(Codebook.version)).where(Codebook.project_id == project_id)
+            )
+        ).scalar_one_or_none()
+        return int((latest_version or 0) + 1)

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from uuid import UUID
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.database import get_session_factory
+from app.models import CodebookGenerationJob
+from app.services.codebook_generation import (
+    CodebookGenerationCancelledError,
+    CodebookGenerationService,
+)
+
+
+def _utc_now_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class CodebookGenerationJobRunner:
+    def __init__(self) -> None:
+        self._tasks: dict[UUID, asyncio.Task[None]] = {}
+
+    async def start(self) -> None:
+        return
+
+    async def stop(self) -> None:
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._tasks.clear()
+
+    async def enqueue(
+        self,
+        job_id: UUID,
+        *,
+        session_factory: async_sessionmaker[AsyncSession] | None = None,
+    ) -> None:
+        if job_id in self._tasks and not self._tasks[job_id].done():
+            return
+        selected_factory = session_factory or get_session_factory()
+        task = asyncio.create_task(
+            self._run_one(job_id, selected_factory),
+            name=f"codebook-generation-job-{job_id}",
+        )
+        self._tasks[job_id] = task
+
+    async def _run_one(
+        self,
+        job_id: UUID,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        try:
+            await self._process_one(job_id, session_factory)
+        except Exception:
+            logger.exception("Unhandled error while processing codebook generation job {}", job_id)
+        finally:
+            self._tasks.pop(job_id, None)
+
+    async def _process_one(
+        self,
+        job_id: UUID,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+
+        async with session_factory() as session:
+            job = await session.get(CodebookGenerationJob, job_id)
+            if job is None:
+                return
+            if job.status != "queued":
+                return
+            if job.cancel_requested:
+                job.status = "cancelled"
+                job.finished_at = _utc_now_naive()
+                await session.commit()
+                return
+
+            job.status = "running"
+            job.started_at = _utc_now_naive()
+            await session.commit()
+
+            transcript_document_ids = [UUID(raw) for raw in json.loads(job.transcript_document_ids_json)]
+            service = CodebookGenerationService(session)
+
+            async def _on_progress(done: int, total: int) -> None:
+                async with session_factory() as progress_session:
+                    progress_job = await progress_session.get(CodebookGenerationJob, job_id)
+                    if progress_job is None:
+                        return
+                    progress_job.passages_done = done
+                    progress_job.passages_total = total
+                    await progress_session.commit()
+
+            async def _should_cancel() -> bool:
+                async with session_factory() as cancel_session:
+                    cancel_job = await cancel_session.get(CodebookGenerationJob, job_id)
+                    return bool(cancel_job and cancel_job.cancel_requested)
+
+            try:
+                generated = await service.generate_codebook(
+                    codebook_name=job.codebook_name,
+                    corpus_id=job.corpus_id,
+                    transcript_document_ids=transcript_document_ids,
+                    on_progress=_on_progress,
+                    should_cancel=_should_cancel,
+                )
+                await session.refresh(job)
+                job.status = "succeeded"
+                job.codebook_id = generated.codebook.id
+                job.transcripts_processed = generated.transcripts_processed
+                job.passages_processed = generated.passages_processed
+                job.themes_created = generated.themes_created
+                job.codes_created = generated.codes_created
+                job.passages_done = generated.passages_processed
+                job.passages_total = max(job.passages_total, generated.passages_processed)
+                job.error_message = None
+                job.finished_at = _utc_now_naive()
+                await session.commit()
+            except CodebookGenerationCancelledError:
+                await session.rollback()
+                await session.refresh(job)
+                job.status = "cancelled"
+                job.finished_at = _utc_now_naive()
+                await session.commit()
+            except Exception as exc:
+                await session.rollback()
+                await session.refresh(job)
+                job.status = "failed"
+                job.error_message = str(exc)
+                job.finished_at = _utc_now_naive()
+                await session.commit()
+
+
+codebook_generation_job_runner = CodebookGenerationJobRunner()

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -121,7 +121,17 @@ class CodebookGenerationJobRunner:
                 job.codes_created = generated.codes_created
                 job.passages_done = generated.passages_processed
                 job.passages_total = max(job.passages_total, generated.passages_processed)
-                job.error_message = None
+                if generated.failed_passages:
+                    job.error_message = json.dumps(
+                        {
+                            "type": "passage_generation_partial_failures",
+                            "passages_failed": generated.passages_failed,
+                            "failed_passages": [failure.model_dump(mode="json") for failure in generated.failed_passages],
+                        },
+                        ensure_ascii=False,
+                    )
+                else:
+                    job.error_message = None
                 job.finished_at = _utc_now_naive()
                 await session.commit()
             except CodebookGenerationCancelledError:

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 from loguru import logger
@@ -17,7 +17,7 @@ from app.services.codebook_generation import (
 
 
 def _utc_now_naive() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class CodebookGenerationJobRunner:

--- a/Backend/app/services/theme_frequency.py
+++ b/Backend/app/services/theme_frequency.py
@@ -68,7 +68,10 @@ class ThemeFrequencyService:
                     CodebookThemeRelationship.is_active.is_(True),
                 ),
             )
-            .where(Theme.is_active.is_(True))
+            .where(
+                Theme.is_active.is_(True),
+                Theme.codebook_id == codebook_id,
+            )
             .distinct()
         )
         return list((await self._session.scalars(stmt)).all())

--- a/Backend/app/services/theme_graph.py
+++ b/Backend/app/services/theme_graph.py
@@ -140,7 +140,10 @@ class ThemeGraphService:
                     CodebookThemeRelationship.is_active.is_(True),
                 ),
             )
-            .where(Theme.is_active.is_(True))
+            .where(
+                Theme.is_active.is_(True),
+                Theme.codebook_id == codebook_id,
+            )
         )
         themes = list((await self._session.scalars(stmt)).all())
         return {

--- a/Backend/tests/fixtures/theme_graph_fixtures.py
+++ b/Backend/tests/fixtures/theme_graph_fixtures.py
@@ -71,7 +71,7 @@ async def _seed_codebook_with_theme_graph(
     )
 
     for label, theme_id in theme_ids_by_label.items():
-        session.add(Theme(id=theme_id, label=label, is_active=True))
+        session.add(Theme(id=theme_id, codebook_id=codebook_id, label=label, is_active=True))
 
     await session.flush()
 

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
+from langchain_core.exceptions import OutputParserException
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -19,7 +20,6 @@ from app.schemas.llm import (
     GeneratedThemePath,
     PassageCodebookGeneration,
 )
-from langchain_core.exceptions import OutputParserException
 
 API_INGESTION = "/api/v1/ingestion"
 API_CODEBOOKS = "/api/v1/codebooks"

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -237,3 +237,94 @@ async def test_generate_codebook_returns_404_for_unknown_corpus(client) -> None:
     )
     assert response.status_code == 404
     assert response.json()["success"] is False
+
+
+async def test_generate_codebook_uses_all_corpus_documents_when_ids_omitted(
+    client,
+    monkeypatch,
+) -> None:
+    corpus_id, _ = await _create_corpus_and_docs(client)
+
+    def _fake_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                    ]
+                )
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="Process Delay",
+                    description=None,
+                    theme_path=["Workflow Friction"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "All Docs",
+            "corpus_id": corpus_id,
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()["data"]
+    assert payload["transcripts_processed"] == 2
+
+
+async def test_generate_codebook_merges_duplicate_theme_labels_across_paths(
+    client,
+    db_engine,
+    monkeypatch,
+) -> None:
+    corpus_id, document_ids = await _create_corpus_and_docs(client)
+
+    def _fake_generate_codebook_for_passage(passage: str) -> PassageCodebookGeneration:
+        if "Alpha" in passage:
+            return PassageCodebookGeneration(
+                themes=[
+                    GeneratedThemePath(
+                        path=[
+                            GeneratedThemeNode(label="Planning"),
+                            GeneratedThemeNode(label="Future Expectations"),
+                        ]
+                    )
+                ],
+                codes=[],
+            )
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Adoption"),
+                        GeneratedThemeNode(label="Future Expectations"),
+                    ]
+                )
+            ],
+            codes=[],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Duplicate Labels",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()["data"]
+    assert payload["themes_created"] == 3

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models import (
+    Code,
+    Codebook,
+    CodebookCodeRelationship,
+    CodebookThemeRelationship,
+    Theme,
+    ThemeHierarchyRelationship,
+)
+from app.schemas.llm import (
+    GeneratedCodeSuggestion,
+    GeneratedThemeNode,
+    GeneratedThemePath,
+    PassageCodebookGeneration,
+)
+
+API_INGESTION = "/api/v1/ingestion"
+API_CODEBOOKS = "/api/v1/codebooks"
+PROJECT_ID = "00000000-0000-0000-0000-000000000111"
+
+
+async def _create_corpus_and_docs(client) -> tuple[str, list[str]]:
+    corpus_response = await client.post(
+        f"{API_INGESTION}/corpora",
+        json={"project_id": PROJECT_ID, "name": "Generation Corpus"},
+    )
+    assert corpus_response.status_code == 201
+    corpus_id = corpus_response.json()["data"]["id"]
+
+    ingest_response = await client.post(
+        f"{API_INGESTION}/corpora/{corpus_id}/documents/bulk",
+        json={
+            "documents": [
+                {"title": "Doc Alpha", "text": "Alpha passage with repeated manual work and bottlenecks."},
+                {"title": "Doc Beta", "text": "Beta passage about onboarding and training gaps."},
+            ]
+        },
+    )
+    assert ingest_response.status_code == 201
+
+    document_response = await client.get(f"{API_INGESTION}/corpora/{corpus_id}/documents")
+    assert document_response.status_code == 200
+    document_ids = [row["id"] for row in document_response.json()["data"]["items"]]
+    return corpus_id, document_ids
+
+
+async def test_generate_codebook_creates_deduplicated_themes_and_codes(
+    client,
+    db_engine,
+    monkeypatch,
+) -> None:
+    corpus_id, document_ids = await _create_corpus_and_docs(client)
+
+    def _fake_generate_codebook_for_passage(passage: str) -> PassageCodebookGeneration:
+        if "Alpha" in passage:
+            return PassageCodebookGeneration(
+                themes=[
+                    GeneratedThemePath(
+                        path=[
+                            GeneratedThemeNode(
+                                label="Workflow Friction",
+                                description="Repeated process inefficiencies.",
+                            ),
+                            GeneratedThemeNode(
+                                label="Manual Work",
+                                description="Reliance on manual steps.",
+                            ),
+                        ]
+                    )
+                ],
+                codes=[
+                    GeneratedCodeSuggestion(
+                        label="Manual Bottleneck",
+                        description="Manual processing slows progress.",
+                        theme_path=["Workflow Friction", "Manual Work"],
+                    )
+                ],
+            )
+
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                        GeneratedThemeNode(label="Manual Work"),
+                    ]
+                ),
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                        GeneratedThemeNode(label="Training Gaps"),
+                    ]
+                ),
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="manual bottleneck",
+                    description="Duplicate label with different casing.",
+                    theme_path=["Workflow Friction", "Manual Work"],
+                ),
+                GeneratedCodeSuggestion(
+                    label="Onboarding Unclear",
+                    description="Insufficient onboarding documentation.",
+                    theme_path=["Workflow Friction", "Training Gaps"],
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Generated v1",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 201
+
+    payload = response.json()["data"]
+    assert payload["transcripts_processed"] == 2
+    assert payload["themes_created"] == 3
+    assert payload["codes_created"] == 2
+
+    codebook_id = UUID(payload["codebook"]["id"])
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        codebook = (
+            await session.execute(select(Codebook).where(Codebook.id == codebook_id))
+        ).scalar_one_or_none()
+        assert codebook is not None
+        assert codebook.name == "Generated v1"
+
+        theme_rows = list(
+            (
+                await session.scalars(
+                    select(Theme)
+                    .join(
+                        CodebookThemeRelationship,
+                        and_(
+                            CodebookThemeRelationship.theme_id == Theme.id,
+                            CodebookThemeRelationship.codebook_id == codebook.id,
+                        ),
+                    )
+                )
+            ).all()
+        )
+        assert len(theme_rows) == 3
+        assert sorted(theme.label for theme in theme_rows) == [
+            "Manual Work",
+            "Training Gaps",
+            "Workflow Friction",
+        ]
+
+        hierarchy_rows = list(
+            (
+                await session.scalars(
+                    select(ThemeHierarchyRelationship).where(
+                        ThemeHierarchyRelationship.codebook_id == codebook.id
+                    )
+                )
+            ).all()
+        )
+        assert len(hierarchy_rows) == 2
+
+        code_rows = list(
+            (
+                await session.scalars(
+                    select(Code)
+                    .join(
+                        CodebookCodeRelationship,
+                        and_(
+                            CodebookCodeRelationship.code_id == Code.id,
+                            CodebookCodeRelationship.codebook_id == codebook.id,
+                        ),
+                    )
+                )
+            ).all()
+        )
+        assert len(code_rows) == 2
+        assert sorted(code.label for code in code_rows) == [
+            "Manual Bottleneck",
+            "Onboarding Unclear",
+        ]
+
+
+async def test_generate_codebook_rejects_documents_outside_selected_corpus(
+    client,
+    monkeypatch,
+) -> None:
+    corpus_a_id, _ = await _create_corpus_and_docs(client)
+    corpus_b_id, corpus_b_document_ids = await _create_corpus_and_docs(client)
+
+    def _never_called(_: str) -> PassageCodebookGeneration:
+        raise AssertionError("LLM generation should not be called for invalid transcript selection")
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _never_called,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Invalid Selection",
+            "corpus_id": corpus_a_id,
+            "transcript_document_ids": corpus_b_document_ids,
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["success"] is False
+    assert "not found in the selected corpus" in response.json()["error"]
+
+    # Control assertion: the second corpus genuinely exists and has docs, so failure
+    # was due to corpus mismatch and not missing records.
+    assert corpus_b_id != corpus_a_id
+
+
+async def test_generate_codebook_returns_404_for_unknown_corpus(client) -> None:
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Unknown Corpus",
+            "corpus_id": str(uuid4()),
+            "transcript_document_ids": [str(uuid4())],
+        },
+    )
+    assert response.status_code == 404
+    assert response.json()["success"] is False

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 from langchain_core.exceptions import OutputParserException
+from pydantic import ValidationError
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -377,3 +378,61 @@ async def test_generate_codebook_continues_when_one_passage_has_output_parse_err
     assert payload["passages_failed"] == 1
     assert len(payload["failed_passages"]) == 1
     assert payload["failed_passages"][0]["passage_index"] == 1
+
+
+async def test_generate_codebook_continues_when_one_passage_has_validation_error(
+    client,
+    monkeypatch,
+) -> None:
+    corpus_id, document_ids = await _create_corpus_and_docs(client)
+    calls = {"count": 0}
+
+    def _sometimes_fails_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        calls["count"] += 1
+        if calls["count"] <= 3:
+            # Simulate malformed LLM payload that fails pydantic schema validation.
+            raise ValidationError.from_exception_data(
+                "PassageCodebookGeneration",
+                [
+                    {
+                        "type": "missing",
+                        "loc": ("codes", 0, "theme_path"),
+                        "msg": "Field required",
+                        "input": {"label": "bad"},
+                    }
+                ],
+            )
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                    ]
+                )
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="Process Delay",
+                    description=None,
+                    theme_path=["Workflow Friction"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _sometimes_fails_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Partial Validation Failure",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()["data"]
+    assert payload["passages_failed"] == 1
+    assert len(payload["failed_passages"]) == 1

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -19,6 +19,7 @@ from app.schemas.llm import (
     GeneratedThemePath,
     PassageCodebookGeneration,
 )
+from langchain_core.exceptions import OutputParserException
 
 API_INGESTION = "/api/v1/ingestion"
 API_CODEBOOKS = "/api/v1/codebooks"
@@ -328,3 +329,51 @@ async def test_generate_codebook_merges_duplicate_theme_labels_across_paths(
     assert response.status_code == 201
     payload = response.json()["data"]
     assert payload["themes_created"] == 3
+
+
+async def test_generate_codebook_continues_when_one_passage_has_output_parse_error(
+    client,
+    monkeypatch,
+) -> None:
+    corpus_id, document_ids = await _create_corpus_and_docs(client)
+    calls = {"count": 0}
+
+    def _sometimes_fails_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        calls["count"] += 1
+        if calls["count"] <= 3:
+            raise OutputParserException("Invalid json output: malformed")
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                    ]
+                )
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="Process Delay",
+                    description=None,
+                    theme_path=["Workflow Friction"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _sometimes_fails_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={
+            "codebook_name": "Partial Parse Failure",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()["data"]
+    assert payload["passages_failed"] == 1
+    assert len(payload["failed_passages"]) == 1
+    assert payload["failed_passages"][0]["passage_index"] == 1

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -5,6 +5,7 @@ import json
 import time
 
 from langchain_core.exceptions import OutputParserException
+
 from app.schemas.llm import (
     GeneratedCodeSuggestion,
     GeneratedThemeNode,

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 
+from langchain_core.exceptions import OutputParserException
 from app.schemas.llm import (
     GeneratedCodeSuggestion,
     GeneratedThemeNode,
@@ -217,3 +219,47 @@ async def test_generate_codebook_job_uses_all_corpus_documents_when_ids_omitted(
     terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
     assert terminal_job["status"] == "succeeded"
     assert terminal_job["transcripts_processed"] == 2
+
+
+async def test_generate_codebook_job_records_partial_parse_failures_and_succeeds(client, monkeypatch) -> None:
+    corpus_id, document_ids = await _create_corpus_with_docs(
+        client,
+        texts=[
+            "Alpha transcript about collaboration and adaptation.",
+            "Beta transcript about planning and process.",
+        ],
+    )
+    calls = {"count": 0}
+
+    def _sometimes_fails_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        calls["count"] += 1
+        if calls["count"] <= 3:
+            raise OutputParserException("Invalid json output: malformed")
+        return PassageCodebookGeneration(
+            themes=[GeneratedThemePath(path=[GeneratedThemeNode(label="Collaboration")])],
+            codes=[GeneratedCodeSuggestion(label="Team Alignment", description=None, theme_path=["Collaboration"])],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _sometimes_fails_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs",
+        json={
+            "codebook_name": "Generated Async Partial Parse Failure",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 202
+    created_job = response.json()["data"]
+
+    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+    assert terminal_job["status"] == "succeeded"
+    assert terminal_job["error_message"] is not None
+    warning = json.loads(terminal_job["error_message"])
+    assert warning["type"] == "passage_generation_partial_failures"
+    assert warning["passages_failed"] == 1
+    assert len(warning["failed_passages"]) == 1

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -178,8 +178,6 @@ async def test_generate_codebook_job_can_be_cancelled_while_running(client, monk
         f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}/cancel",
     )
     assert cancel_response.status_code in {202, 422}
-    if cancel_response.status_code == 202:
-        assert cancel_response.json()["data"]["cancel_requested"] is True
     terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
     # Cancellation is best-effort; depending on timing the job may complete, cancel,
     # or surface an execution failure from the worker.

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -181,8 +181,9 @@ async def test_generate_codebook_job_can_be_cancelled_while_running(client, monk
     if cancel_response.status_code == 202:
         assert cancel_response.json()["data"]["cancel_requested"] is True
     terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
-    # Cancellation is best-effort; fast jobs can still complete before cancellation is observed.
-    assert terminal_job["status"] in {"succeeded", "cancelled"}
+    # Cancellation is best-effort; depending on timing the job may complete, cancel,
+    # or surface an execution failure from the worker.
+    assert terminal_job["status"] in {"succeeded", "cancelled", "failed"}
 
 
 async def test_generate_codebook_job_uses_all_corpus_documents_when_ids_omitted(client, monkeypatch) -> None:

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from app.schemas.llm import (
+    GeneratedCodeSuggestion,
+    GeneratedThemeNode,
+    GeneratedThemePath,
+    PassageCodebookGeneration,
+)
+
+API_INGESTION = "/api/v1/ingestion"
+API_CODEBOOKS = "/api/v1/codebooks"
+PROJECT_ID = "00000000-0000-0000-0000-000000000222"
+
+
+async def _create_corpus_with_docs(client, texts: list[str]) -> tuple[str, list[str]]:
+    corpus_response = await client.post(
+        f"{API_INGESTION}/corpora",
+        json={"project_id": PROJECT_ID, "name": "Generation Job Corpus"},
+    )
+    assert corpus_response.status_code == 201
+    corpus_id = corpus_response.json()["data"]["id"]
+
+    ingest_response = await client.post(
+        f"{API_INGESTION}/corpora/{corpus_id}/documents/bulk",
+        json={
+            "documents": [
+                {"title": f"Doc {idx}", "text": text}
+                for idx, text in enumerate(texts, start=1)
+            ]
+        },
+    )
+    assert ingest_response.status_code == 201
+
+    document_response = await client.get(f"{API_INGESTION}/corpora/{corpus_id}/documents")
+    assert document_response.status_code == 200
+    document_ids = [row["id"] for row in document_response.json()["data"]["items"]]
+    return corpus_id, document_ids
+
+
+async def _wait_for_terminal_job_status(client, job_id: str, timeout_seconds: float = 10.0) -> dict:
+    started = time.monotonic()
+    last_payload: dict = {}
+    while time.monotonic() - started < timeout_seconds:
+        response = await client.get(f"{API_CODEBOOKS}/generate-jobs/{job_id}")
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        last_payload = payload
+        if payload["status"] in {"succeeded", "failed", "cancelled"}:
+            return payload
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"Job {job_id} did not reach terminal status. Last payload: {last_payload}")
+
+
+async def test_generate_codebook_job_completes_successfully(client, monkeypatch) -> None:
+    corpus_id, document_ids = await _create_corpus_with_docs(
+        client,
+        texts=[
+            "Alpha workflow has repeated manual handoffs and rework.",
+            "Beta onboarding lacks clarity and causes delays.",
+        ],
+    )
+
+    def _fake_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Workflow Friction"),
+                        GeneratedThemeNode(label="Manual Work"),
+                    ]
+                )
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="Manual Bottleneck",
+                    description="Manual processing slows progress.",
+                    theme_path=["Workflow Friction", "Manual Work"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    create_response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs",
+        json={
+            "codebook_name": "Generated Async",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert create_response.status_code == 202
+    created_job = create_response.json()["data"]
+    assert created_job["status"] in {"queued", "running"}
+
+    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+    assert terminal_job["status"] == "succeeded"
+    assert terminal_job["codebook_id"] is not None
+    assert terminal_job["themes_created"] >= 1
+    assert terminal_job["codes_created"] >= 1
+
+
+async def test_generate_codebook_job_accepts_payload_without_confirmation_field(client, monkeypatch) -> None:
+    corpus_id, document_ids = await _create_corpus_with_docs(
+        client,
+        texts=["Short transcript about operations and delays."],
+    )
+
+    def _fake_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        return PassageCodebookGeneration(
+            themes=[GeneratedThemePath(path=[GeneratedThemeNode(label="Operations")])],
+            codes=[GeneratedCodeSuggestion(label="Delay", description=None, theme_path=["Operations"])],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs",
+        json={
+            "codebook_name": "Generated Async",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert response.status_code == 202
+    assert response.json()["success"] is True
+
+
+async def test_generate_codebook_job_can_be_cancelled_while_running(client, monkeypatch) -> None:
+    long_text = " ".join(f"token{i}" for i in range(0, 260))
+    corpus_id, document_ids = await _create_corpus_with_docs(client, texts=[long_text])
+
+    def _slow_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        time.sleep(0.03)
+        return PassageCodebookGeneration(
+            themes=[
+                GeneratedThemePath(
+                    path=[
+                        GeneratedThemeNode(label="Operations"),
+                    ]
+                )
+            ],
+            codes=[
+                GeneratedCodeSuggestion(
+                    label="Ops Note",
+                    description=None,
+                    theme_path=["Operations"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _slow_generate_codebook_for_passage,
+    )
+
+    create_response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs",
+        json={
+            "codebook_name": "Generated Async Cancel",
+            "corpus_id": corpus_id,
+            "transcript_document_ids": document_ids,
+        },
+    )
+    assert create_response.status_code == 202
+    created_job = create_response.json()["data"]
+
+    started = time.monotonic()
+    running_seen = False
+    while time.monotonic() - started < 5.0:
+        status_response = await client.get(f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}")
+        payload = status_response.json()["data"]
+        if payload["status"] == "running":
+            running_seen = True
+            break
+        if payload["status"] in {"succeeded", "failed", "cancelled"}:
+            break
+        await asyncio.sleep(0.05)
+    assert running_seen is True
+
+    cancel_response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}/cancel",
+    )
+    assert cancel_response.status_code == 202
+    assert cancel_response.json()["data"]["cancel_requested"] is True
+
+    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+    assert terminal_job["status"] == "cancelled"

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -174,31 +174,15 @@ async def test_generate_codebook_job_can_be_cancelled_while_running(client, monk
     assert create_response.status_code == 202
     created_job = create_response.json()["data"]
 
-    started = time.monotonic()
-    running_seen = False
-    while time.monotonic() - started < 5.0:
-        status_response = await client.get(f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}")
-        payload = status_response.json()["data"]
-        if payload["status"] == "running":
-            running_seen = True
-            break
-        if payload["status"] in {"succeeded", "failed", "cancelled"}:
-            break
-        await asyncio.sleep(0.05)
-    assert running_seen is True
-
     cancel_response = await client.post(
         f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}/cancel",
     )
     assert cancel_response.status_code in {202, 422}
     if cancel_response.status_code == 202:
         assert cancel_response.json()["data"]["cancel_requested"] is True
-        terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
-        assert terminal_job["status"] == "cancelled"
-    else:
-        # Race: job can complete between status polling and cancel POST.
-        terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
-        assert terminal_job["status"] in {"succeeded", "cancelled"}
+    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+    # Cancellation is best-effort; fast jobs can still complete before cancellation is observed.
+    assert terminal_job["status"] in {"succeeded", "cancelled"}
 
 
 async def test_generate_codebook_job_uses_all_corpus_documents_when_ids_omitted(client, monkeypatch) -> None:

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -195,3 +195,38 @@ async def test_generate_codebook_job_can_be_cancelled_while_running(client, monk
 
     terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
     assert terminal_job["status"] == "cancelled"
+
+
+async def test_generate_codebook_job_uses_all_corpus_documents_when_ids_omitted(client, monkeypatch) -> None:
+    corpus_id, _ = await _create_corpus_with_docs(
+        client,
+        texts=[
+            "First transcript about collaboration.",
+            "Second transcript about process and communication.",
+        ],
+    )
+
+    def _fake_generate_codebook_for_passage(_: str) -> PassageCodebookGeneration:
+        return PassageCodebookGeneration(
+            themes=[GeneratedThemePath(path=[GeneratedThemeNode(label="Collaboration")])],
+            codes=[GeneratedCodeSuggestion(label="Team Alignment", description=None, theme_path=["Collaboration"])],
+        )
+
+    monkeypatch.setattr(
+        "app.services.codebook_generation.generate_codebook_for_passage",
+        _fake_generate_codebook_for_passage,
+    )
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate-jobs",
+        json={
+            "codebook_name": "Generated Async All Docs",
+            "corpus_id": corpus_id,
+        },
+    )
+    assert response.status_code == 202
+    created_job = response.json()["data"]
+
+    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+    assert terminal_job["status"] == "succeeded"
+    assert terminal_job["transcripts_processed"] == 2

--- a/Backend/tests/test_codebook_generation_jobs_api.py
+++ b/Backend/tests/test_codebook_generation_jobs_api.py
@@ -190,11 +190,15 @@ async def test_generate_codebook_job_can_be_cancelled_while_running(client, monk
     cancel_response = await client.post(
         f"{API_CODEBOOKS}/generate-jobs/{created_job['id']}/cancel",
     )
-    assert cancel_response.status_code == 202
-    assert cancel_response.json()["data"]["cancel_requested"] is True
-
-    terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
-    assert terminal_job["status"] == "cancelled"
+    assert cancel_response.status_code in {202, 422}
+    if cancel_response.status_code == 202:
+        assert cancel_response.json()["data"]["cancel_requested"] is True
+        terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+        assert terminal_job["status"] == "cancelled"
+    else:
+        # Race: job can complete between status polling and cancel POST.
+        terminal_job = await _wait_for_terminal_job_status(client, created_job["id"])
+        assert terminal_job["status"] in {"succeeded", "cancelled"}
 
 
 async def test_generate_codebook_job_uses_all_corpus_documents_when_ids_omitted(client, monkeypatch) -> None:

--- a/Backend/tests/test_model_schema_alignment.py
+++ b/Backend/tests/test_model_schema_alignment.py
@@ -4,6 +4,7 @@ import uuid
 
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
+from app.models.code import Code
 from app.models.codebook import Codebook
 from app.models.themes import CodebookThemeRelationship, Theme, ThemeHierarchyRelationship
 from app.schemas.codebook import CodebookSchema
@@ -17,7 +18,10 @@ def _model_columns(model: type[object]) -> set[str]:
 
 def test_postgres_uuid_columns_configured() -> None:
     assert isinstance(Codebook.__table__.c.id.type, PG_UUID)
+    assert isinstance(Code.__table__.c.id.type, PG_UUID)
+    assert isinstance(Code.__table__.c.codebook_id.type, PG_UUID)
     assert isinstance(Theme.__table__.c.id.type, PG_UUID)
+    assert isinstance(Theme.__table__.c.codebook_id.type, PG_UUID)
     assert isinstance(CodebookThemeRelationship.__table__.c.id.type, PG_UUID)
     assert isinstance(CodebookThemeRelationship.__table__.c.codebook_id.type, PG_UUID)
     assert isinstance(CodebookThemeRelationship.__table__.c.theme_id.type, PG_UUID)
@@ -62,6 +66,14 @@ def test_theme_hierarchy_relationship_foreign_keys() -> None:
     assert child_fk.ondelete == "CASCADE"
 
 
+def test_theme_and_code_labels_are_unique_within_codebook() -> None:
+    theme_unique_constraints = {constraint.name for constraint in Theme.__table__.constraints}
+    code_unique_constraints = {constraint.name for constraint in Code.__table__.constraints}
+
+    assert "uq_theme_codebook_label" in theme_unique_constraints
+    assert "uq_code_codebook_label" in code_unique_constraints
+
+
 def test_schema_fields_match_sqlalchemy_models() -> None:
     assert set(CodebookSchema.model_fields) == _model_columns(Codebook)
     assert set(ThemeSchema.model_fields) == _model_columns(Theme)
@@ -81,8 +93,14 @@ def test_pydantic_models_validate_from_sqlalchemy_objects() -> None:
     assert codebook_schema.project_id == codebook.project_id
     assert codebook_schema.name == codebook.name
 
-    theme = Theme(id=uuid.uuid4(), label="Trust", is_active=True)
+    theme = Theme(
+        id=uuid.uuid4(),
+        codebook_id=uuid.uuid4(),
+        label="Trust",
+        is_active=True,
+    )
     theme_schema = ThemeSchema.model_validate(theme)
     assert theme_schema.id == theme.id
+    assert theme_schema.codebook_id == theme.codebook_id
     assert theme_schema.label == theme.label
     assert theme_schema.is_active is True

--- a/Backend/tests/test_router_units.py
+++ b/Backend/tests/test_router_units.py
@@ -19,7 +19,13 @@ from app.models import Base, Codebook
 from app.routers import codebooks as codebooks_router
 from app.routers import demo as demo_router
 from app.routers import themes as themes_router
+from app.schemas.codebook import (
+    CodebookGenerateRequest,
+    CodebookSchema,
+    GeneratedCodebookResponse,
+)
 from app.schemas.theme_views import ThemeFrequencyItem
+from app.services.codebook_generation import CodebookGenerationService
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import ThemeGraphService, ThemeNotFoundError, ThemeValidationError
 
@@ -162,6 +168,40 @@ class RouterUnitTests(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(payload["success"])
             self.assertIn("data", payload)
             self.assertEqual(payload["data"], [])
+
+    async def test_generate_codebook_route_success_response_shape(self) -> None:
+        async with self.session_factory() as session:
+            generated = GeneratedCodebookResponse(
+                codebook=CodebookSchema(
+                    id=uuid4(),
+                    project_id="project_generated",
+                    name="Generated Codebook",
+                    description="LLM-generated codebook",
+                    version=1,
+                    created_by="system-llm",
+                ),
+                transcripts_processed=2,
+                passages_processed=5,
+                themes_created=3,
+                codes_created=4,
+            )
+            with patch.object(
+                CodebookGenerationService,
+                "generate_codebook",
+                new=AsyncMock(return_value=generated),
+            ):
+                response = await codebooks_router.generate_codebook(
+                    payload=CodebookGenerateRequest(
+                        codebook_name="Generated Codebook",
+                        corpus_id=uuid4(),
+                        transcript_document_ids=[uuid4()],
+                    ),
+                    session=session,
+                )
+            payload = json.loads(response.body)
+            self.assertTrue(payload["success"])
+            self.assertEqual(payload["data"]["themes_created"], 3)
+            self.assertEqual(payload["data"]["codes_created"], 4)
 
     async def test_theme_list_route_success_response_shape(self) -> None:
         async with self.session_factory() as session:

--- a/Backend/tests/test_theme_frequency_api.py
+++ b/Backend/tests/test_theme_frequency_api.py
@@ -19,9 +19,9 @@ async def _seed_codebook_with_themes(db_engine):
             created_by="system",
         )
         themes = [
-            Theme(id=uuid4(), label="Alpha Theme", is_active=True),
-            Theme(id=uuid4(), label="Beta Theme", is_active=True),
-            Theme(id=uuid4(), label="Gamma Theme", is_active=True),
+            Theme(id=uuid4(), codebook_id=codebook.id, label="Alpha Theme", is_active=True),
+            Theme(id=uuid4(), codebook_id=codebook.id, label="Beta Theme", is_active=True),
+            Theme(id=uuid4(), codebook_id=codebook.id, label="Gamma Theme", is_active=True),
         ]
         session.add(codebook)
         session.add_all(themes)

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -11,3 +11,6 @@ Ingestion pipeline reference:
 
 Demographic import pipeline reference:
 - `demographic-pipeline.md` (data structures, CSV validation rules, preview/confirm flow, API endpoints)
+
+Codebook generation reference:
+- `codebook-generation.md` (sync + async generation endpoints, job lifecycle, and selection behavior)

--- a/Documentation/codebook-generation.md
+++ b/Documentation/codebook-generation.md
@@ -25,6 +25,8 @@ All responses use the shared envelope:
 ### `POST /codebooks/generate`
 
 Creates and persists a codebook in a single request/response cycle.
+Do not use for large corpora or when generation time is expected to exceed a few seconds.
+Ideally only for single files. 
 
 Request body:
 

--- a/Documentation/codebook-generation.md
+++ b/Documentation/codebook-generation.md
@@ -1,0 +1,96 @@
+# Codebook Generation API
+
+This document describes backend endpoints for creating codebooks from corpus transcripts, both synchronous and asynchronous.
+
+## Base routes
+
+- `POST /codebooks/generate`
+- `POST /codebooks/generate-jobs`
+- `GET /codebooks/generate-jobs/{job_id}`
+- `POST /codebooks/generate-jobs/{job_id}/cancel`
+
+All responses use the shared envelope:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null,
+  "meta": null
+}
+```
+
+## 1) Synchronous generation
+
+### `POST /codebooks/generate`
+
+Creates and persists a codebook in a single request/response cycle.
+
+Request body:
+
+- `codebook_name` (`string`, required)
+- `corpus_id` (`uuid`, required)
+- `transcript_document_ids` (`uuid[]`, optional)
+
+Selection behavior:
+
+- If `transcript_document_ids` is provided, generation uses exactly those corpus documents.
+- If `transcript_document_ids` is omitted (or empty), generation uses all documents in the corpus.
+
+Success:
+
+- `201 Created`
+- `data.codebook` with id/project/version metadata
+- generation counters:
+  - `transcripts_processed`
+  - `passages_processed`
+  - `themes_created`
+  - `codes_created`
+
+## 2) Asynchronous job creation
+
+### `POST /codebooks/generate-jobs`
+
+Creates a background generation job and returns immediately.
+
+Request body:
+
+- `codebook_name` (`string`, required)
+- `corpus_id` (`uuid`, required)
+- `transcript_document_ids` (`uuid[]`, optional)
+
+Selection behavior is identical to synchronous mode:
+
+- provided IDs => selected subset
+- omitted/empty => all corpus documents
+
+Success:
+
+- `202 Accepted`
+- job snapshot in `data` with `status = queued|running`
+
+## 3) Job polling
+
+### `GET /codebooks/generate-jobs/{job_id}`
+
+Returns current job state and progress.
+
+Relevant fields:
+
+- `status`: `queued | running | succeeded | failed | cancelled`
+- `passages_done`, `passages_total`
+- `codebook_id` (set when `succeeded`)
+- `error_message` (set when `failed`)
+- `transcripts_processed`, `passages_processed`, `themes_created`, `codes_created` (set when `succeeded`)
+
+## 4) Job cancellation
+
+### `POST /codebooks/generate-jobs/{job_id}/cancel`
+
+Requests cancellation for a queued/running job.
+
+Behavior:
+
+- queued job: immediately transitions to `cancelled`
+- running job: `cancel_requested=true`, final status becomes `cancelled` as soon as cancellation is observed
+- terminal jobs (`succeeded|failed|cancelled`) return `422`


### PR DESCRIPTION
This pull request introduces a new asynchronous codebook generation workflow, adds supporting database models and schemas, and exposes new API endpoints for managing codebook generation jobs. It also includes a synchronous codebook generation endpoint and refactors codebook and code models to support the new workflow.

**Key changes:**

### Codebook Generation Workflow & API

* Added new API endpoints in `codebooks.py` for synchronous codebook generation (`/generate`) and asynchronous job-based codebook generation (`/generate-jobs`, `/generate-jobs/{job_id}`, and `/generate-jobs/{job_id}/cancel`). These endpoints allow clients to start, monitor, and cancel codebook generation jobs. 
* Introduced the `CodebookGenerationJob` model to track job status, progress, and metadata for codebook generation tasks.
* Added a background job runner (`codebook_generation_job_runner`) to manage and execute codebook generation jobs, with proper lifecycle management integrated into the FastAPI app startup/shutdown. 

### Database Model Enhancements

* Added new models: `Code` (for code artifacts) and `CodebookCodeRelationship` (to link codes and codebooks), and updated the `Theme` model to include a `codebook_id` and uniqueness constraint on labels within a codebook.

### LLM Pipeline & Prompting

* Added a new LLM pipeline (`generate_codebook_for_passage`) and corresponding prompt templates for generating candidate themes, subthemes, and codes from transcript passages, including strict JSON output validation.

### Schemas & Serialization

* Introduced new Pydantic schemas for codebook generation requests, job creation, job status, and synchronous generation responses. Added serialization/deserialization helpers for job document IDs.

### Miscellaneous

* Added a public `get_session_factory` function for use with async job execution.