### PR TITLE
135 delete codebook

### DIFF
--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -301,3 +301,14 @@ async def get_codebook_detail(
     codebook, themes, edges, codes, theme_code_edges = await service.get_codebook_detail(codebook_id)
     detail = CodebookService.build_detail_schema(codebook, themes, edges, codes, theme_code_edges)
     return JSONResponse(content=ResponseEnvelope.ok(detail).model_dump(mode="json"))
+
+
+@router.delete("/{codebook_id}", response_model=ResponseEnvelope[None])
+async def delete_codebook(
+    codebook_id: UUID,
+    session: DbSession,
+) -> JSONResponse:
+    """Delete a codebook and all its themes/codes."""
+    service = CodebookService(session)
+    await service.delete_codebook(codebook_id)
+    return JSONResponse(content=ResponseEnvelope.ok(None).model_dump(mode="json"))

--- a/Backend/app/services/codebook.py
+++ b/Backend/app/services/codebook.py
@@ -252,6 +252,26 @@ class CodebookService:
         return codebook, themes, edges, codes, theme_code_edges
 
     # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    async def delete_codebook(self, codebook_id: uuid.UUID) -> None:
+        """Delete a codebook and all associated themes/codes via cascade.
+
+        Raises:
+            NotFoundError: If no codebook with ``codebook_id`` exists.
+        """
+        codebook_result = await self._session.execute(
+            select(Codebook).where(Codebook.id == codebook_id)
+        )
+        codebook = codebook_result.scalar_one_or_none()
+        if codebook is None:
+            raise NotFoundError(f"Codebook '{codebook_id}' not found.")
+
+        await self._session.delete(codebook)
+        await self._session.commit()
+
+    # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 

--- a/Backend/tests/test_codebook_router.py
+++ b/Backend/tests/test_codebook_router.py
@@ -224,3 +224,40 @@ async def test_list_codebooks_empty(client):
     body = resp.json()
     assert body["success"] is True
     assert isinstance(body["data"], list)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /codebooks/{codebook_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_codebook_success(client):
+    await _ensure_corpus(client)
+    payload = {
+        "name": "Delete Me Codebook",
+        "corpus_id": CORPUS_ID,
+        "nodes": [
+            {"name": "A", "description": "Desc A", "node_type": "THEME"},
+            {"name": "B", "description": "Desc B", "node_type": "THEME"},
+            {"name": "C", "description": "Desc C", "node_type": "THEME"},
+        ],
+    }
+    create_resp = await client.post(f"{API}/", json=payload)
+    cb_id = create_resp.json()["data"]["id"]
+
+    delete_resp = await client.delete(f"{API}/{cb_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["success"] is True
+
+    get_resp = await client.get(f"{API}/{cb_id}")
+    assert get_resp.status_code == 404
+
+
+async def test_delete_codebook_not_found(client):
+    unknown_id = str(uuid.uuid4())
+    resp = await client.delete(f"{API}/{unknown_id}")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["success"] is False
+    assert "not found" in body["error"].lower()
+

--- a/Backend/tests/test_codebook_service.py
+++ b/Backend/tests/test_codebook_service.py
@@ -126,6 +126,28 @@ async def test_get_codebook_detail_not_found_raises(db_session):
 
 
 # ---------------------------------------------------------------------------
+# delete_codebook
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_codebook_cascades_and_succeeds(db_session):
+    await _ensure_corpus(db_session)
+    svc = CodebookService(db_session)
+    created_cb, _, _, _, _ = await svc.create_codebook(_payload(3))
+
+    await svc.delete_codebook(created_cb.id)
+
+    with pytest.raises(NotFoundError):
+        await svc.get_codebook_detail(created_cb.id)
+
+
+async def test_delete_codebook_not_found_raises(db_session):
+    svc = CodebookService(db_session)
+    with pytest.raises(NotFoundError):
+        await svc.delete_codebook(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
 # build_detail_schema
 # ---------------------------------------------------------------------------
 

--- a/Documentation/theme-data-type.md
+++ b/Documentation/theme-data-type.md
@@ -117,3 +117,5 @@ The frontend calculates theme statistics (root themes, total themes, sub-themes)
 - `GET /codebooks/{codebook_id}/themes/tree`
   - Returns the recursive theme tree for the selected codebook (excludes `Code` nodes).
   - Optional query param: `root_theme_id` to return only one subtree.
+- `DELETE /codebooks/{codebook_id}`
+  - Deletes a codebook and cascades deletion to all associated themes, codes, and relationships. Returns `200 OK` on success, or `404 Not Found` if the codebook doesn't exist.

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -93,6 +93,10 @@ class FakeBackend:
 
     # ---- Codebooks / themes -------------------------------------------------
 
+    def delete_codebook(self, codebook_id: str) -> None:
+        self._maybe_raise("delete_codebook")
+        self.codebooks = [cb for cb in self.codebooks if cb.get("id") != codebook_id]
+
     def list_codebooks(self, corpus_id: str | None = None) -> list[dict]:
         self._maybe_raise("list_codebooks")
         if not corpus_id:

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -506,3 +506,29 @@ def test_auto_demo_link_present_on_mode_select(client, fake_backend):
     assert b"/auto-demo" in resp.data
 
 
+# POST /codebooks/<corpus_id>/<codebook_id>/delete
+
+
+def test_delete_codebook_success(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    resp = client.post(f"/codebooks/{fake_backend.corpus_id}/cb-1/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"successfully deleted" in resp.data
+    assert len(fake_backend.codebooks) == 0
+
+
+def test_delete_codebook_handles_backend_error(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.raise_on = "delete_codebook"
+    resp = client.post(f"/codebooks/{fake_backend.corpus_id}/cb-1/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"simulated delete_codebook failure" in resp.data
+    assert len(fake_backend.codebooks) == 1

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -726,3 +726,14 @@ def codebook_review(codebook_id: str) -> str:
         themes=_flatten_codebook_for_preview(codebook),
         error=None,
     )
+
+
+@bp.post("/<corpus_id>/<codebook_id>/delete")
+def delete_codebook(corpus_id: str, codebook_id: str):
+    """Delete a codebook and its themes."""
+    try:
+        _backend().delete_codebook(codebook_id)
+        flash("Codebook successfully deleted.", "success")
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+    return redirect(url_for("codebooks.list_codebooks_for_corpus", corpus_id=corpus_id))

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -263,6 +263,10 @@ class BackendClient:
             return result
         return result.get("items", result) if isinstance(result, dict) else []
 
+    def delete_codebook(self, codebook_id: str) -> None:
+        """Delete a codebook and all its associated themes/codes via cascade."""
+        self._delete(f"/codebooks/{codebook_id}")
+
     # ---- Codebook generation jobs -------------------------------------------
 
     def create_generation_job(
@@ -336,6 +340,17 @@ class BackendClient:
             self._handle_exc(exc, path, "POST", started_at)
         except (json.JSONDecodeError, KeyError) as exc:
             self._handle_exc(exc, path, "POST", started_at)
+
+    def _delete(self, path: str, *, sub_key: str | None = None, **kwargs):
+        started_at = time.monotonic()
+        try:
+            r = self._client.delete(path, **kwargs)
+            r.raise_for_status()
+            return self._unwrap(r, sub_key=sub_key)
+        except httpx.HTTPError as exc:
+            self._handle_exc(exc, path, "DELETE", started_at)
+        except (json.JSONDecodeError, KeyError) as exc:
+            self._handle_exc(exc, path, "DELETE", started_at)
 
     def _handle_exc(
         self,

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -83,6 +83,30 @@
                      href="{{ url_for('codebooks.export_codebook', corpus_id=corpus_id, codebook_id=cb.id) }}">
                     Export
                   </a>
+                  <button type="button" class="btn btn-sm btn-outline-danger ms-1" data-bs-toggle="modal" data-bs-target="#deleteCodebookModal-{{ cb.id }}">
+                    Delete
+                  </button>
+
+                  <!-- Delete Modal -->
+                  <div class="modal fade" id="deleteCodebookModal-{{ cb.id }}" tabindex="-1" aria-labelledby="deleteCodebookModalLabel-{{ cb.id }}" aria-hidden="true">
+                    <div class="modal-dialog">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="deleteCodebookModalLabel-{{ cb.id }}">Delete Codebook</h5>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body text-wrap text-break" style="white-space: normal;">
+                          Are you sure you want to delete the codebook <strong>{{ cb.name }}</strong>? This action cannot be undone and will permanently remove all associated themes and codes.
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                          <form action="{{ url_for('codebooks.delete_codebook', corpus_id=corpus_id, codebook_id=cb.id) }}" method="post" class="d-inline">
+                            <button type="submit" class="btn btn-danger">Delete</button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
This PR introduces the ability to delete codebooks from a corpus. It fulfills part of the larger "Delete Corpus" epic by letting researchers safely remove incorrect or outdated codebooks and their associated thematic structures.

Key Changes:

Frontend UI: Added a "Delete" button next to each codebook in the list.

Confirmation Modal: Implemented a safety modal to ask "Are you sure?" before deleting, preventing accidental data loss and warning users that the action is irreversible.

Backend Endpoint: Added a new DELETE /api/v1/codebooks/{codebook_id} endpoint that cleanly removes the codebook, automatically cascading the deletion to all of its nested themes, codes, and relationship mappings in the database.

Testing & Docs: Added comprehensive unit tests for both the backend service and frontend controllers, and updated the theme-data-type.md documentation to include the new endpoint.

Note: This PR is fully self-contained and is safe to merge directly into main.
