### PR TITLE
feat: add frontend workflows to setup and teardown scripts

### DIFF
--- a/scripts/lib/env.sh
+++ b/scripts/lib/env.sh
@@ -7,16 +7,26 @@ ensure_env_file() {
   local env_example="$SCRIPT_DIR/Backend/.env.example"
 
   if [[ -f "$env_file" ]]; then
-    log_info ".env already exists — skipping copy"
-    return 0
+    log_info "Backend/.env already exists — skipping copy"
+  else
+    [[ -f "$env_example" ]] \
+      || die "Template $env_example not found. Is the repository fully checked out?"
+    cp "$env_example" "$env_file"
+    log_success "Created Backend/.env from Backend/.env.example"
+    log_warn  "Set LLM_API_KEY in Backend/.env before using LLM-dependent features"
   fi
 
-  [[ -f "$env_example" ]] \
-    || die "Template $env_example not found. Is the repository fully checked out?"
+  local fe_env_file="$SCRIPT_DIR/Frontend/.env"
+  local fe_env_example="$SCRIPT_DIR/Frontend/.env.example"
 
-  cp "$env_example" "$env_file"
-  log_success "Created Backend/.env from Backend/.env.example"
-  log_warn  "Set LLM_API_KEY in Backend/.env before using LLM-dependent features"
+  if [[ -f "$fe_env_file" ]]; then
+    log_info "Frontend/.env already exists — skipping copy"
+  elif [[ -f "$fe_env_example" ]]; then
+    cp "$fe_env_example" "$fe_env_file"
+    log_success "Created Frontend/.env from Frontend/.env.example"
+  else
+    log_warn "Frontend/.env.example not found — skipping frontend env setup"
+  fi
 }
 
 scan_env_placeholders() {

--- a/setup-ps51.ps1
+++ b/setup-ps51.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  One-command bootstrap for the Automated Thematic Analysis stack (Windows).
+  One-command bootstrap for the Automated Thematic Analysis stack (Windows, PS 5.1).
 
 .DESCRIPTION
   Verifies prerequisites (Docker, Docker Compose v2), creates Backend\.env and
@@ -9,6 +9,7 @@
   the full stack (API + frontend), and polls both health endpoints until ready.
 
   Run this script from the repository root in PowerShell or Windows Terminal.
+  Compatible with Windows PowerShell 5.1 and PowerShell 7+.
 
 .PARAMETER Test
   Run the pytest test suite inside Docker.
@@ -35,12 +36,12 @@
   Skip all confirmation prompts (use with -DownVolumes).
 
 .EXAMPLE
-  .\setup.ps1
-  .\setup.ps1 -Test
-  .\setup.ps1 -Lint
-  .\setup.ps1 -Down
-  .\setup.ps1 -DownVolumes -Yes
-  .\setup.ps1 -Foreground
+  .\setup-ps51.ps1
+  .\setup-ps51.ps1 -Test
+  .\setup-ps51.ps1 -Lint
+  .\setup-ps51.ps1 -Down
+  .\setup-ps51.ps1 -DownVolumes -Yes
+  .\setup-ps51.ps1 -Foreground
 #>
 [CmdletBinding()]
 param(
@@ -59,19 +60,23 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$ScriptDir     = $PSScriptRoot
-$ComposeDir    = $ScriptDir
-$AppPort       = if ($env:APP_PORT)      { $env:APP_PORT }      else { '8000' }
-$FrontendPort  = if ($env:FRONTEND_PORT) { $env:FRONTEND_PORT } else { '3000' }
-$EnvFile       = Join-Path $ScriptDir 'Backend'  '.env'
-$EnvExample    = Join-Path $ScriptDir 'Backend'  '.env.example'
-$FeEnvFile     = Join-Path $ScriptDir 'Frontend' '.env'
-$FeEnvExample  = Join-Path $ScriptDir 'Frontend' '.env.example'
+$ScriptDir    = $PSScriptRoot
+$ComposeDir   = $ScriptDir
+$AppPort      = if ($env:APP_PORT)      { $env:APP_PORT }      else { '8000' }
+$FrontendPort = if ($env:FRONTEND_PORT) { $env:FRONTEND_PORT } else { '3000' }
+
+# Join-Path with 3 args requires PS 6+; nest calls for PS 5.1 compatibility.
+$BackendDir   = Join-Path $ScriptDir 'Backend'
+$FrontendDir  = Join-Path $ScriptDir 'Frontend'
+$EnvFile      = Join-Path $BackendDir  '.env'
+$EnvExample   = Join-Path $BackendDir  '.env.example'
+$FeEnvFile    = Join-Path $FrontendDir '.env'
+$FeEnvExample = Join-Path $FrontendDir '.env.example'
 
 # == Logging helpers ===========================================================
 function Write-Info    { param([string]$Msg) Write-Host "[INFO]  $Msg" -ForegroundColor Cyan }
 function Write-Ok      { param([string]$Msg) Write-Host "[OK]    $Msg" -ForegroundColor Green }
-function Write-Warning { param([string]$Msg) Write-Host "[WARN]  $Msg" -ForegroundColor Yellow }
+function Write-Warn    { param([string]$Msg) Write-Host "[WARN]  $Msg" -ForegroundColor Yellow }
 function Write-Err     { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red }
 
 function Exit-WithError {
@@ -113,8 +118,8 @@ function Ensure-EnvFile {
       Exit-WithError "Template $EnvExample not found. Is the repository fully checked out?"
     }
     Copy-Item $EnvExample $EnvFile
-    Write-Ok      "Created Backend\.env from Backend\.env.example"
-    Write-Warning "Set LLM_API_KEY in Backend\.env before using LLM-dependent features"
+    Write-Ok   "Created Backend\.env from Backend\.env.example"
+    Write-Warn "Set LLM_API_KEY in Backend\.env before using LLM-dependent features"
   }
 
   if (Test-Path $FeEnvFile) {
@@ -125,7 +130,7 @@ function Ensure-EnvFile {
     Write-Ok "Created Frontend\.env from Frontend\.env.example"
   }
   else {
-    Write-Warning "Frontend\.env.example not found - skipping frontend env setup"
+    Write-Warn "Frontend\.env.example not found - skipping frontend env setup"
   }
 }
 
@@ -133,8 +138,8 @@ function Test-EnvPlaceholders {
   if (Test-Path $EnvFile) {
     $content = Get-Content $EnvFile -Raw
     if ($content -match '<your_api_key_here>') {
-      Write-Warning "LLM_API_KEY is still the placeholder value in Backend\.env"
-      Write-Warning "LLM-dependent endpoints will return errors until a real key is set"
+      Write-Warn "LLM_API_KEY is still the placeholder value in Backend\.env"
+      Write-Warn "LLM-dependent endpoints will return errors until a real key is set"
     }
   }
 }
@@ -156,7 +161,7 @@ function Wait-ForHttp {
       if ($response.StatusCode -eq 200) { return $true }
     }
     catch {
-      # Connection refused or non-200 - keep waiting
+      # Connection refused or non-200 — keep waiting
     }
 
     Start-Sleep -Seconds $interval
@@ -167,7 +172,7 @@ function Wait-ForHttp {
 }
 
 # == Compose wrapper ===========================================================
-# NOTE: $Args is a PowerShell automatic variable - do NOT use it as a param name.
+# NOTE: $Args is a PowerShell automatic variable — do NOT use it as a param name.
 function Invoke-Compose {
   param([string[]]$ComposeArgs)
   Push-Location $ComposeDir
@@ -237,11 +242,8 @@ function Invoke-Test {
 function Invoke-Lint {
   Write-Info "Running lint checks inside Docker..."
 
-  $ruffArgs = @('--profile', 'test', 'run', '--rm', 'api-test', 'ruff', 'check', 'app', 'tests')
-  Invoke-Compose $ruffArgs
-
-  $mypyArgs = @('--profile', 'test', 'run', '--rm', 'api-test', 'mypy', 'app')
-  Invoke-Compose $mypyArgs
+  Invoke-Compose @('--profile', 'test', 'run', '--rm', 'api-test', 'ruff', 'check', 'app', 'tests')
+  Invoke-Compose @('--profile', 'test', 'run', '--rm', 'api-test', 'mypy', 'app')
 
   Write-Ok "Lint checks complete."
 }
@@ -250,18 +252,18 @@ function Invoke-Lint {
 function Invoke-Up {
   Write-Info "Starting the stack..."
 
-  $upFlags = @()
-  if (-not $Foreground) { $upFlags += '-d' }
-  if ($Rebuild)         { $upFlags += '--build'; $upFlags += '--no-cache' }
-  elseif (-not $NoBuild){ $upFlags += '--build' }
+  $upFlags = [System.Collections.ArrayList]@()
+  if (-not $Foreground) { $null = $upFlags.Add('-d') }
+  if ($Rebuild)         { $null = $upFlags.Add('--build'); $null = $upFlags.Add('--no-cache') }
+  elseif (-not $NoBuild){ $null = $upFlags.Add('--build') }
 
   if (-not $NoBuild) {
     Write-Info "Building images - first run can take 3-5 minutes..."
   }
 
-  Invoke-Compose (@('up') + $upFlags)
+  Invoke-Compose ([string[]](@('up') + $upFlags))
 
-  # In foreground mode, Compose streams until Ctrl+C - nothing more to do.
+  # In foreground mode, Compose streams until Ctrl+C — nothing more to do.
   if ($Foreground) { return }
 
   Write-Info "Waiting for API to become ready (up to 60s)..."
@@ -298,9 +300,9 @@ function Invoke-Up {
     Write-Host ""
     Write-Host "Next steps:"
     Write-Host "  Tail logs    docker compose logs -f frontend api"
-    Write-Host "  Run tests    .\setup.ps1 -Test"
-    Write-Host "  Run lint     .\setup.ps1 -Lint"
-    Write-Host "  Stop stack   .\setup.ps1 -Down"
+    Write-Host "  Run tests    .\setup-ps51.ps1 -Test"
+    Write-Host "  Run lint     .\setup-ps51.ps1 -Lint"
+    Write-Host "  Stop stack   .\setup-ps51.ps1 -Down"
     Write-Host ""
   }
   else {
@@ -346,4 +348,3 @@ elseif ($Test) {
 else {
   Invoke-Up
 }
-

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,9 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-COMPOSE_DIR="$SCRIPT_DIR/Backend"
+COMPOSE_DIR="$SCRIPT_DIR"
 APP_PORT="${APP_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 
 # shellcheck source=scripts/lib/common.sh
 source "$SCRIPT_DIR/scripts/lib/common.sh"
@@ -43,6 +44,7 @@ OPTIONS
 
 ENVIRONMENT
   APP_PORT             Override the API host port (default: 8000)
+  FRONTEND_PORT        Override the frontend host port (default: 3000)
 
 EXAMPLES
   ./setup.sh                       Build and start the full stack
@@ -81,7 +83,7 @@ done
 
 # ── Compose wrapper ───────────────────────────────────────────────────────────
 # All mode functions run after `cd "$COMPOSE_DIR"`, so docker compose
-# picks up docker-compose.yml from Backend/ automatically.
+# picks up docker-compose.yml from the repository root automatically.
 run_compose() {
   docker compose "$@"
 }
@@ -111,18 +113,23 @@ mode_test() {
   log_info "Running test suite inside Docker..."
 
   if $REBUILD; then
-    log_info "Rebuilding api-test image with --no-cache..."
-    run_compose --profile test build --no-cache api-test
+    log_info "Rebuilding test images with --no-cache..."
+    run_compose --profile test build --no-cache api-test frontend-test
   elif $BUILD; then
-    log_info "Ensuring api-test image is up to date..."
-    run_compose --profile test build api-test
+    log_info "Ensuring test images are up to date..."
+    run_compose --profile test build api-test frontend-test
   fi
 
-  local pytest_cmd=(pytest --cov=app --cov-report=term-missing --cov-report=html)
-  (( ${#EXTRA_ARGS[@]} > 0 )) && pytest_cmd+=("${EXTRA_ARGS[@]}")
+  local api_pytest_cmd=(pytest --cov=app --cov-report=term-missing --cov-report=html)
+  (( ${#EXTRA_ARGS[@]} > 0 )) && api_pytest_cmd+=("${EXTRA_ARGS[@]}")
 
-  run_compose --profile test run --rm api-test "${pytest_cmd[@]}"
-  log_success "Tests complete. Open Backend/htmlcov/index.html for the coverage report."
+  log_info "Running backend tests..."
+  run_compose --profile test run --rm api-test "${api_pytest_cmd[@]}"
+  log_success "Backend tests complete. Open Backend/htmlcov/index.html for the coverage report."
+
+  log_info "Running frontend tests..."
+  run_compose --profile test run --rm frontend-test pytest
+  log_success "Frontend tests complete."
 }
 
 # ── Mode: lint ────────────────────────────────────────────────────────────────
@@ -157,12 +164,9 @@ mode_up() {
   $DETACH || return 0
 
   log_info "Waiting for API to become ready (up to 60s)..."
-  local health_url="http://localhost:${APP_PORT}/api/v1/health/ready"
+  local api_health_url="http://localhost:${APP_PORT}/api/v1/health/ready"
 
-  if wait_for_http "$health_url" 60; then
-    print_success_banner
-  else
-    # Diagnose: distinguish exited container vs slow startup
+  if ! wait_for_http "$api_health_url" 60; then
     local running
     running=$(run_compose ps --status running --quiet api 2>/dev/null || true)
     if [[ -z "$running" ]]; then
@@ -170,7 +174,24 @@ mode_up() {
     else
       log_error "API container is running but health check timed out (60s)."
     fi
-    log_error "Inspect logs with: docker compose logs api  (run from the Backend/ directory)"
+    log_error "Inspect logs with: docker compose logs api"
+    exit 1
+  fi
+
+  log_info "Waiting for frontend to become ready (up to 60s)..."
+  local fe_health_url="http://localhost:${FRONTEND_PORT}/health"
+
+  if wait_for_http "$fe_health_url" 60; then
+    print_success_banner
+  else
+    local fe_running
+    fe_running=$(run_compose ps --status running --quiet frontend 2>/dev/null || true)
+    if [[ -z "$fe_running" ]]; then
+      log_error "The 'frontend' container exited unexpectedly."
+    else
+      log_error "Frontend container is running but health check timed out (60s)."
+    fi
+    log_error "Inspect logs with: docker compose logs frontend"
     exit 1
   fi
 }
@@ -181,12 +202,13 @@ print_success_banner() {
   printf "${GREEN}${BOLD}║        Stack is up and healthy!              ║${RESET}\n"
   printf "${GREEN}${BOLD}╚══════════════════════════════════════════════╝${RESET}\n"
   printf "\n"
+  printf "  Frontend UI  ${BOLD}http://localhost:${FRONTEND_PORT}${RESET}\n"
   printf "  API server   ${BOLD}http://localhost:${APP_PORT}${RESET}\n"
   printf "  API docs     ${BOLD}http://localhost:${APP_PORT}/docs${RESET}\n"
   printf "  Postgres     ${BOLD}localhost:5433${RESET}\n"
   printf "\n"
   printf "Next steps:\n"
-  printf "  Tail logs    ${BOLD}docker compose logs -f api${RESET}   (from Backend/ directory)\n"
+  printf "  Tail logs    ${BOLD}docker compose logs -f frontend api${RESET}\n"
   printf "  Run tests    ${BOLD}./setup.sh --test${RESET}\n"
   printf "  Run lint     ${BOLD}./setup.sh --lint${RESET}\n"
   printf "  Stop stack   ${BOLD}./setup.sh --down${RESET}\n"

--- a/teardown.ps1
+++ b/teardown.ps1
@@ -1,0 +1,5 @@
+#Requires -Version 5.1
+# Convenience wrapper — equivalent to: .\setup-ps51.ps1 -Down
+# Pass -Yes to also skip the confirmation prompt.
+# Pass -DownVolumes to remove data volumes as well.
+& "$PSScriptRoot\setup-ps51.ps1" -Down @args


### PR DESCRIPTION
- Switch compose file from Backend/docker-compose.yml to root docker-compose.yml so the frontend service is included in all modes
- Add FRONTEND_PORT env var (default 3000) to setup.sh and setup-ps51.ps1
- Bootstrap Frontend/.env from Frontend/.env.example alongside Backend/.env
- Add frontend health check (GET /health) after API health check in mode_up
- Update success banner to show Frontend UI URL and combined log command
- Extend --test mode to build and run frontend-test alongside api-test
- Add setup-ps51.ps1: PS 5.1 compatible version (nested Join-Path calls)
- Add teardown.ps1: Windows equivalent of teardown.sh