### PR TITLE
Improve Errors and Notifications for Codebook Generation

### DIFF
--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -92,13 +92,19 @@ class CodebookGenerationService:
             transcript_document_ids=normalized_document_ids,
         )
         if not documents:
-            raise UnprocessableError("No documents found in the selected corpus")
+            raise UnprocessableError(
+                "No transcripts found in the selected corpus. "
+                "Please upload transcripts before generating a codebook."
+            )
         passages = await self._load_passages(
             corpus_id=corpus_id,
             transcript_document_ids=[document.id for document in documents],
         )
         if not passages:
-            raise UnprocessableError("No transcript passages found for selected transcript_document_ids")
+            raise UnprocessableError(
+                "The transcripts in the selected corpus contain no processable text. "
+                "Please check that your uploads completed successfully and contain text content."
+            )
 
         # End the read transaction before long-running LLM calls so the session
         # does not keep a checked-out DB connection during inference.

--- a/Frontend/tests/test_ingestion.py
+++ b/Frontend/tests/test_ingestion.py
@@ -44,7 +44,8 @@ def test_upload_submit_renders_per_file_results(client, fake_backend):
     assert b"a.txt" in body
     assert b"b.pdf" in body
     assert b"Uploaded" in body
-    assert b"2 succeeded, 0 failed" in body
+    assert b"2 uploaded" in body
+    assert b"No content" not in body
     assert fake_backend.uploaded_files == ["a.txt", "b.pdf"]
 
 
@@ -71,7 +72,8 @@ def test_upload_submit_renders_per_file_errors(client, fake_backend):
     )
 
     assert resp.status_code == 200
-    assert b"1 succeeded, 1 failed" in resp.data
+    assert b"1 uploaded" in resp.data
+    assert b"1 failed" in resp.data
     assert b"Unsupported file extension" in resp.data
 
 

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -384,6 +384,7 @@ def confirm_submit(corpus_id: str) -> str:
                     for r in rows
                 ]
             if codebook_name == original_name and _normalise(themes) == _normalise(original_themes):
+                flash("No changes were made to the codebook.", "info")
                 return redirect(url_for(
                     "codebooks.success",
                     corpus_id=corpus_id,

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -353,6 +353,7 @@ def manual_form(corpus_id: str) -> str:
 def confirm_submit(corpus_id: str) -> str:
     """Validate, customise, and confirm a codebook and its themes."""
     codebook_name = (request.form.get("codebook_name") or "").strip()
+    source_codebook_id = request.form.get("source_codebook_id", "").strip()
     node_types = request.form.getlist("node_types[]")
     theme_names = request.form.getlist("theme_names[]")
     theme_descriptions = request.form.getlist("theme_descriptions[]")
@@ -367,6 +368,29 @@ def confirm_submit(corpus_id: str) -> str:
             "description": desc.strip(),
             "parent_name": parent.strip() if parent.strip() else None
         })
+
+    # If this is an edit of an existing codebook, check whether anything actually
+    # changed. If not, skip the create and go straight to the success page.
+    if source_codebook_id:
+        try:
+            original = _backend().get_codebook(source_codebook_id)
+            original_name = (original.get("name") or "").strip()
+            original_themes = _flatten_codebook_for_preview(original)
+            # Normalise parent_name to "" on both sides before comparing —
+            # the form assembles None for empty parents, the flatten helper uses "".
+            def _normalise(rows: list[dict]) -> list[dict]:
+                return [
+                    {**r, "parent_name": r.get("parent_name") or ""}
+                    for r in rows
+                ]
+            if codebook_name == original_name and _normalise(themes) == _normalise(original_themes):
+                return redirect(url_for(
+                    "codebooks.success",
+                    corpus_id=corpus_id,
+                    codebook_id=source_codebook_id,
+                ))
+        except BackendError:
+            pass  # original no longer accessible; fall through to create
 
     # Frontend validation
     error = None
@@ -724,5 +748,6 @@ def codebook_review(codebook_id: str) -> str:
         corpus_id=corpus_id,
         codebook_name=name,
         themes=_flatten_codebook_for_preview(codebook),
+        source_codebook_id=codebook_id,
         error=None,
     )

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -120,7 +120,7 @@
     document.querySelectorAll('.site-flash').forEach((el) => {
       const cat = el.dataset.flashCategory;
       if (cat === 'success' || cat === 'info') {
-        setTimeout(() => bootstrap.Alert.getOrCreateInstance(el).close(), 5000);
+        setTimeout(() => bootstrap.Alert.getOrCreateInstance(el).close(), 10000);
       }
     });
   </script>

--- a/Frontend/web/templates/codebooks/new/progress.html
+++ b/Frontend/web/templates/codebooks/new/progress.html
@@ -100,7 +100,9 @@
           const pct = Math.min(99, Math.max(2, raw));
           setBar(pct);
           counts.textContent = done + " / " + total + " passages";
-          statusLine.textContent = "Generating themes and codes…";
+          statusLine.textContent = total > 0
+            ? "Generating themes and codes — " + done + " of " + total + " passages processed…"
+            : "Generating themes and codes…";
           return;
         }
 

--- a/Frontend/web/templates/codebooks/preview.html
+++ b/Frontend/web/templates/codebooks/preview.html
@@ -5,6 +5,9 @@
 {% block content %}
 <div class="container py-4" style="max-width: 900px;">
   <form id="codebook-form" method="post" action="{{ url_for('codebooks.confirm_submit', corpus_id=corpus_id) }}">
+  {% if source_codebook_id %}
+    <input type="hidden" name="source_codebook_id" value="{{ source_codebook_id }}">
+  {% endif %}
   
   <div class="card shadow-sm border-0 rounded-4 mb-4">
     <div class="card-body p-4">

--- a/Frontend/web/templates/codebooks/preview.html
+++ b/Frontend/web/templates/codebooks/preview.html
@@ -28,7 +28,9 @@
                value="{{ codebook_name or 'My Codebook' }}"
                class="form-control form-control-lg bg-light"
                placeholder="Enter a name for this codebook"
+               minlength="1"
                required>
+        <div class="invalid-feedback">Codebook name must not be blank.</div>
       </div>
     </div>
   </div>
@@ -201,6 +203,36 @@
     const row = button.closest('.theme-row');
     row.remove();
     updateThemeList();
+  }
+
+  // --- Trim-check on the codebook name before submit ---
+  const nameInput = document.getElementById("codebook_name");
+  const form = document.getElementById("codebook-form");
+  if (form && nameInput) {
+    form.addEventListener("submit", (e) => {
+      if (!nameInput.value.trim()) {
+        e.preventDefault();
+        nameInput.value = "";
+        nameInput.classList.add("is-invalid");
+        nameInput.focus();
+      }
+    });
+    nameInput.addEventListener("input", () => {
+      if (nameInput.value.trim()) nameInput.classList.remove("is-invalid");
+    });
+
+    // --- Warn before navigating away with unsaved edits ---
+    const serialize = (fd) => [...fd.entries()].map(([k, v]) => k + "=" + v).sort().join("&");
+    const originalData = serialize(new FormData(form));
+    let formSubmitting = false;
+    form.addEventListener("submit", () => { formSubmitting = true; });
+    window.addEventListener("beforeunload", (e) => {
+      if (formSubmitting) return;
+      if (serialize(new FormData(form)) !== originalData) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    });
   }
 </script>
 {% endblock %}

--- a/Frontend/web/templates/ingestion/results.html
+++ b/Frontend/web/templates/ingestion/results.html
@@ -12,9 +12,14 @@
   <h1 class="h3 mb-4">Upload Results</h1>
 
   {% if results %}
-    {% set succeeded = results | selectattr("success") | list | length %}
-    {% set failed = results | rejectattr("success") | list | length %}
-    <p class="mb-3">{{ succeeded }} succeeded, {{ failed }} failed.</p>
+    {% set succeeded = results | selectattr("success") | selectattr("documents_created") | list | length %}
+    {% set warned   = results | selectattr("success") | rejectattr("documents_created") | list | length %}
+    {% set failed   = results | rejectattr("success") | list | length %}
+    <p class="mb-3">
+      {{ succeeded }} uploaded
+      {%- if warned %}, {{ warned }} uploaded with warnings{% endif %}
+      {%- if failed %}, {{ failed }} failed{% endif %}.
+    </p>
 
     <div class="bg-white border rounded-2 mb-4">
       <div class="table-responsive">
@@ -28,17 +33,24 @@
           </thead>
           <tbody>
             {% for r in results %}
-              <tr class="{{ 'table-success' if r.success else 'table-danger' }}">
+              {% set no_content = r.success and r.documents_created == 0 %}
+              <tr class="{{ 'table-warning' if no_content else ('table-success' if r.success else 'table-danger') }}">
                 <td>{{ r.filename }}</td>
                 <td>
-                  {% if r.success %}
+                  {% if no_content %}
+                    <span class="badge text-bg-warning text-dark">No content</span>
+                  {% elif r.success %}
                     <span class="badge text-bg-success">Uploaded</span>
                   {% else %}
                     <span class="badge text-bg-danger">Failed</span>
                   {% endif %}
                 </td>
                 <td>
-                  {% if r.success %}
+                  {% if no_content %}
+                    The file was parsed successfully but contained no storable content
+                    (all text was blank or all entries were skipped).
+                    Nothing was added to the corpus.
+                  {% elif r.success %}
                     {% if r.stored_filename != r.filename %}
                       Renamed to <code>{{ r.stored_filename }}</code> (duplicate name).<br>
                     {% endif %}


### PR DESCRIPTION
**Fixes and small UX improvements for the codebook and upload pages**

- Empty corpus or blank transcripts now show a helpful error instead of crashing
- Saving a codebook without changes no longer creates a duplicate
- Uploading a file that parses but stores nothing shows a warning instead of a green tick
- Leaving the editor mid-edit asks for confirmation before navigating away
- Blank codebook names are caught before submission
- Progress page shows how many passages have been processed
