### PR TITLE
92 demographic data upload fix

### DIFF
--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from sqlalchemy import and_, desc, exists, or_, select
+from sqlalchemy import desc, exists, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.dependencies import DbSession
@@ -76,10 +76,12 @@ async def get_codebooks(
     if corpus_id is None:
         stmt = select(Codebook).order_by(Codebook.project_id.asc(), desc(Codebook.version))
     else:
-        corpus = (
-            await session.execute(select(Corpus).where(Corpus.id == corpus_id))
-        ).scalar_one_or_none()
-        if corpus is None:
+        corpus_exists = (
+            await session.execute(
+                select(exists().where(Corpus.id == corpus_id))
+            )
+        ).scalar_one()
+        if not corpus_exists:
             return JSONResponse(content=ResponseEnvelope.ok([]).model_dump(mode="json"))
 
         generated_for_selected_corpus = exists(
@@ -90,18 +92,9 @@ async def get_codebooks(
                 CodebookGenerationJob.status == "succeeded",
             )
         )
-        has_any_generation_job = exists(
-            select(CodebookGenerationJob.id).where(
-                CodebookGenerationJob.codebook_id == Codebook.id
-            )
-        )
-        legacy_project_scoped = and_(
-            Codebook.project_id == str(corpus.project_id),
-            ~has_any_generation_job,
-        )
         stmt = (
             select(Codebook)
-            .where(or_(generated_for_selected_corpus, legacy_project_scoped))
+            .where(generated_for_selected_corpus)
             .order_by(Codebook.project_id.asc(), desc(Codebook.version))
         )
     codebooks = list((await session.scalars(stmt)).all())

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -6,12 +6,12 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from sqlalchemy import desc, select
+from sqlalchemy import and_, desc, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.dependencies import DbSession
 from app.exceptions import NotFoundError, UnprocessableError
-from app.models import Codebook, CodebookGenerationJob
+from app.models import Codebook, CodebookGenerationJob, Corpus
 from app.schemas.codebook import (
     CodebookGenerateRequest,
     CodebookGenerationJobCreateRequest,
@@ -68,11 +68,42 @@ def _to_job_schema(job: CodebookGenerationJob) -> CodebookGenerationJobSchema:
 )
 async def get_codebooks(
     session: DbSession,
+    corpus_id: UUID | None = None,
 ) -> JSONResponse:
     # TODO: Completely refactor / replace this endpoint. This is just a quick implementation to get some working data
     #  for the frontend.
     # The user needs to be able to select a project_id in the frontend in order to load a themes tree
-    stmt = select(Codebook).order_by(Codebook.project_id.asc(), desc(Codebook.version))
+    if corpus_id is None:
+        stmt = select(Codebook).order_by(Codebook.project_id.asc(), desc(Codebook.version))
+    else:
+        corpus = (
+            await session.execute(select(Corpus).where(Corpus.id == corpus_id))
+        ).scalar_one_or_none()
+        if corpus is None:
+            return JSONResponse(content=ResponseEnvelope.ok([]).model_dump(mode="json"))
+
+        generated_for_selected_corpus = exists(
+            select(CodebookGenerationJob.id).where(
+                CodebookGenerationJob.codebook_id == Codebook.id,
+                CodebookGenerationJob.corpus_id == corpus_id,
+                CodebookGenerationJob.codebook_id.is_not(None),
+                CodebookGenerationJob.status == "succeeded",
+            )
+        )
+        has_any_generation_job = exists(
+            select(CodebookGenerationJob.id).where(
+                CodebookGenerationJob.codebook_id == Codebook.id
+            )
+        )
+        legacy_project_scoped = and_(
+            Codebook.project_id == str(corpus.project_id),
+            ~has_any_generation_job,
+        )
+        stmt = (
+            select(Codebook)
+            .where(or_(generated_for_selected_corpus, legacy_project_scoped))
+            .order_by(Codebook.project_id.asc(), desc(Codebook.version))
+        )
     codebooks = list((await session.scalars(stmt)).all())
     payload = [CodebookSchema.model_validate(codebook) for codebook in codebooks]
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))

--- a/Backend/app/services/demographic.py
+++ b/Backend/app/services/demographic.py
@@ -205,7 +205,8 @@ class DemographicService:
         )
         if existing:
             raise UnprocessableError(
-                f"username already exists: '{sorted(existing)[0]}'"
+                f"username already exists: '{sorted(existing)[0]}'. "
+                "This usually means the same demographic data was already uploaded for this corpus."
             )
 
     async def list_files(

--- a/Backend/app/services/demographic.py
+++ b/Backend/app/services/demographic.py
@@ -123,10 +123,26 @@ class DemographicService:
         except UnicodeDecodeError as exc:
             raise UnprocessableError(f"Could not decode '{filename}' as UTF-8") from exc
 
+    @staticmethod
+    def _detect_csv_delimiter(csv_text: str) -> str:
+        sample = csv_text[:4096]
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=";,")
+            if dialect.delimiter in {";", ","}:
+                return dialect.delimiter
+        except csv.Error:
+            pass
+
+        header = csv_text.splitlines()[0] if csv_text.splitlines() else ""
+        semicolons = header.count(";")
+        commas = header.count(",")
+        return "," if commas > semicolons else ";"
+
     def _parse_demographic_csv(self, filename: str, content: bytes) -> ParsedDemographicCsv:
         csv_text = self._decode_csv_bytes(filename, content)
         text_stream = io.StringIO(csv_text)
-        reader = csv.DictReader(text_stream, delimiter=';', restkey="__extra__")
+        delimiter = self._detect_csv_delimiter(csv_text)
+        reader = csv.DictReader(text_stream, delimiter=delimiter, restkey="__extra__")
         rows = list(reader)
         fieldnames = list(reader.fieldnames or [])
 

--- a/Backend/tests/test_demographic_api.py
+++ b/Backend/tests/test_demographic_api.py
@@ -158,14 +158,13 @@ async def test_demographic_upload_rejects_non_csv_extension_even_with_csv_mime_v
     assert "Unsupported file extension" in bad_response.json()["meta"]["detail"]
 
 
-async def test_demographic_upload_rejects_comma_delimited_csv(client):
+async def test_demographic_upload_accepts_comma_delimited_csv(client):
     corpus_id = await _create_corpus(client, "Corpus Delimiter")
     content = "username,segment\nuser_e,A\n"
 
     response = await _upload_csv(client, corpus_id, "demo.csv", content, content_type="text/csv")
-    assert response.status_code == 422
-    assert response.json()["success"] is False
-    assert "must include 'username' column" in response.json()["meta"]["detail"]
+    assert response.status_code == 201
+    assert response.json()["success"] is True
 
 
 async def test_demographic_upload_rejects_duplicate_username(client):

--- a/Backend/tests/test_router_units.py
+++ b/Backend/tests/test_router_units.py
@@ -15,7 +15,7 @@ from sqlalchemy.pool import StaticPool
 from starlette.requests import Request
 
 from app.exceptions import NotFoundError, UnprocessableError
-from app.models import Base, Codebook
+from app.models import Base, Codebook, CodebookGenerationJob, Corpus
 from app.routers import codebooks as codebooks_router
 from app.routers import demo as demo_router
 from app.routers import themes as themes_router
@@ -110,6 +110,84 @@ class RouterUnitTests(unittest.IsolatedAsyncioTestCase):
                 ordered_pairs,
                 [("project_a", 2), ("project_a", 1), ("project_b", 1)],
             )
+
+    async def test_codebooks_route_can_filter_by_corpus_with_legacy_fallback(self) -> None:
+        async with self.session_factory() as session:
+            corpus_a = Corpus(id=uuid4(), project_id=uuid4(), name="Corpus A")
+            corpus_b = Corpus(id=uuid4(), project_id=uuid4(), name="Corpus B")
+            session.add_all([corpus_a, corpus_b])
+            await session.flush()
+
+            legacy_a = Codebook(
+                id=uuid4(),
+                project_id=str(corpus_a.project_id),
+                name="Legacy A",
+                description="desc",
+                version=1,
+                created_by="system",
+            )
+            generated_a = Codebook(
+                id=uuid4(),
+                project_id=str(corpus_a.project_id),
+                name="Generated A",
+                description="desc",
+                version=2,
+                created_by="system",
+            )
+            generated_b = Codebook(
+                id=uuid4(),
+                project_id=str(corpus_b.project_id),
+                name="Generated B",
+                description="desc",
+                version=1,
+                created_by="system",
+            )
+            legacy_b = Codebook(
+                id=uuid4(),
+                project_id=str(corpus_b.project_id),
+                name="Legacy B",
+                description="desc",
+                version=3,
+                created_by="system",
+            )
+            session.add_all([legacy_a, generated_a, generated_b, legacy_b])
+            await session.flush()
+
+            session.add_all(
+                [
+                    CodebookGenerationJob(
+                        id=uuid4(),
+                        status="succeeded",
+                        codebook_name=generated_a.name,
+                        corpus_id=corpus_a.id,
+                        transcript_document_ids_json="[]",
+                        cancel_requested=False,
+                        codebook_id=generated_a.id,
+                        passages_total=1,
+                        passages_done=1,
+                    ),
+                    CodebookGenerationJob(
+                        id=uuid4(),
+                        status="succeeded",
+                        codebook_name=generated_b.name,
+                        corpus_id=corpus_b.id,
+                        transcript_document_ids_json="[]",
+                        cancel_requested=False,
+                        codebook_id=generated_b.id,
+                        passages_total=1,
+                        passages_done=1,
+                    ),
+                ]
+            )
+            await session.commit()
+
+            response = await codebooks_router.get_codebooks(
+                session=session,
+                corpus_id=corpus_a.id,
+            )
+            payload = json.loads(response.body)
+            names = sorted(row["name"] for row in payload["data"])
+            self.assertEqual(names, ["Generated A", "Legacy A"])
 
     async def test_themes_route_maps_not_found_error(self) -> None:
         async with self.session_factory() as session:

--- a/Backend/tests/test_router_units.py
+++ b/Backend/tests/test_router_units.py
@@ -111,7 +111,7 @@ class RouterUnitTests(unittest.IsolatedAsyncioTestCase):
                 [("project_a", 2), ("project_a", 1), ("project_b", 1)],
             )
 
-    async def test_codebooks_route_can_filter_by_corpus_with_legacy_fallback(self) -> None:
+    async def test_codebooks_route_can_filter_by_corpus_id_only(self) -> None:
         async with self.session_factory() as session:
             corpus_a = Corpus(id=uuid4(), project_id=uuid4(), name="Corpus A")
             corpus_b = Corpus(id=uuid4(), project_id=uuid4(), name="Corpus B")
@@ -187,7 +187,7 @@ class RouterUnitTests(unittest.IsolatedAsyncioTestCase):
             )
             payload = json.loads(response.body)
             names = sorted(row["name"] for row in payload["data"])
-            self.assertEqual(names, ["Generated A", "Legacy A"])
+            self.assertEqual(names, ["Generated A"])
 
     async def test_themes_route_maps_not_found_error(self) -> None:
         async with self.session_factory() as session:

--- a/Documentation/demographic-pipeline.md
+++ b/Documentation/demographic-pipeline.md
@@ -41,7 +41,7 @@ Pending uploads expire based on `DEMOGRAPHIC_UPLOAD_TTL_SECONDS`.
 
 - Supported extension: `.csv`
 - UTF-8 (including UTF-8 BOM) is required
-- Standard comma-separated CSV format is required
+- Delimiter can be comma (`,`) or semicolon (`;`)
 - Header row is required
 - Header must contain a `username` column
 - At least one demographic column in addition to `username` is required

--- a/Documentation/sample-data/demographic_comma.csv
+++ b/Documentation/sample-data/demographic_comma.csv
@@ -1,0 +1,4 @@
+username,age,gender,department
+user_delta,26,female,marketing
+user_epsilon,38,male,product
+user_zeta,31,non-binary,operations

--- a/Documentation/sample-data/demographic_semicolon.csv
+++ b/Documentation/sample-data/demographic_semicolon.csv
@@ -1,0 +1,4 @@
+username;age;gender;department
+user_alpha;29;female;engineering
+user_beta;34;male;design
+user_gamma;41;non-binary;research

--- a/Documentation/sample-data/transcripts_for_demographic_comma.jsonl
+++ b/Documentation/sample-data/transcripts_for_demographic_comma.jsonl
@@ -1,0 +1,6 @@
+{"username":"user_delta","event_type":"human_response","message_index":1,"message_content":"I am user delta in marketing. I analyze campaign performance and audience segments."}
+{"username":"user_delta","event_type":"human_response","message_index":2,"message_content":"We are testing new messaging themes for regional outreach."}
+{"username":"user_epsilon","event_type":"human_response","message_index":1,"message_content":"I am user epsilon from product. I coordinate roadmap priorities across teams."}
+{"username":"user_epsilon","event_type":"human_response","message_index":2,"message_content":"We are preparing a release focused on workflow clarity and reporting."}
+{"username":"user_zeta","event_type":"human_response","message_index":1,"message_content":"I am user zeta in operations. I manage support escalations and process changes."}
+{"username":"user_zeta","event_type":"human_response","message_index":2,"message_content":"We are tracking cycle time and reducing incident response delays."}

--- a/Documentation/sample-data/transcripts_for_demographic_semicolon.jsonl
+++ b/Documentation/sample-data/transcripts_for_demographic_semicolon.jsonl
@@ -1,0 +1,6 @@
+{"username":"user_alpha","event_type":"human_response","message_index":1,"message_content":"I am user alpha and I work in engineering. I collaborate closely with design and research."}
+{"username":"user_alpha","event_type":"human_response","message_index":2,"message_content":"My current focus is improving onboarding and reducing operational overhead."}
+{"username":"user_beta","event_type":"human_response","message_index":1,"message_content":"I am user beta from the design team. I lead interface prototyping."}
+{"username":"user_beta","event_type":"human_response","message_index":2,"message_content":"Our biggest challenge is aligning design handoff with engineering timelines."}
+{"username":"user_gamma","event_type":"human_response","message_index":1,"message_content":"I am user gamma and part of research. I run interview studies with participants."}
+{"username":"user_gamma","event_type":"human_response","message_index":2,"message_content":"We synthesize findings and share them with product and engineering weekly."}

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -33,6 +33,10 @@ class FakeBackend:
 
     def __init__(self) -> None:
         self.corpus_id = "test-corpus-id"
+        self.corpora: list[dict] = [
+            {"id": self.corpus_id, "name": "Default Corpus"},
+        ]
+        self.last_created_corpus: dict | None = None
         self.documents: list[dict] = []
         self.upload_results: list[dict] = []
         self.uploaded_files: list[str] = []
@@ -57,7 +61,21 @@ class FakeBackend:
 
     def ensure_corpus(self, project_id: str, name: str) -> str:
         self._maybe_raise("ensure_corpus")
+        if not any(c.get("id") == self.corpus_id for c in self.corpora):
+            self.corpora.append({"id": self.corpus_id, "name": name})
         return self.corpus_id
+
+    def list_corpora(self, project_id: str) -> list[dict]:
+        self._maybe_raise("list_corpora")
+        return self.corpora
+
+    def create_corpus(self, project_id: str, name: str) -> dict:
+        self._maybe_raise("create_corpus")
+        new_id = f"new-corpus-{len(self.corpora) + 1}"
+        created = {"id": new_id, "name": name}
+        self.corpora.append(created)
+        self.last_created_corpus = created
+        return created
 
     def upload_files(self, corpus_id, files) -> list[dict]:
         self._maybe_raise("upload_files")
@@ -70,9 +88,16 @@ class FakeBackend:
 
     # ---- Codebooks / themes -------------------------------------------------
 
-    def list_codebooks(self) -> list[dict]:
+    def list_codebooks(self, corpus_id: str | None = None) -> list[dict]:
         self._maybe_raise("list_codebooks")
-        return self.codebooks
+        if not corpus_id:
+            return self.codebooks
+        scoped = []
+        for cb in self.codebooks:
+            cb_corpus = cb.get("corpus_id")
+            if cb_corpus is None or cb_corpus == corpus_id:
+                scoped.append(cb)
+        return scoped
 
     def get_theme_frequencies(self, codebook_id: str) -> list[dict]:
         self._maybe_raise("get_theme_frequencies")

--- a/Frontend/tests/test_backend_client.py
+++ b/Frontend/tests/test_backend_client.py
@@ -85,6 +85,23 @@ def test_status_422_parses_fastapi_validation_detail():
     assert "themes: must contain at least 1 item" in msg
 
 
+def test_status_422_parses_response_envelope_meta_detail():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={
+                "success": False,
+                "error": "UnprocessableError",
+                "meta": {"detail": "username already exists: 'user_a'"},
+            },
+        )
+
+    client = _client_with_handler(handler)
+    with pytest.raises(BackendValidationError) as exc_info:
+        client.list_codebooks()
+    assert "username already exists" in exc_info.value.user_message
+
+
 def test_status_500_maps_to_server_error():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"detail": "boom"})

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -73,11 +73,24 @@ def test_codebook_list_shows_unavailable_message_when_backend_down(client, fake_
     assert b"No codebooks found" not in resp.data
 
 
+def test_codebook_list_shows_error_when_requested_corpus_missing(client, fake_backend):
+    fake_backend.corpora = [{"id": "existing-corpus", "name": "Existing Corpus"}]
+    resp = client.get("/codebooks/missing-corpus/", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"selected corpus couldn" in resp.data
+    assert b"No codebooks found" not in resp.data
+
+
 # GET /codebooks/<id>/themes
 
 
 
 def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
     fake_backend.theme_frequencies = [
         {"theme_id": "t-1", "theme_name": "Work-Life Balance",
          "occurrence_count": 5, "interview_coverage_percentage": 60.0},
@@ -93,6 +106,11 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
 
 
 def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 3,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
     fake_backend.theme_frequencies = []
     fake_backend.theme_tree = []
     resp = client.get("/codebooks/cb-1/themes?name=My+Codebook&version=3", follow_redirects=True)
@@ -101,6 +119,11 @@ def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
 
 
 def test_codebook_themes_renders_empty_state(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
     fake_backend.theme_frequencies = []
     fake_backend.theme_tree = []
     resp = client.get("/codebooks/cb-1/themes", follow_redirects=True)
@@ -109,6 +132,11 @@ def test_codebook_themes_renders_empty_state(client, fake_backend):
 
 
 def test_codebook_themes_renders_backend_error(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
     fake_backend.raise_on = "get_theme_frequencies"
     resp = client.get("/codebooks/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
@@ -119,10 +147,27 @@ def test_codebook_themes_renders_backend_error(client, fake_backend):
 def test_codebook_themes_shows_not_found_message_for_missing_codebook(client, fake_backend):
     from web.services.backend_client import BackendNotFoundError
 
+    fake_backend.codebooks = [
+        {"id": "missing-id", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
     fake_backend.raise_on = ("get_theme_frequencies", BackendNotFoundError)
     resp = client.get("/codebooks/missing-id/themes", follow_redirects=True)
     assert resp.status_code == 200
     # Substring avoids apostrophe in "couldn't" — Jinja2 HTML-escapes it.
     assert b"may have been deleted" in resp.data
     # Empty-state line must NOT appear alongside the error.
+    assert b"No themes found for this codebook" not in resp.data
+
+
+def test_codebook_themes_shows_error_for_codebook_outside_selected_corpus(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-2", "name": "Other Corpus Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "bob", "description": None,
+         "corpus_id": "other-corpus"},
+    ]
+    resp = client.get(f"/codebooks/{fake_backend.corpus_id}/cb-1/themes", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"selected corpus" in resp.data
     assert b"No themes found for this codebook" not in resp.data

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -34,24 +34,25 @@ def test_codebook_list_renders_codebooks(client, fake_backend):
         {"id": "cb-2", "name": "Focus Group Codebook", "version": 2,
          "project_id": "proj-1", "created_by": "bob", "description": None},
     ]
-    resp = client.get("/codebooks/")
+    resp = client.get("/codebooks/", follow_redirects=True)
     assert resp.status_code == 200
     assert b"Interview Codebook" in resp.data
     assert b"Focus Group Codebook" in resp.data
     assert b"alice" in resp.data
     assert b"bob" in resp.data
+    assert b'id="corpus_selector"' in resp.data
 
 
 def test_codebook_list_renders_empty_state(client, fake_backend):
     fake_backend.codebooks = []
-    resp = client.get("/codebooks/")
+    resp = client.get("/codebooks/", follow_redirects=True)
     assert resp.status_code == 200
     assert b"No codebooks found" in resp.data
 
 
 def test_codebook_list_renders_backend_error(client, fake_backend):
     fake_backend.raise_on = "list_codebooks"
-    resp = client.get("/codebooks/")
+    resp = client.get("/codebooks/", follow_redirects=True)
     assert resp.status_code == 200
     assert b"simulated list_codebooks failure" in resp.data
     # Never leak internals.
@@ -63,7 +64,7 @@ def test_codebook_list_shows_unavailable_message_when_backend_down(client, fake_
     from web.services.backend_client import BackendUnavailableError
 
     fake_backend.raise_on = ("list_codebooks", BackendUnavailableError)
-    resp = client.get("/codebooks/")
+    resp = client.get("/codebooks/", follow_redirects=True)
     assert resp.status_code == 200
     # Substring chosen to avoid the apostrophe in "can't", which Jinja2
     # HTML-escapes to "can&#39;t" when rendering the flash message.
@@ -85,15 +86,16 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
         {"theme": {"id": "t-1", "label": "Work-Life Balance", "is_active": True},
          "children": []},
     ]
-    resp = client.get("/codebooks/cb-1/themes")
+    resp = client.get("/codebooks/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
     assert b"Work-Life Balance" in resp.data
+    assert b'id="corpus_selector"' in resp.data
 
 
 def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
     fake_backend.theme_frequencies = []
     fake_backend.theme_tree = []
-    resp = client.get("/codebooks/cb-1/themes?name=My+Codebook&version=3")
+    resp = client.get("/codebooks/cb-1/themes?name=My+Codebook&version=3", follow_redirects=True)
     assert resp.status_code == 200
     assert b"My Codebook" in resp.data
 
@@ -101,14 +103,14 @@ def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
 def test_codebook_themes_renders_empty_state(client, fake_backend):
     fake_backend.theme_frequencies = []
     fake_backend.theme_tree = []
-    resp = client.get("/codebooks/cb-1/themes")
+    resp = client.get("/codebooks/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
     assert b"No themes found" in resp.data
 
 
 def test_codebook_themes_renders_backend_error(client, fake_backend):
     fake_backend.raise_on = "get_theme_frequencies"
-    resp = client.get("/codebooks/cb-1/themes")
+    resp = client.get("/codebooks/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
     assert b"simulated get_theme_frequencies failure" in resp.data
     assert b"Traceback" not in resp.data
@@ -118,7 +120,7 @@ def test_codebook_themes_shows_not_found_message_for_missing_codebook(client, fa
     from web.services.backend_client import BackendNotFoundError
 
     fake_backend.raise_on = ("get_theme_frequencies", BackendNotFoundError)
-    resp = client.get("/codebooks/missing-id/themes")
+    resp = client.get("/codebooks/missing-id/themes", follow_redirects=True)
     assert resp.status_code == 200
     # Substring avoids apostrophe in "couldn't" — Jinja2 HTML-escapes it.
     assert b"may have been deleted" in resp.data

--- a/Frontend/tests/test_demographic.py
+++ b/Frontend/tests/test_demographic.py
@@ -35,6 +35,7 @@ def test_list_renders_demographic_files(client, fake_backend):
     assert resp.status_code == 200
     assert b"participants" in resp.data
     assert b"View Data" in resp.data
+    assert b'id="corpus_selector"' in resp.data
     assert b"No demographic data uploaded yet" not in resp.data
 
 

--- a/Frontend/tests/test_ingestion.py
+++ b/Frontend/tests/test_ingestion.py
@@ -150,6 +150,54 @@ def test_upload_submit_re_renders_form_on_validation_error(client, fake_backend)
     assert b"Upload Results" not in resp.data
 
 
+def test_upload_form_shows_corpus_selector_for_both_upload_forms(client, fake_backend):
+    fake_backend.corpora = [
+        {"id": CORPUS, "name": "Main Corpus"},
+        {"id": "second-corpus-id", "name": "Pilot Corpus"},
+    ]
+
+    resp = client.get(f"/transcripts/{CORPUS}/upload")
+
+    assert resp.status_code == 200
+    assert b'id="corpus_selector"' in resp.data
+    assert b"Main Corpus" in resp.data
+    assert b"Pilot Corpus" in resp.data
+    assert b"data-switch-template" in resp.data
+    assert b"/transcripts/test-corpus-id/upload" in resp.data
+    assert b"/demographic/test-corpus-id/upload" in resp.data
+    assert b'id="create-corpus-form"' in resp.data
+    assert b"/transcripts/corpora" in resp.data
+
+
+def test_create_corpus_from_upload_page_redirects_to_new_corpus(client, fake_backend):
+    fake_backend.corpora = [{"id": CORPUS, "name": "Main Corpus"}]
+
+    resp = client.post(
+        "/transcripts/corpora",
+        data={"name": "Pilot Corpus", "current_corpus_id": CORPUS},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert fake_backend.last_created_corpus is not None
+    new_id = fake_backend.last_created_corpus["id"]
+    assert resp.headers["Location"].endswith(f"/transcripts/{new_id}/upload")
+
+    follow = client.get(resp.headers["Location"])
+    assert follow.status_code == 200
+    assert b"Pilot Corpus" in follow.data
+
+
+def test_create_corpus_requires_name_and_stays_on_current_upload(client, fake_backend):
+    resp = client.post(
+        "/transcripts/corpora",
+        data={"name": "   ", "current_corpus_id": CORPUS},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith(f"/transcripts/{CORPUS}/upload")
+
+
 def test_upload_rejects_oversize_file(client, fake_backend):
     """Per-file cap is enforced in the controller before forwarding."""
     huge = b"x" * (11 * 1024 * 1024)

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -17,6 +17,7 @@ def list_codebooks() -> str:
         active_corpus_id, _, _ = resolve_active_corpus(
             _backend(),
             requested_corpus_id=requested_corpus_id,
+            strict_requested=bool(requested_corpus_id),
         )
     except BackendError as exc:
         flash(exc.user_message, "danger")
@@ -42,6 +43,7 @@ def list_codebooks_for_corpus(corpus_id: str) -> str:
         active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
             client,
             requested_corpus_id=corpus_id,
+            strict_requested=True,
         )
         corpus_name = active_corpus.get("name", corpus_name)
         codebooks = client.list_codebooks(corpus_id=active_corpus_id)
@@ -102,6 +104,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
     set_active_corpus_id(corpus_id)
     name = request.args.get("name", "")
     version = request.args.get("version", "")
+    active_codebook_id = codebook_id
     corpus_name = "Selected Corpus"
     corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
     try:
@@ -109,18 +112,35 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
             client,
             requested_corpus_id=corpus_id,
+            strict_requested=True,
         )
         corpus_name = active_corpus.get("name", corpus_name)
-        frequencies = client.get_theme_frequencies(codebook_id)
-        tree = client.get_theme_tree(codebook_id)
-    except BackendNotFoundError:
-        flash(
-            "That codebook couldn't be found. It may have been deleted.",
-            "danger",
+        codebooks = client.list_codebooks(corpus_id=active_corpus_id)
+        active_codebook = next(
+            (cb for cb in codebooks if str(cb.get("id")) == str(codebook_id)),
+            None,
         )
+        if active_codebook is None:
+            raise BackendNotFoundError(
+                user_message=(
+                    "That codebook couldn't be found in the selected corpus. "
+                    "Please choose another codebook."
+                )
+            )
+
+        active_codebook_id = str(active_codebook["id"])
+        if not name:
+            name = active_codebook.get("name", "")
+        if not version and active_codebook.get("version") is not None:
+            version = str(active_codebook["version"])
+
+        frequencies = client.get_theme_frequencies(active_codebook_id)
+        tree = client.get_theme_tree(active_codebook_id)
+    except BackendNotFoundError as exc:
+        flash(exc.user_message, "danger")
         return render_template(
             "codebooks/themes.html",
-            codebook_id=codebook_id,
+            codebook_id=active_codebook_id,
             name=name,
             version=version,
             corpus_id=corpus_id,
@@ -134,7 +154,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         flash(exc.user_message, "danger")
         return render_template(
             "codebooks/themes.html",
-            codebook_id=codebook_id,
+            codebook_id=active_codebook_id,
             name=name,
             version=version,
             corpus_id=corpus_id,
@@ -146,7 +166,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         )
     return render_template(
         "codebooks/themes.html",
-        codebook_id=codebook_id,
+        codebook_id=active_codebook_id,
         name=name,
         version=version,
         corpus_id=active_corpus_id,

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -1,30 +1,116 @@
-from flask import Blueprint, flash, render_template, request
+from flask import Blueprint, flash, redirect, render_template, request, url_for
 
 from web.services.backend_client import (
     BackendError,
     BackendNotFoundError,
     get_backend_client as _backend,
 )
+from web.services.corpus_context import resolve_active_corpus, set_active_corpus_id
 
 bp = Blueprint("codebooks", __name__)
 
 
 @bp.get("/")
 def list_codebooks() -> str:
+    requested_corpus_id = request.args.get("corpus_id")
     try:
-        codebooks = _backend().list_codebooks()
+        active_corpus_id, _, _ = resolve_active_corpus(
+            _backend(),
+            requested_corpus_id=requested_corpus_id,
+        )
     except BackendError as exc:
         flash(exc.user_message, "danger")
-        return render_template("codebooks/list.html", codebooks=[], error=True)
-    return render_template("codebooks/list.html", codebooks=codebooks)
+        return render_template(
+            "codebooks/list.html",
+            codebooks=[],
+            corpus_id=None,
+            corpus_options=[],
+            active_corpus_name=None,
+            error=True,
+        )
+
+    return redirect(url_for("codebooks.list_codebooks_for_corpus", corpus_id=active_corpus_id))
+
+
+@bp.get("/<corpus_id>/")
+def list_codebooks_for_corpus(corpus_id: str) -> str:
+    set_active_corpus_id(corpus_id)
+    corpus_name = "Selected Corpus"
+    corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
+    try:
+        client = _backend()
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+        corpus_name = active_corpus.get("name", corpus_name)
+        codebooks = client.list_codebooks(corpus_id=active_corpus_id)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return render_template(
+            "codebooks/list.html",
+            codebooks=[],
+            corpus_id=corpus_id,
+            corpus_options=corpus_options,
+            active_corpus_name=corpus_name,
+            error=True,
+        )
+    return render_template(
+        "codebooks/list.html",
+        codebooks=codebooks,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        active_corpus_name=corpus_name,
+    )
 
 
 @bp.get("/<codebook_id>/themes")
 def codebook_themes(codebook_id: str) -> str:
+    requested_corpus_id = request.args.get("corpus_id")
+    if requested_corpus_id:
+        return redirect(
+            url_for(
+                "codebooks.codebook_themes_for_corpus",
+                corpus_id=requested_corpus_id,
+                codebook_id=codebook_id,
+                name=request.args.get("name", ""),
+                version=request.args.get("version", ""),
+            )
+        )
+
+    # Backward-compatible route: use whichever corpus is active in session.
+    try:
+        active_corpus_id, _, _ = resolve_active_corpus(_backend())
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        active_corpus_id = ""
+    if active_corpus_id:
+        return redirect(
+            url_for(
+                "codebooks.codebook_themes_for_corpus",
+                corpus_id=active_corpus_id,
+                codebook_id=codebook_id,
+                name=request.args.get("name", ""),
+                version=request.args.get("version", ""),
+            )
+        )
+    return redirect(url_for("codebooks.list_codebooks"))
+
+
+@bp.get("/<corpus_id>/<codebook_id>/themes")
+def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
+    set_active_corpus_id(corpus_id)
     name = request.args.get("name", "")
     version = request.args.get("version", "")
+    corpus_name = "Selected Corpus"
+    corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
     try:
         client = _backend()
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+        corpus_name = active_corpus.get("name", corpus_name)
         frequencies = client.get_theme_frequencies(codebook_id)
         tree = client.get_theme_tree(codebook_id)
     except BackendNotFoundError:
@@ -37,6 +123,9 @@ def codebook_themes(codebook_id: str) -> str:
             codebook_id=codebook_id,
             name=name,
             version=version,
+            corpus_id=corpus_id,
+            corpus_options=corpus_options,
+            active_corpus_name=corpus_name,
             frequencies=[],
             tree=[],
             error=True,
@@ -48,6 +137,9 @@ def codebook_themes(codebook_id: str) -> str:
             codebook_id=codebook_id,
             name=name,
             version=version,
+            corpus_id=corpus_id,
+            corpus_options=corpus_options,
+            active_corpus_name=corpus_name,
             frequencies=[],
             tree=[],
             error=True,
@@ -57,6 +149,9 @@ def codebook_themes(codebook_id: str) -> str:
         codebook_id=codebook_id,
         name=name,
         version=version,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        active_corpus_name=corpus_name,
         frequencies=frequencies,
         tree=tree,
     )

--- a/Frontend/web/controllers/demographic.py
+++ b/Frontend/web/controllers/demographic.py
@@ -10,23 +10,14 @@ from flask import (
 )
 
 from web.services.backend_client import (
-    BackendClient,
     BackendError,
     BackendNotFoundError,
     BackendValidationError,
     get_backend_client as _backend,
 )
+from web.services.corpus_context import resolve_active_corpus, set_active_corpus_id
 
 bp = Blueprint("demographic", __name__)
-
-
-def _resolve_workspace_corpus(client: BackendClient) -> str:
-    """MVP single-workspace: resolve or create the default corpus."""
-    cfg = current_app.config
-    return client.ensure_corpus(
-        project_id=cfg["DEFAULT_PROJECT_ID"],
-        name=cfg["DEFAULT_CORPUS_NAME"],
-    )
 
 
 # ---- Landings ---------------------------------------------------------------
@@ -35,7 +26,7 @@ def _resolve_workspace_corpus(client: BackendClient) -> str:
 def _landing_with_corpus(target_endpoint: str):
     """Resolve the default corpus then redirect to a corpus-scoped view."""
     try:
-        corpus_id = _resolve_workspace_corpus(_backend())
+        corpus_id, _, _ = resolve_active_corpus(_backend())
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
@@ -61,16 +52,33 @@ def upload_landing():
 
 @bp.get("/<corpus_id>/")
 def list_files(corpus_id: str) -> str:
+    set_active_corpus_id(corpus_id)
     corpus_name = current_app.config["DEFAULT_CORPUS_NAME"]
+    corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
     try:
-        files = _backend().list_demographic_files(corpus_id)
+        client = _backend()
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+        files = client.list_demographic_files(active_corpus_id)
+        corpus_name = active_corpus.get("name", corpus_name)
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
-            "demographic/list.html", files=[], corpus_id=corpus_id, error=True, corpus_name=corpus_name
+            "demographic/list.html",
+            files=[],
+            corpus_id=corpus_id,
+            corpus_options=corpus_options,
+            error=True,
+            corpus_name=corpus_name,
         )
     return render_template(
-        "demographic/list.html", files=files, corpus_id=corpus_id, corpus_name=corpus_name
+        "demographic/list.html",
+        files=files,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        corpus_name=corpus_name,
     )
 
 
@@ -107,6 +115,7 @@ def upload_form(corpus_id: str):
 
 @bp.post("/<corpus_id>/upload")
 def upload_submit(corpus_id: str):
+    set_active_corpus_id(corpus_id)
     f = request.files.get("file")
     if not f or not f.filename:
         flash("Please select a CSV file to upload.", "danger")
@@ -146,6 +155,7 @@ def upload_submit(corpus_id: str):
 
 @bp.get("/<corpus_id>/preview/<import_id>")
 def preview_upload(corpus_id: str, import_id: str) -> str:
+    set_active_corpus_id(corpus_id)
     preview_data = session.get(f"demo_preview_{import_id}")
     if not preview_data:
         flash("Preview data expired or not found. Please upload again.", "warning")
@@ -162,6 +172,7 @@ def preview_upload(corpus_id: str, import_id: str) -> str:
 
 @bp.post("/<corpus_id>/preview/<import_id>")
 def preview_confirm(corpus_id: str, import_id: str):
+    set_active_corpus_id(corpus_id)
     action = request.form.get("action", "discard")
     confirm = action == "confirm"
 
@@ -186,7 +197,10 @@ def preview_confirm(corpus_id: str, import_id: str):
 
 @bp.get("/<corpus_id>/view/<file_id>")
 def view_data(corpus_id: str, file_id: str) -> str:
+    set_active_corpus_id(corpus_id)
     page = request.args.get("page", 1, type=int)
+    corpus_name = current_app.config["DEFAULT_CORPUS_NAME"]
+    corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
     # Render the same error-state shell from either except branch so the
     # template doesn't have to know which exception class fired.
     error_kwargs = dict(
@@ -196,16 +210,23 @@ def view_data(corpus_id: str, file_id: str) -> str:
         columns=[],
         transcript_lookup={},
         corpus_id=corpus_id,
+        corpus_options=corpus_options,
+        corpus_name=corpus_name,
         file_id=file_id,
         error=True,
     )
     try:
         client = _backend()
-        files = client.list_demographic_files(corpus_id)
-        rows_page = client.list_demographic_rows(corpus_id, file_id, page=page, page_size=100)
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+        corpus_name = active_corpus.get("name", corpus_name)
+        files = client.list_demographic_files(active_corpus_id)
+        rows_page = client.list_demographic_rows(active_corpus_id, file_id, page=page, page_size=100)
         rows = rows_page.get("items", [])
         meta = rows_page.get("meta", {})
-        link_summary = client.get_demographic_link_summary(corpus_id)
+        link_summary = client.get_demographic_link_summary(active_corpus_id)
     except BackendNotFoundError:
         # Specific user-facing message when a stale link points at a file
         # that no longer exists — same pattern as codebook_themes uses.
@@ -239,6 +260,8 @@ def view_data(corpus_id: str, file_id: str) -> str:
         meta=meta,
         columns=columns,
         transcript_lookup=transcript_lookup,
-        corpus_id=corpus_id,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        corpus_name=corpus_name,
         file_id=file_id,
     )

--- a/Frontend/web/controllers/ingestion.py
+++ b/Frontend/web/controllers/ingestion.py
@@ -6,21 +6,12 @@ from web.services.backend_client import (
     BackendValidationError,
     get_backend_client as _backend,
 )
+from web.services.corpus_context import (
+    resolve_active_corpus,
+    set_active_corpus_id,
+)
 
 bp = Blueprint("ingestion", __name__)
-
-
-def _resolve_workspace_corpus(client: BackendClient) -> str:
-    """MVP single-workspace: resolve or create the default corpus.
-
-    Only invoked from the no-arg landing routes. Every other view receives
-    the corpus_id from the URL, so the id is explicit and shareable rather
-    than hidden in an in-memory cache."""
-    cfg = current_app.config
-    return client.ensure_corpus(
-        project_id=cfg["DEFAULT_PROJECT_ID"],
-        name=cfg["DEFAULT_CORPUS_NAME"],
-    )
 
 
 # Landings — resolve the default corpus then redirect to the corpus-scoped URL.
@@ -32,7 +23,7 @@ def _landing_with_corpus(target_endpoint: str):
     transcript list with the user-facing error message — the only sensible
     fallback view when we don't yet know a corpus id."""
     try:
-        corpus_id = _resolve_workspace_corpus(_backend())
+        corpus_id, _, _ = resolve_active_corpus(_backend())
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
@@ -55,11 +46,26 @@ def upload_landing():
 
 
 def _render_upload_form(corpus_id: str) -> str:
+    cfg = current_app.config
+    try:
+        client = _backend()
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        active_corpus_id = corpus_id
+        active_corpus = {"id": corpus_id, "name": cfg["DEFAULT_CORPUS_NAME"]}
+        corpus_options = [active_corpus]
+
     return render_template(
         "ingestion/upload.html",
-        corpus_id=corpus_id,
-        max_size_mb=current_app.config["MAX_UPLOAD_SIZE_MB"],
-        accepted_extensions=sorted(current_app.config["ACCEPTED_EXTENSIONS"]),
+        corpus_id=active_corpus_id,
+        active_corpus_name=active_corpus.get("name"),
+        corpus_options=corpus_options,
+        max_size_mb=cfg["MAX_UPLOAD_SIZE_MB"],
+        accepted_extensions=sorted(cfg["ACCEPTED_EXTENSIONS"]),
     )
 
 
@@ -74,15 +80,69 @@ def _file_size(fileobj) -> int:
 
 @bp.get("/<corpus_id>/upload")
 def upload_form(corpus_id: str) -> str:
+    set_active_corpus_id(corpus_id)
     return _render_upload_form(corpus_id)
+
+
+@bp.post("/corpora")
+def create_corpus_submit():
+    """Create a new corpus from the uploads page selector flow.
+
+    The backend owns UUID creation; the frontend only collects a corpus name.
+    On success, redirect to the upload page scoped to the new corpus so both
+    transcript and demographic forms target it immediately.
+    """
+    cfg = current_app.config
+    name = (request.form.get("name") or "").strip()
+    current_corpus_id = (request.form.get("current_corpus_id") or "").strip()
+
+    if not name:
+        flash("Please enter a corpus name.", "danger")
+        if current_corpus_id:
+            return redirect(url_for("ingestion.upload_form", corpus_id=current_corpus_id))
+        return redirect(url_for("ingestion.upload_landing"))
+
+    try:
+        created = _backend().create_corpus(
+            project_id=cfg["DEFAULT_PROJECT_ID"],
+            name=name,
+        )
+    except BackendValidationError as exc:
+        flash(exc.user_message, "danger")
+        if current_corpus_id:
+            return redirect(url_for("ingestion.upload_form", corpus_id=current_corpus_id))
+        return redirect(url_for("ingestion.upload_landing"))
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        if current_corpus_id:
+            return redirect(url_for("ingestion.upload_form", corpus_id=current_corpus_id))
+        return redirect(url_for("ingestion.upload_landing"))
+
+    new_corpus_id = created["id"]
+    set_active_corpus_id(new_corpus_id)
+    flash(f"Created corpus '{created.get('name', name)}'.", "success")
+    return redirect(url_for("ingestion.upload_form", corpus_id=new_corpus_id))
 
 
 @bp.post("/<corpus_id>/upload")
 def upload_submit(corpus_id: str) -> str:
+    set_active_corpus_id(corpus_id)
+    active_corpus_name = current_app.config["DEFAULT_CORPUS_NAME"]
+    corpus_options: list[dict] = [{"id": corpus_id, "name": active_corpus_name}]
+    active_corpus_id = corpus_id
+    try:
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            _backend(),
+            requested_corpus_id=corpus_id,
+        )
+        active_corpus_name = active_corpus.get("name", active_corpus_name)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+
     files = [f for f in request.files.getlist("files") if f and f.filename]
     if not files:
         flash("Please select at least one file to upload.", "danger")
-        return _render_upload_form(corpus_id)
+        return _render_upload_form(active_corpus_id)
 
     max_bytes = current_app.config["MAX_UPLOAD_BYTES"]
     oversize = [f.filename for f in files if _file_size(f) > max_bytes]
@@ -92,22 +152,33 @@ def upload_submit(corpus_id: str) -> str:
             f"Each file must be at most {max_mb} MB. Too large: {', '.join(oversize)}.",
             "danger",
         )
-        return _render_upload_form(corpus_id)
+        return _render_upload_form(active_corpus_id)
 
     try:
-        results = _backend().upload_files(corpus_id, files)
+        results = _backend().upload_files(active_corpus_id, files)
     except BackendValidationError as exc:
         # Backend rejected the payload — re-render the form so the user
         # can fix it. The validation message names the offending field.
         flash(exc.user_message, "danger")
-        return _render_upload_form(corpus_id)
+        return _render_upload_form(active_corpus_id)
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
-            "ingestion/results.html", results=[], corpus_id=corpus_id, error=True
+            "ingestion/results.html",
+            results=[],
+            corpus_id=active_corpus_id,
+            corpus_options=corpus_options,
+            active_corpus_name=active_corpus_name,
+            error=True,
         )
 
-    return render_template("ingestion/results.html", results=results, corpus_id=corpus_id)
+    return render_template(
+        "ingestion/results.html",
+        results=results,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        active_corpus_name=active_corpus_name,
+    )
 
 # List (corpus-scoped)
 
@@ -115,11 +186,31 @@ def upload_submit(corpus_id: str) -> str:
 
 @bp.get("/<corpus_id>/")
 def list_transcripts(corpus_id: str) -> str:
+    set_active_corpus_id(corpus_id)
+    active_corpus_name = current_app.config["DEFAULT_CORPUS_NAME"]
+    corpus_options: list[dict] = [{"id": corpus_id, "name": active_corpus_name}]
     try:
-        documents = _backend().list_documents(corpus_id)
+        client = _backend()
+        active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
+            client,
+            requested_corpus_id=corpus_id,
+        )
+        documents = client.list_documents(active_corpus_id)
+        active_corpus_name = active_corpus.get("name", active_corpus_name)
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return render_template(
-            "ingestion/list.html", documents=[], corpus_id=corpus_id, error=True
+            "ingestion/list.html",
+            documents=[],
+            corpus_id=corpus_id,
+            corpus_options=corpus_options,
+            active_corpus_name=active_corpus_name,
+            error=True,
         )
-    return render_template("ingestion/list.html", documents=documents, corpus_id=corpus_id)
+    return render_template(
+        "ingestion/list.html",
+        documents=documents,
+        corpus_id=active_corpus_id,
+        corpus_options=corpus_options,
+        active_corpus_name=active_corpus_name,
+    )

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -154,8 +154,9 @@ class BackendClient:
 
     # ---- Codebooks ----------------------------------------------------------
 
-    def list_codebooks(self) -> list[dict]:
-        return self._get("/codebooks/")
+    def list_codebooks(self, corpus_id: str | None = None) -> list[dict]:
+        params = {"corpus_id": corpus_id} if corpus_id else None
+        return self._get("/codebooks/", params=params)
 
     def get_theme_frequencies(self, codebook_id: str) -> list[dict]:
         return self._get(f"/codebooks/{codebook_id}/themes")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -326,9 +326,23 @@ def _parse_validation_detail(response: httpx.Response) -> str | None:
         body = response.json()
     except (json.JSONDecodeError, ValueError):
         return None
-    detail = body.get("detail") if isinstance(body, dict) else None
-    if not isinstance(detail, list):
+    if not isinstance(body, dict):
         return None
+
+    detail = body.get("detail")
+    if isinstance(detail, str) and detail.strip():
+        return detail
+
+    if not isinstance(detail, list):
+        # Our backend envelope for handled 422s is:
+        # {"success": false, "error": "...", "meta": {"detail": "..."}}
+        meta = body.get("meta")
+        if isinstance(meta, dict):
+            meta_detail = meta.get("detail")
+            if isinstance(meta_detail, str) and meta_detail.strip():
+                return meta_detail
+        return None
+
     messages: list[str] = []
     for item in detail:
         if not isinstance(item, dict):

--- a/Frontend/web/services/corpus_context.py
+++ b/Frontend/web/services/corpus_context.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from flask import current_app, session
+
+from web.services.backend_client import BackendClient
+
+ACTIVE_CORPUS_SESSION_KEY = "active_corpus_id"
+
+
+def list_workspace_corpora(client: BackendClient) -> list[dict]:
+    """Return all corpora for the configured workspace project.
+
+    Ensures at least one corpus exists by creating the default corpus on demand.
+    """
+    cfg = current_app.config
+    project_id = cfg["DEFAULT_PROJECT_ID"]
+    corpora = client.list_corpora(project_id)
+    if corpora:
+        return corpora
+
+    ensured_id = client.ensure_corpus(
+        project_id=project_id,
+        name=cfg["DEFAULT_CORPUS_NAME"],
+    )
+    corpora = client.list_corpora(project_id)
+    if corpora:
+        return corpora
+    return [{"id": ensured_id, "name": cfg["DEFAULT_CORPUS_NAME"], "project_id": project_id}]
+
+
+def set_active_corpus_id(corpus_id: str) -> None:
+    session[ACTIVE_CORPUS_SESSION_KEY] = corpus_id
+
+
+def resolve_active_corpus(
+    client: BackendClient,
+    *,
+    requested_corpus_id: str | None = None,
+) -> tuple[str, list[dict], dict]:
+    """Resolve the active corpus id and persist it in session.
+
+    Priority:
+    1. requested_corpus_id from route/query
+    2. session-stored active corpus id
+    3. first available corpus in the project
+    """
+    corpora = list_workspace_corpora(client)
+    corpora_by_id = {str(c["id"]): c for c in corpora}
+
+    selected_id: str | None = None
+    for candidate in (requested_corpus_id, session.get(ACTIVE_CORPUS_SESSION_KEY)):
+        if candidate and candidate in corpora_by_id:
+            selected_id = candidate
+            break
+
+    if selected_id is None:
+        selected_id = str(corpora[0]["id"])
+
+    session[ACTIVE_CORPUS_SESSION_KEY] = selected_id
+    return selected_id, corpora, corpora_by_id[selected_id]

--- a/Frontend/web/services/corpus_context.py
+++ b/Frontend/web/services/corpus_context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from flask import current_app, session
 
-from web.services.backend_client import BackendClient
+from web.services.backend_client import BackendClient, BackendNotFoundError
 
 ACTIVE_CORPUS_SESSION_KEY = "active_corpus_id"
 
@@ -36,6 +36,7 @@ def resolve_active_corpus(
     client: BackendClient,
     *,
     requested_corpus_id: str | None = None,
+    strict_requested: bool = False,
 ) -> tuple[str, list[dict], dict]:
     """Resolve the active corpus id and persist it in session.
 
@@ -43,9 +44,24 @@ def resolve_active_corpus(
     1. requested_corpus_id from route/query
     2. session-stored active corpus id
     3. first available corpus in the project
+
+    When strict_requested=True and requested_corpus_id is provided but missing,
+    raise BackendNotFoundError instead of silently falling back.
     """
     corpora = list_workspace_corpora(client)
     corpora_by_id = {str(c["id"]): c for c in corpora}
+
+    if (
+        strict_requested
+        and requested_corpus_id
+        and requested_corpus_id not in corpora_by_id
+    ):
+        raise BackendNotFoundError(
+            user_message=(
+                "The selected corpus couldn't be found. "
+                "Please choose another corpus."
+            )
+        )
 
     selected_id: str | None = None
     for candidate in (requested_corpus_id, session.get(ACTIVE_CORPUS_SESSION_KEY)):

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}Codebooks{% endblock %}
 {% block content %}
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('codebooks.list_codebooks_for_corpus', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   <h1 class="h3 mb-4">Codebooks</h1>
 
   {% if error %}
@@ -25,7 +42,7 @@
                 <td class="text-secondary">{{ cb.created_by }}</td>
                 <td>
                   <a class="btn btn-sm btn-outline-primary"
-                     href="{{ url_for('codebooks.codebook_themes', codebook_id=cb.id, name=cb.name, version=cb.version) }}">
+                     href="{{ url_for('codebooks.codebook_themes_for_corpus', corpus_id=corpus_id, codebook_id=cb.id, name=cb.name, version=cb.version) }}">
                     View themes
                   </a>
                 </td>
@@ -38,4 +55,18 @@
   {% else %}
     <p class="text-secondary">No codebooks found.</p>
   {% endif %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+      selector.addEventListener("change", () => {
+        const template = selector.dataset.switchTemplate;
+        const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+        window.location.href = target;
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -6,11 +6,28 @@
      data-frequencies='{{ frequencies | tojson }}'
      data-tree='{{ tree | tojson }}'>
 
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('codebooks.list_codebooks_for_corpus', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   {# Breadcrumb #}
   <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb mb-0">
       <li class="breadcrumb-item">
-        <a href="{{ url_for('codebooks.list_codebooks') }}">Codebooks</a>
+        <a href="{{ url_for('codebooks.list_codebooks_for_corpus', corpus_id=corpus_id) }}">Codebooks</a>
       </li>
       <li class="breadcrumb-item active">{{ name or 'Theme Browser' }}</li>
     </ol>
@@ -123,5 +140,16 @@
 {% endblock %}
 
 {% block scripts %}
+<script>
+  (() => {
+    const selector = document.getElementById("corpus_selector");
+    if (!selector) return;
+    selector.addEventListener("change", () => {
+      const template = selector.dataset.switchTemplate;
+      const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+      window.location.href = target;
+    });
+  })();
+</script>
 <script src="{{ url_for('static', filename='js/codebook_themes.js') }}"></script>
 {% endblock %}

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}Demographic Data{% endblock %}
 {% block content %}
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('demographic.list_files', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="h3 mb-0">Demographic Data</h1>
     {% if corpus_id %}
@@ -57,4 +74,18 @@
   {% else %}
     <p class="text-secondary">No demographic data to show.</p>
   {% endif %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+      selector.addEventListener("change", () => {
+        const template = selector.dataset.switchTemplate;
+        const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+        window.location.href = target;
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/demographic/view.html
+++ b/Frontend/web/templates/demographic/view.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}View — {{ file_info.name if file_info else 'Demographic Data' }}{% endblock %}
 {% block content %}
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('demographic.list_files', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="mb-2">
     <a class="text-decoration-none small"
        href="{{ url_for('demographic.list_files', corpus_id=corpus_id) }}">&larr; Back to file list</a>
@@ -82,4 +99,18 @@
     <h1 class="h3 mb-4">Demographic Data</h1>
     <p class="text-secondary">File not found.</p>
   {% endif %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+      selector.addEventListener("change", () => {
+        const template = selector.dataset.switchTemplate;
+        const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+        window.location.href = target;
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/ingestion/list.html
+++ b/Frontend/web/templates/ingestion/list.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}Transcripts{% endblock %}
 {% block content %}
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('ingestion.list_transcripts', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   <h1 class="h3 mb-4">Uploaded Transcripts</h1>
 
   {% if error %}
@@ -36,4 +53,18 @@
   {% else %}
     <p class="text-secondary">No transcripts to show.</p>
   {% endif %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+      selector.addEventListener("change", () => {
+        const template = selector.dataset.switchTemplate;
+        const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+        window.location.href = target;
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/ingestion/results.html
+++ b/Frontend/web/templates/ingestion/results.html
@@ -1,6 +1,23 @@
 {% extends "base.html" %}
 {% block title %}Upload Results{% endblock %}
 {% block content %}
+  {% if corpus_id and corpus_options %}
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <label for="corpus_selector" class="form-label fw-semibold mb-2">Selected corpus</label>
+        <select id="corpus_selector"
+                class="form-select"
+                data-switch-template="{{ url_for('ingestion.upload_form', corpus_id='__CORPUS_ID__') }}">
+          {% for corpus in corpus_options %}
+            <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+              {{ corpus.name }} ({{ corpus.id }})
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
   <h1 class="h3 mb-4">Upload Results</h1>
 
   {% if results %}
@@ -55,4 +72,18 @@
       <a class="btn btn-outline-secondary" href="{{ url_for('ingestion.upload_landing') }}">Back to upload</a>
     {% endif %}
   </div>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+      selector.addEventListener("change", () => {
+        const template = selector.dataset.switchTemplate;
+        const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
+        window.location.href = target;
+      });
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -8,6 +8,46 @@
     </p>
   </div>
 
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-body">
+      <label for="corpus_selector" class="form-label fw-semibold mb-2">
+        Upload target corpus
+      </label>
+      <select id="corpus_selector"
+              class="form-select"
+              data-switch-template="{{ url_for('ingestion.upload_form', corpus_id='__CORPUS_ID__') }}">
+        {% for corpus in corpus_options %}
+          <option value="{{ corpus.id }}" {% if corpus.id == corpus_id %}selected{% endif %}>
+            {{ corpus.name }} ({{ corpus.id }})
+          </option>
+        {% endfor %}
+      </select>
+      <p class="text-secondary small mb-0 mt-2">
+        This selection applies to both transcript and demographic uploads on this page.
+      </p>
+
+      <form id="create-corpus-form"
+            class="mt-3"
+            method="post"
+            action="{{ url_for('ingestion.create_corpus_submit') }}">
+        <input type="hidden" id="current_corpus_id" name="current_corpus_id" value="{{ corpus_id }}">
+        <label for="new_corpus_name" class="form-label fw-semibold mb-2">
+          + Create new corpus
+        </label>
+        <div class="input-group">
+          <input type="text"
+                 id="new_corpus_name"
+                 name="name"
+                 class="form-control"
+                 maxlength="255"
+                 placeholder="Enter corpus name"
+                 required>
+          <button type="submit" class="btn btn-outline-secondary">Create</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <div class="row g-4 upload-row">
 
     {# ─── Transcripts card (primary, indigo) ─────────────────────────── #}
@@ -161,6 +201,21 @@
   </div>
 
   <script>
+    (() => {
+      const selector = document.getElementById("corpus_selector");
+      if (!selector) return;
+
+      function routeFromTemplate(template, corpusId) {
+        return template.replace("__CORPUS_ID__", encodeURIComponent(corpusId));
+      }
+
+      selector.addEventListener("change", () => {
+        const selectedCorpus = selector.value;
+        const template = selector.dataset.switchTemplate;
+        window.location.href = routeFromTemplate(template, selectedCorpus);
+      });
+    })();
+
     (() => {
       const MAX_MB = {{ max_size_mb }};
       const MAX_BYTES = MAX_MB * 1024 * 1024;


### PR DESCRIPTION
Implemented a UX and reliability improvement for demographic uploads and corpus handling.

First, I improved the demographic upload error handling: if a user uploads demographic data that already exists for the same corpus, the UI now shows a clear reason that duplicate demographic data cannot be uploaded for that corpus.

I also made demographic CSV parsing more flexible by accepting both ; and , delimiters, so more CSV variants work out of the box.

To make testing easier, I added sample demographic CSV files to the repository.

Finally, to avoid user frustration and confusion, I introduced explicit corpus selection in the upload flow, so users can directly choose which corpus transcripts and demographic data should be uploaded to. Corpus selection is now synchronized across relevant views, and codebook listing/filtering follows the selected corpus context.