### PR TITLE
Implement full transcript viewing feature with UI and backend updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ uv.lock
 
 # Python virtual environments
 venv/
+.venv/
 
 # pytest coverage
 .coverage

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -96,6 +96,14 @@ class FakeBackend:
         self._maybe_raise("delete_document")
         self.documents = [d for d in self.documents if d["id"] != document_id]
 
+    def get_document_content(self, corpus_id: str, document_id: str) -> dict:
+        self._maybe_raise("get_document_content")
+        for d in self.documents:
+            if d["id"] == document_id:
+                return {**d, "content": d.get("content", "")}
+        from web.services.backend_client import BackendNotFoundError
+        raise BackendNotFoundError(user_message="Transcript not found.")
+
     # ---- Codebooks / themes -------------------------------------------------
 
     def delete_codebook(self, codebook_id: str) -> None:

--- a/Frontend/tests/test_ingestion.py
+++ b/Frontend/tests/test_ingestion.py
@@ -283,3 +283,38 @@ def test_delete_transcript_backend_error(client, fake_backend):
     resp = client.post(f"/transcripts/{CORPUS}/doc-1/delete", follow_redirects=True)
     assert resp.status_code == 200
     assert b"simulated delete_document failure" in resp.data
+
+
+# GET /transcripts/<corpus_id>/<document_id>/view
+
+
+def test_view_transcript_renders_full_content(client, fake_backend):
+    fake_backend.documents = [
+        {
+            "id": "doc-1",
+            "title": "Interview Alpha",
+            "filename": "alpha.txt",
+            "created_at": "2026-05-12T10:00:00Z",
+            "content": "Interviewer: How are you?\nParticipant: Fine, thanks.",
+        }
+    ]
+    resp = client.get(f"/transcripts/{CORPUS}/doc-1/view")
+    assert resp.status_code == 200
+    assert b"Interview Alpha" in resp.data
+    assert b"How are you?" in resp.data
+    assert b"Fine, thanks." in resp.data
+    assert b"alpha.txt" in resp.data
+
+
+def test_view_transcript_not_found_redirects(client, fake_backend):
+    fake_backend.documents = []
+    resp = client.get(f"/transcripts/{CORPUS}/missing-id/view", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Transcript not found" in resp.data
+
+
+def test_view_transcript_backend_error_redirects(client, fake_backend):
+    fake_backend.raise_on = "get_document_content"
+    resp = client.get(f"/transcripts/{CORPUS}/doc-1/view", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"simulated get_document_content failure" in resp.data

--- a/Frontend/web/controllers/ingestion.py
+++ b/Frontend/web/controllers/ingestion.py
@@ -3,6 +3,7 @@ from flask import Blueprint, current_app, flash, redirect, render_template, requ
 
 from web.services.backend_client import (
     BackendError,
+    BackendNotFoundError,
     BackendValidationError,
     get_backend_client as _backend,
 )
@@ -214,6 +215,24 @@ def list_transcripts(corpus_id: str) -> str:
         corpus_id=active_corpus_id,
         corpus_options=corpus_options,
         active_corpus_name=active_corpus_name,
+    )
+
+
+@bp.get("/<corpus_id>/<document_id>/view")
+def view_transcript(corpus_id: str, document_id: str) -> str:
+    set_active_corpus_id(corpus_id)
+    try:
+        document = _backend().get_document_content(corpus_id, document_id)
+    except BackendNotFoundError:
+        flash("Transcript not found.", "danger")
+        return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
+    return render_template(
+        "ingestion/view.html",
+        document=document,
+        corpus_id=corpus_id,
     )
 
 

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -166,6 +166,9 @@ class BackendClient:
         except (json.JSONDecodeError, KeyError) as exc:
             self._handle_exc(exc, path, "DELETE", started_at)
 
+    def get_document_content(self, corpus_id: str, document_id: str) -> dict:
+        return self._get(f"/ingestion/corpora/{corpus_id}/documents/{document_id}")
+
     # ---- Codebooks ----------------------------------------------------------
 
 

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -628,3 +628,18 @@
 }
 .ata-toast-title { font-weight: 600; margin-bottom: .2rem; }
 .ata-toast-body  { color: #495057; }
+
+/* ── Transcript viewer ──────────────────────────────────────────────────────── */
+.transcript-body {
+    font-size: 1rem;
+    line-height: 1.75;
+    color: #212529;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
+.transcript-speaker {
+    color: #1e1b4b;
+    font-weight: 600;
+}

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -42,7 +42,7 @@
                href="{{ url_for('ingestion.upload_landing') }}">Upload</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint in ('ingestion.transcripts_landing', 'ingestion.list_transcripts') %}active{% endif %}"
+            <a class="nav-link {% if request.endpoint in ('ingestion.transcripts_landing', 'ingestion.list_transcripts', 'ingestion.view_transcript') %}active{% endif %}"
                href="{{ url_for('ingestion.transcripts_landing') }}">Transcripts</a>
           </li>
           <li class="nav-item">

--- a/Frontend/web/templates/ingestion/list.html
+++ b/Frontend/web/templates/ingestion/list.html
@@ -32,6 +32,10 @@
                 <td>{{ d.title }}</td>
                 <td class="text-secondary">{{ d.created_at }}</td>
                 <td class="text-end">
+                  <a href="{{ url_for('ingestion.view_transcript', corpus_id=corpus_id, document_id=d.id) }}"
+                     class="btn btn-sm btn-outline-secondary me-1">
+                    <i class="bi bi-eye"></i> View
+                  </a>
                   <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteTranscriptModal-{{ d.id }}">
                     <i class="bi bi-trash"></i> Delete
                   </button>

--- a/Frontend/web/templates/ingestion/view.html
+++ b/Frontend/web/templates/ingestion/view.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}{{ document.title }} — Transcript{% endblock %}
+
+{% block content %}
+<div class="d-flex align-items-center gap-3 mb-3">
+  <a href="{{ url_for('ingestion.list_transcripts', corpus_id=corpus_id) }}"
+     class="btn btn-sm btn-outline-secondary">
+    <i class="bi bi-arrow-left"></i> Back to Transcripts
+  </a>
+  <h1 class="h4 mb-0">{{ document.title }}</h1>
+</div>
+
+<div class="d-flex flex-wrap gap-3 mb-3 text-secondary small">
+  {% if document.filename %}
+    <span><i class="bi bi-file-text me-1"></i>{{ document.filename }}</span>
+  {% endif %}
+  <span><i class="bi bi-calendar me-1"></i>Uploaded {{ document.created_at }}</span>
+</div>
+
+<div class="bg-white border rounded-2 p-4">
+  <div id="transcript-content" class="transcript-body">{{ document.content }}</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+(function () {
+  var el = document.getElementById('transcript-content');
+  if (!el) return;
+  var text = el.textContent;
+  var speakerRe = /^([^:\n]{1,60}):\s(.+)$/;
+  function esc(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+  var html = text.split('\n').map(function (line) {
+    var m = line.match(speakerRe);
+    if (m) return '<strong class="transcript-speaker">' + esc(m[1]) + ':</strong> ' + esc(m[2]);
+    return esc(line);
+  }).join('\n');
+  el.innerHTML = html;
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
feat: add full transcript viewer (#<issue>)
  
  ## Summary

  - Add `GET /transcripts/<corpus_id>/<document_id>/view` route and `view.html` template that renders a transcript's full text
  without truncation
  - Add **View** button (eye icon) to each row in the transcript list, alongside the existing Delete button
  - Speaker labels (`Speaker: text` patterns) are detected client-side and rendered in bold/dark for visual distinction
  - Readable typography: 1rem font (≥14px), 1.75 line-height, high-contrast `#212529` on white
  - Native browser Ctrl+F search works — text is rendered directly in the DOM, not behind a canvas or virtual scroller
  - No backend changes required — `GET /api/v1/ingestion/corpora/{corpus_id}/documents/{document_id}` already returned full
  content; only the frontend client method and view layer were missing

