### PR TITLE
137 delete demographic data

### DIFF
--- a/Backend/app/routers/demographic.py
+++ b/Backend/app/routers/demographic.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, File, Form, Query, UploadFile
 from fastapi.responses import JSONResponse
 
 from app.dependencies import AppSettings, DbSession
-from app.exceptions import UnprocessableError
+from app.exceptions import NotFoundError, UnprocessableError
 from app.schemas import Page, PageMeta, ResponseEnvelope
 from app.schemas.demographic import (
     DemographicFileSummary,
@@ -186,6 +186,41 @@ async def list_demographic_rows(
             meta=PageMeta(total=total, page=page, page_size=page_size, pages=_pages(total, page_size)),
         )
     )
+
+
+@router.delete(
+    "/files/{file_id}",
+    response_model=ResponseEnvelope[None],
+    summary="Delete a demographic file",
+    description="Delete a demographic file and all of its rows.",
+)
+async def delete_demographic_file(
+    corpus_id: uuid.UUID,
+    file_id: uuid.UUID,
+    session: DbSession,
+    settings: AppSettings,
+) -> ResponseEnvelope[None] | JSONResponse:
+    """Delete a demographic file and all associated rows."""
+    service = DemographicService(session, settings)
+    try:
+        await service.delete_file(corpus_id=corpus_id, demographic_file_id=file_id)
+    except NotFoundError as exc:
+        return JSONResponse(
+            status_code=NotFoundError.status_code,
+            content=ResponseEnvelope[None].fail(
+                error="NotFoundError",
+                detail=str(exc),
+            ).model_dump(mode="json"),
+        )
+    except UnprocessableError as exc:
+        return JSONResponse(
+            status_code=UnprocessableError.status_code,
+            content=ResponseEnvelope[None].fail(
+                error="UnprocessableError",
+                detail=str(exc),
+            ).model_dump(mode="json"),
+        )
+    return ResponseEnvelope[None].ok(data=None)
 
 
 @router.get(

--- a/Backend/app/services/demographic.py
+++ b/Backend/app/services/demographic.py
@@ -441,6 +441,28 @@ class DemographicService:
             rows_created=len(parsed.parsed_rows),
         )
 
+    async def delete_file(self, corpus_id: uuid.UUID, demographic_file_id: uuid.UUID) -> None:
+        await self._validate_corpus(corpus_id)
+
+        file_obj = (
+            await self._session.execute(
+                select(DemographicFiles).where(
+                    DemographicFiles.id == demographic_file_id,
+                    DemographicFiles.corpus_id == corpus_id,
+                )
+            )
+        ).scalar_one_or_none()
+
+        if file_obj is None:
+            raise NotFoundError(f"Demographic file '{demographic_file_id}' not found in corpus '{corpus_id}'")
+
+        await self._session.delete(file_obj)
+        try:
+            await self._session.commit()
+        except Exception as exc:
+            await self._session.rollback()
+            raise UnprocessableError(f"Could not delete demographic data: {exc}") from exc
+
     async def get_link_summary(self, corpus_id: uuid.UUID) -> LinkingSummary:
         await self._validate_corpus(corpus_id)
 

--- a/Backend/tests/test_demographic_api.py
+++ b/Backend/tests/test_demographic_api.py
@@ -477,3 +477,27 @@ async def test_list_demographic_rows_pagination_and_file_filter(client):
     assert wrong_filter.status_code == 422
     assert wrong_filter.json()["success"] is False
     assert "does not belong to corpus" in wrong_filter.json()["meta"]["detail"]
+
+
+async def test_delete_demographic_file_success(client, db_engine):
+    corpus_id = await _create_corpus(client, "Corpus Delete")
+    csv_content = "username;group\nuser_d;D\n"
+    import_id = await _upload_and_confirm_named_csv(client, corpus_id, "batch-delete", csv_content)
+
+    delete_resp = await client.delete(f"{DEMOGRAPHIC_API}/{corpus_id}/files/{import_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["success"] is True
+
+    files_resp = await client.get(f"{DEMOGRAPHIC_API}/{corpus_id}/files")
+    files = files_resp.json()["data"]["items"]
+    assert len(files) == 0
+
+
+async def test_delete_demographic_file_not_found(client):
+    corpus_id = await _create_corpus(client, "Corpus Delete Missing")
+    fake_id = str(uuid.uuid4())
+
+    delete_resp = await client.delete(f"{DEMOGRAPHIC_API}/{corpus_id}/files/{fake_id}")
+    assert delete_resp.status_code == 404
+    assert delete_resp.json()["success"] is False
+    assert "not found" in delete_resp.json()["meta"]["detail"]

--- a/Backend/tests/test_demographic_service_units.py
+++ b/Backend/tests/test_demographic_service_units.py
@@ -75,3 +75,32 @@ async def test_list_rows_rejects_file_not_in_corpus(tmp_path):
             page=1,
             page_size=10,
         )
+
+
+@pytest.mark.asyncio
+async def test_delete_file_not_found(tmp_path):
+    none_result = Mock()
+    none_result.scalar_one_or_none.return_value = None
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=none_result)
+    service = DemographicService(session=session, settings=_settings(tmp_path))
+    service._validate_corpus = AsyncMock(return_value=None)
+    
+    from app.exceptions import NotFoundError
+    with pytest.raises(NotFoundError, match="not found in corpus"):
+        await service.delete_file(uuid.uuid4(), uuid.uuid4())
+
+@pytest.mark.asyncio
+async def test_delete_file_success(tmp_path):
+    file_obj = Mock()
+    result = Mock()
+    result.scalar_one_or_none.return_value = file_obj
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    service = DemographicService(session=session, settings=_settings(tmp_path))
+    service._validate_corpus = AsyncMock(return_value=None)
+    
+    await service.delete_file(uuid.uuid4(), uuid.uuid4())
+    session.delete.assert_called_once_with(file_obj)
+    session.commit.assert_called_once()
+

--- a/Backend/tests/test_demographic_service_units.py
+++ b/Backend/tests/test_demographic_service_units.py
@@ -85,7 +85,7 @@ async def test_delete_file_not_found(tmp_path):
     session.execute = AsyncMock(return_value=none_result)
     service = DemographicService(session=session, settings=_settings(tmp_path))
     service._validate_corpus = AsyncMock(return_value=None)
-    
+
     from app.exceptions import NotFoundError
     with pytest.raises(NotFoundError, match="not found in corpus"):
         await service.delete_file(uuid.uuid4(), uuid.uuid4())
@@ -99,7 +99,7 @@ async def test_delete_file_success(tmp_path):
     session.execute = AsyncMock(return_value=result)
     service = DemographicService(session=session, settings=_settings(tmp_path))
     service._validate_corpus = AsyncMock(return_value=None)
-    
+
     await service.delete_file(uuid.uuid4(), uuid.uuid4())
     session.delete.assert_called_once_with(file_obj)
     session.commit.assert_called_once()

--- a/Documentation/demographic-pipeline.md
+++ b/Documentation/demographic-pipeline.md
@@ -62,5 +62,6 @@ All routes are under `/api/v1/demographic/{corpus_id}`.
 | `POST` | `/confirm?import_id=...&confirm=true|false` | Persist or cancel a pending upload |
 | `GET` | `/files` | List confirmed demographic imports (paginated) |
 | `GET` | `/rows` | List confirmed demographic rows (paginated, optional `demographic_file_id` filter) |
+| `DELETE` | `/files/{file_id}` | Delete a demographic file and all associated rows |
 
 All responses use the shared response envelope shape.

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -153,6 +153,10 @@ class FakeBackend:
         self._maybe_raise("get_demographic_link_summary")
         return self.demographic_link_summary
 
+    def delete_demographic_file(self, corpus_id, file_id) -> None:
+        self._maybe_raise("delete_demographic_file")
+        pass
+
     # ---- Codebook generation jobs -------------------------------------------
 
     def create_generation_job(

--- a/Frontend/tests/test_demographic.py
+++ b/Frontend/tests/test_demographic.py
@@ -367,3 +367,26 @@ def test_view_renders_empty_when_no_rows(client, fake_backend):
     resp = client.get(f"/demographic/{CORPUS}/view/file-1")
     assert resp.status_code == 200
     assert b"No data rows" in resp.data
+
+
+# ---- Delete file ------------------------------------------------------------
+
+
+def test_delete_file_success(client, fake_backend):
+    resp = client.post(
+        f"/demographic/{CORPUS}/delete/file-1",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"deleted successfully" in resp.data
+
+
+def test_delete_file_backend_error(client, fake_backend):
+    fake_backend.raise_on = "delete_demographic_file"
+    resp = client.post(
+        f"/demographic/{CORPUS}/delete/file-1",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"simulated delete_demographic_file failure" in resp.data
+

--- a/Frontend/web/controllers/demographic.py
+++ b/Frontend/web/controllers/demographic.py
@@ -193,6 +193,19 @@ def preview_confirm(corpus_id: str, import_id: str):
     return redirect(url_for("demographic.list_files", corpus_id=corpus_id))
 
 
+@bp.post("/<corpus_id>/delete/<file_id>")
+def delete_file(corpus_id: str, file_id: str):
+    set_active_corpus_id(corpus_id)
+    try:
+        _backend().delete_demographic_file(corpus_id, file_id)
+        flash("Demographic data deleted successfully.", "success")
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+
+    return redirect(url_for("demographic.list_files", corpus_id=corpus_id))
+
+
+
 # ---- View (corpus-scoped) --------------------------------------------------
 
 

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -226,6 +226,19 @@ class BackendClient:
         """Get transcript ↔ demographic linking status."""
         return self._get(f"/demographic/{corpus_id}/link-summary")
 
+    def delete_demographic_file(self, corpus_id: str, file_id: str) -> None:
+        """Delete a demographic file from the backend."""
+        path = f"/demographic/{corpus_id}/files/{file_id}"
+        started_at = time.monotonic()
+        try:
+            r = self._client.delete(path)
+            r.raise_for_status()
+            return self._unwrap(r)
+        except httpx.HTTPError as exc:
+            self._handle_exc(exc, path, "DELETE", started_at)
+        except (json.JSONDecodeError, KeyError) as exc:
+            self._handle_exc(exc, path, "DELETE", started_at)
+
     # ---- Codebook Upload & Parsing ------------------------------------------
 
     def parse_csv_preview(self, file: FileStorage) -> list[dict]:

--- a/Frontend/web/templates/_delete_modal.html
+++ b/Frontend/web/templates/_delete_modal.html
@@ -1,0 +1,30 @@
+{# Reusable Delete Confirmation Modal #}
+{# 
+  Requires the following context variables when included:
+  - modal_id: Unique ID for the modal element
+  - form_action: The URL where the POST request should be sent
+  - item_name: The name of the item being deleted (for display)
+  - title: (Optional) Modal title, defaults to "Confirm Deletion"
+  - message: (Optional) Custom warning message
+#}
+<div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-labelledby="{{ modal_id }}Label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="{{ modal_id }}Label">{{ title | default('Confirm Deletion') }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>
+          {{ message | default('Are you sure you want to delete <strong>' ~ item_name ~ '</strong>? This action cannot be undone.') | safe }}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <form action="{{ form_action }}" method="POST" class="d-inline">
+          <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -50,6 +50,15 @@
                      href="{{ url_for('demographic.view_data', corpus_id=corpus_id, file_id=f.id) }}">
                     View Data
                   </a>
+                  <button type="button" class="btn btn-sm btn-outline-danger ms-2"
+                          id="delete-data-btn-{{ loop.index }}"
+                          data-bs-toggle="modal" 
+                          data-bs-target="#deleteDemographicModal-{{ loop.index }}">
+                    Delete
+                  </button>
+                  {% with modal_id='deleteDemographicModal-' ~ loop.index, form_action=url_for('demographic.delete_file', corpus_id=corpus_id, file_id=f.id), item_name=f.name %}
+                    {% include "_delete_modal.html" %}
+                  {% endwith %}
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
This PR introduces the ability to delete uploaded demographic data files from a corpus. It fulfills part of the larger "Delete Corpus" epic by letting researchers safely remove incorrect or outdated demographic batches.

**Key Changes:**

Frontend UI: Added a "Delete" button next to each demographic data file in the list.

Confirmation Modal: Implemented a safety modal to ask "Are you sure?" before deleting, preventing accidental data loss.
Backend Endpoint: Added a new DELETE /api/v1/demographic/{corpus_id}/files/{file_id} endpoint that cleanly removes the file and all of its associated rows from the database.

Testing & Docs: Added comprehensive unit tests for both the backend service and frontend controllers, and updated the demographic-pipeline.md documentation to include the new endpoint.

Note: This PR is fully self-contained and is safe to merge directly into main