### PR TITLE
Fixed issue with -Rebuild flag and --nocache in build scripts

### DIFF
--- a/setup-ps51.ps1
+++ b/setup-ps51.ps1
@@ -254,10 +254,13 @@ function Invoke-Up {
 
   $upFlags = [System.Collections.ArrayList]@()
   if (-not $Foreground) { $null = $upFlags.Add('-d') }
-  if ($Rebuild)         { $null = $upFlags.Add('--build'); $null = $upFlags.Add('--no-cache') }
-  elseif (-not $NoBuild){ $null = $upFlags.Add('--build') }
+  if (-not $NoBuild)    { $null = $upFlags.Add('--build') }
 
-  if (-not $NoBuild) {
+  if ($Rebuild) {
+    Write-Info "Rebuilding images with --no-cache..."
+    Invoke-Compose @('build', '--no-cache')
+  }
+  elseif (-not $NoBuild) {
     Write-Info "Building images - first run can take 3-5 minutes..."
   }
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -252,10 +252,13 @@ function Invoke-Up {
 
   $upFlags = @()
   if (-not $Foreground) { $upFlags += '-d' }
-  if ($Rebuild)         { $upFlags += '--build'; $upFlags += '--no-cache' }
-  elseif (-not $NoBuild){ $upFlags += '--build' }
+  if (-not $NoBuild)    { $upFlags += '--build' }
 
-  if (-not $NoBuild) {
+  if ($Rebuild) {
+    Write-Info "Rebuilding images with --no-cache..."
+    Invoke-Compose @('build', '--no-cache')
+  }
+  elseif (-not $NoBuild) {
     Write-Info "Building images - first run can take 3-5 minutes..."
   }
 

--- a/setup.sh
+++ b/setup.sh
@@ -148,13 +148,14 @@ mode_up() {
 
   local up_flags=()
   $DETACH && up_flags+=("-d")
-  if $REBUILD; then
-    up_flags+=(--build --no-cache)
-  elif $BUILD; then
+  if $BUILD || $REBUILD; then
     up_flags+=(--build)
   fi
 
-  if $BUILD || $REBUILD; then
+  if $REBUILD; then
+    log_info "Rebuilding images with --no-cache..."
+    run_compose build --no-cache
+  elif $BUILD; then
     log_info "Building images — first run can take 3–5 minutes..."
   fi
 


### PR DESCRIPTION
This pull request refactors the logic for handling build and rebuild options in the "up" commands of our setup scripts across PowerShell (`setup.ps1`, `setup-ps51.ps1`) and Bash (`setup.sh`). The changes clarify when images are rebuilt with `--no-cache` when running using the -Rebuild flag.