### PR TITLE
20 read full transcript

### DIFF
--- a/Backend/app/config.py
+++ b/Backend/app/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str = "academic_cloud"  # "academic_cloud" | "litellm"
     LLM_BASE_URL: str = "https://chat-ai.academiccloud.de/v1"
     LLM_API_KEY: str | None = None
-    LLM_MODEL: str = "gemma-3-27b-it"  # "mistral-large-3-675b-instruct-2512" or qwen variants
+    LLM_MODEL: str = "gemma-4-31b-it"  # "mistral-large-3-675b-instruct-2512" or qwen variants
     LLM_TEMPERATURE: float = 0.2
     LLM_REQUEST_TIMEOUT_S: float = 120.0  # too generous for the current test with a single interview file
 

--- a/Backend/app/services/upload_parsers.py
+++ b/Backend/app/services/upload_parsers.py
@@ -89,14 +89,28 @@ def parse_jsonl_upload(filename: str, content: bytes) -> list[DocumentInput]:
     docs: list[DocumentInput] = []
     for username, messages in participants.items():
         messages.sort(key=lambda m: m.get("message_index", 0))
-        human_turns = [
-            m for m in messages
-            if m.get("event_type") == "human_response"
-            and str(m.get("message_content", "")).strip()
-        ]
-        if not human_turns:
+        has_human = any(
+            m.get("event_type") == "human_response" and str(m.get("message_content", "")).strip()
+            for m in messages
+        )
+        if not has_human:
             continue
-        text = "\n\n".join(str(m["message_content"]) for m in human_turns)
+
+        turns = []
+        for m in messages:
+            event_type = m.get("event_type")
+            content = str(m.get("message_content", "")).strip()
+            if not content:
+                continue
+            
+            if event_type == "chatbot_response":
+                turns.append(f"Interviewer: {content}")
+            elif event_type == "human_response":
+                turns.append(f"Interviewee: {content}")
+
+        if not turns:
+            continue
+        text = "\n\n".join(turns)
         docs.append(DocumentInput(title=username, text=text))
     return docs
 

--- a/Backend/app/services/upload_parsers.py
+++ b/Backend/app/services/upload_parsers.py
@@ -102,7 +102,7 @@ def parse_jsonl_upload(filename: str, content: bytes) -> list[DocumentInput]:
             content = str(m.get("message_content", "")).strip()
             if not content:
                 continue
-            
+
             if event_type == "chatbot_response":
                 turns.append(f"Interviewer: {content}")
             elif event_type == "human_response":

--- a/Backend/app/services/upload_parsers.py
+++ b/Backend/app/services/upload_parsers.py
@@ -76,11 +76,15 @@ def parse_jsonl_upload(filename: str, content: bytes) -> list[DocumentInput]:
         try:
             record = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise UnprocessableError(f"'{filename}': invalid JSON on line {line_no}: {exc}") from exc
+            raise UnprocessableError(
+                f"'{filename}': invalid JSON on line {line_no}: {exc}"
+            ) from exc
 
         username = record.get("username")
         if not username:
-            raise UnprocessableError(f"'{filename}': line {line_no} is missing 'username'")
+            raise UnprocessableError(
+                f"'{filename}': line {line_no} is missing 'username'"
+            )
         participants.setdefault(username, []).append(record)
 
     if not participants:
@@ -90,7 +94,8 @@ def parse_jsonl_upload(filename: str, content: bytes) -> list[DocumentInput]:
     for username, messages in participants.items():
         messages.sort(key=lambda m: m.get("message_index", 0))
         has_human = any(
-            m.get("event_type") == "human_response" and str(m.get("message_content", "")).strip()
+            m.get("event_type") == "human_response"
+            and str(m.get("message_content", "")).strip()
             for m in messages
         )
         if not has_human:
@@ -99,14 +104,14 @@ def parse_jsonl_upload(filename: str, content: bytes) -> list[DocumentInput]:
         turns = []
         for m in messages:
             event_type = m.get("event_type")
-            content = str(m.get("message_content", "")).strip()
-            if not content:
+            msg_content = str(m.get("message_content", "")).strip()
+            if not msg_content:
                 continue
 
             if event_type == "chatbot_response":
-                turns.append(f"Interviewer: {content}")
+                turns.append(f"Interviewer: {msg_content}")
             elif event_type == "human_response":
-                turns.append(f"Interviewee: {content}")
+                turns.append(f"Interviewee: {msg_content}")
 
         if not turns:
             continue

--- a/Backend/tests/test-data/test_interview.txt
+++ b/Backend/tests/test-data/test_interview.txt
@@ -10,7 +10,7 @@ experiences with AI in your daily work. Feel free to ask if anything is
 unclear. The interview will take about 30 minutes. To start, could you tell me
 what kind of work you currently do and how long you have been in your role?
 
-Participant: I drive a truck. Long haul, mostly Midwest to West Coast runs.
+Interviewee: I drive a truck. Long haul, mostly Midwest to West Coast runs.
 I have been driving for twenty two years. The last nine I have been an
 owner operator with my own rig, before that I drove for two different
 carriers.
@@ -19,7 +19,7 @@ Interviewer: Thanks for that. Twenty two years is a long view of how the job
 has changed. Could you describe whether AI tools have entered your daily work,
 and if so what they look like for you?
 
-Participant: More than people on the outside probably realize. The truck
+Interviewee: More than people on the outside probably realize. The truck
 itself has a bunch of AI in it now. Lane keep assist, automatic emergency
 braking, adaptive cruise. The fleet I sometimes contract through has a
 dashcam system with AI that watches my face for drowsiness and the road for
@@ -31,7 +31,7 @@ all day.
 Interviewer: Let us start with the in cab dashcam. How does that show up in
 your day, and how do you feel about being monitored that way?
 
-Participant: It feels different than the old paper log days, that is for
+Interviewee: It feels different than the old paper log days, that is for
 sure. The camera is always on. If it detects you yawning or your eyes off
 the road for more than a few seconds it dings at you and uploads a clip.
 Then someone in an office, or these days probably another algorithm,
@@ -43,7 +43,7 @@ with, but a lot of company drivers do not have a choice.
 Interviewer: Does the system catch real problems, or does it mostly create
 new ones?
 
-Participant: Both honestly. It has caught a couple guys I know who were
+Interviewee: Both honestly. It has caught a couple guys I know who were
 genuinely nodding off and that probably saved lives. But it also flags
 things that are not real problems. Looking at your mirrors gets flagged as
 distracted driving sometimes. Eating a sandwich gets flagged. Scratching
@@ -54,7 +54,7 @@ two even when nobody is on the road just because the camera prefers it.
 Interviewer: That distinction between driving safely and driving in a way
 the camera approves of seems important. Could you say more about that?
 
-Participant: Sure. A good driver scans the mirrors constantly, looks at the
+Interviewee: Sure. A good driver scans the mirrors constantly, looks at the
 gauges, watches the road far ahead not just right in front. The camera does
 not always know the difference between scanning your environment and being
 distracted. So you have drivers who literally stop checking their mirrors
@@ -66,7 +66,7 @@ not.
 Interviewer: Have you seen any drivers face consequences from the scoring
 system that you thought were unfair?
 
-Participant: A friend of mine got let go from his carrier last year because
+Interviewee: A friend of mine got let go from his carrier last year because
 his safety score dropped below a threshold. He had no accidents in eleven
 years of driving. The score dropped because the camera kept flagging him
 for following too close on a stretch of interstate where the traffic just
@@ -78,7 +78,7 @@ That is the kind of thing that happens.
 Interviewer: Has the introduction of these systems changed your sense of
 how secure your work is, or how the future of truck driving looks?
 
-Participant: I am less worried about being replaced than I was five years
+Interviewee: I am less worried about being replaced than I was five years
 ago, honestly. The self driving truck thing has not panned out the way the
 hype said it would. The technology can handle the easy highway miles but
 the hard parts, the loading docks, the city streets, the construction
@@ -91,7 +91,7 @@ in the next ten years.
 Interviewer: Are there things about the work that you think the technology
 hype gets wrong?
 
-Participant: Yes. The hype treats driving like its just steering between
+Interviewee: Yes. The hype treats driving like its just steering between
 lines. The actual job is so much more than that. You are inspecting your
 truck, you are talking to dispatchers and shippers, you are problem
 solving when a load is wrong or a dock is backed up or your trailer has a
@@ -102,7 +102,7 @@ because the steering is what looks impressive in a demo.
 
 Interviewer: How has route planning changed with the AI tools?
 
-Participant: For better in some ways. The traffic prediction is good. It
+Interviewee: For better in some ways. The traffic prediction is good. It
 catches accidents and construction faster than the old systems. Fuel stop
 optimization is better. But the load matching is a mixed bag. The
 algorithms tend to squeeze rates because the brokers can see exactly what
@@ -114,7 +114,7 @@ is part of the reason.
 Interviewer: Could you say more about how the load matching has changed
 your earning power?
 
-Participant: When I started owner operating in 2017 I could call a broker
+Interviewee: When I started owner operating in 2017 I could call a broker
 and we would haggle a bit and there was room. Now I open the app, I see
 the loads, I see the offered rate, and if I do not take it within fifteen
 minutes someone else will. The system has more information than I do and
@@ -124,7 +124,7 @@ Other drivers have it worse.
 
 Interviewer: Has the pace or stress of the work changed with these tools?
 
-Participant: More stress. More scrutiny. Every minute is tracked now. The
+Interviewee: More stress. More scrutiny. Every minute is tracked now. The
 electronic logs were already a thing before AI got added on top, but now
 the AI is also looking at how you drive within those hours. Dispatchers
 know exactly where you are at all times. There is a lot less downtime to
@@ -135,7 +135,7 @@ quality of life out of it.
 Interviewer: How did you learn to work with these tools? Was there any
 formal training?
 
-Participant: Mostly figured it out myself. The fleet I contracted with had
+Interviewee: Mostly figured it out myself. The fleet I contracted with had
 a training video for the dashcam, basically here is the system, here is
 what gets you flagged, do not do those things. The load apps you just
 learn by using them. Older drivers struggled more, some of them retired
@@ -145,7 +145,7 @@ with phones and apps. That is a real shift in who can do this work.
 Interviewer: Is there any organization, union, or association that
 represents drivers on these tool questions?
 
-Participant: Teamsters represents some company drivers, owner operators
+Interviewee: Teamsters represents some company drivers, owner operators
 have OOIDA which advocates for us in policy. Both have raised concerns
 about the dashcams and the load board algorithms. But it is hard. Trucking
 is fragmented, there are a million small operators, and we are spread
@@ -155,7 +155,7 @@ tools are very organized. So the playing field is uneven.
 Interviewer: Are shippers or the general public aware of how much AI
 monitoring is involved in trucking now?
 
-Participant: I do not think most people have any idea. They see a truck on
+Interviewee: I do not think most people have any idea. They see a truck on
 the highway and think the driver is the only one in the truck, which is
 true physically, but there is a camera watching me, a GPS tracking me,
 software grading my every move, and an algorithm deciding what I get paid.
@@ -165,7 +165,7 @@ public has no idea how surveilled this job has become.
 Interviewer: Have you ever felt uncomfortable about something one of these
 AI tools was being used for in your work?
 
-Participant: The dashcam audio thing bothered me. Some of the systems
+Interviewee: The dashcam audio thing bothered me. Some of the systems
 record audio inside the cab. The truck is also my home for weeks at a
 time. I sleep in there, I take personal calls, I eat my meals. Having a
 microphone running while you are talking to your wife about your kids
@@ -175,7 +175,7 @@ audio piece. But a lot of drivers do not have that option.
 Interviewer: How do you feel about the broader public conversation around
 AI and trucking jobs? Does it match what you see?
 
-Participant: The conversation is mostly about self driving trucks
+Interviewee: The conversation is mostly about self driving trucks
 replacing all of us, and that is just not the main thing happening. The
 main thing happening is that AI is being used to monitor, score, and
 squeeze the drivers who are already doing the job. That is much less
@@ -186,7 +186,7 @@ never been in a truck. You can tell when you read it.
 Interviewer: If you could change one thing about how AI has been rolled
 out in trucking, what would it be?
 
-Participant: I would have drivers in the room when these tools are
+Interviewee: I would have drivers in the room when these tools are
 designed and evaluated. We know what the job actually is. The vendors
 selling these systems do not. If you involved experienced drivers you
 would build tools that catch real safety problems without creating fake
@@ -197,7 +197,7 @@ we are not at the table.
 
 Interviewer: What about regulation or government policy?
 
-Participant: A few things. First, limits on what these monitoring systems
+Interviewee: A few things. First, limits on what these monitoring systems
 can record, especially audio inside the sleeper. Second, some kind of due
 process when an algorithm decides to dock your pay or end your contract.
 You should be able to appeal to a human who actually understands driving.
@@ -209,7 +209,7 @@ platform with a lot of power.
 Interviewer: Has your overall feeling about AI at work shifted over the
 past couple years, or stayed roughly the same?
 
-Participant: Gotten more skeptical. I started out neutral, thinking some
+Interviewee: Gotten more skeptical. I started out neutral, thinking some
 of it would help with safety and some of it would not, no big deal. Now I
 see how much of it is really about control and squeezing margins out of
 workers. The safety framing is often a cover. If the goal was really
@@ -220,7 +220,7 @@ call it safety.
 Interviewer: Do you have advice for someone entering trucking today,
 knowing what you know?
 
-Participant: Yes. Go into it with your eyes open. The romance of the open
+Interviewee: Yes. Go into it with your eyes open. The romance of the open
 road is real on some days and gone on others. You are going to be
 monitored constantly. The pay is not what it used to be in real terms.
 Owner operator is harder than it was. If you do go in, find a community of
@@ -233,7 +233,7 @@ not.
 Interviewer: Is there anything we have not covered that you think is
 important about how AI is showing up in your work?
 
-Participant: One thing. There is a loneliness to all this that is
+Interviewee: One thing. There is a loneliness to all this that is
 different from the loneliness drivers always had. You used to feel alone
 because you were physically alone in a truck for days at a time. Now you
 feel alone because you are surrounded by systems watching you but nobody
@@ -246,7 +246,7 @@ Interviewer: That is a striking way to put it, and not something I have
 heard described that way before. Thank you for taking the time to share
 all of this. Your perspective has been thoughtful and helpful.
 
-Participant: You are welcome. Honestly it was good to think this through
+Interviewee: You are welcome. Honestly it was good to think this through
 out loud. Most days I just drive and I do not get to put words to what is
 changing. I hope it is useful to somebody. Tell them to listen to drivers
 once in a while. We know things.

--- a/Backend/tests/test_upload_parsing.py
+++ b/Backend/tests/test_upload_parsing.py
@@ -37,13 +37,13 @@ def test_jsonl_one_document_per_participant():
     assert len(docs) == 2
 
 
-def test_jsonl_text_contains_only_human_responses():
+def test_jsonl_text_contains_chatbot_and_human_responses():
     docs = parse_jsonl_upload("interview.jsonl", _make_jsonl(*_SAMPLE))
     p001 = next(d for d in docs if d.title == "p001")
-    assert "I am fine." in p001.text
-    assert "Not much else." in p001.text
-    assert "How are you?" not in p001.text
-    assert "Tell me more." not in p001.text
+    assert "Interviewee: I am fine." in p001.text
+    assert "Interviewee: Not much else." in p001.text
+    assert "Interviewer: How are you?" in p001.text
+    assert "Interviewer: Tell me more." in p001.text
 
 
 def test_jsonl_messages_sorted_by_index():

--- a/Frontend/web/__init__.py
+++ b/Frontend/web/__init__.py
@@ -43,6 +43,105 @@ def create_app(config: Config | None = None) -> Flask:
     app.register_blueprint(codebooks_bp, url_prefix="/codebooks")
     app.register_blueprint(analysis_bp, url_prefix="/analysis")
 
+    @app.template_filter('highlight_speakers')
+    def highlight_speakers_filter(text):
+        """Add a Q/A role badge before every non-blank line of a transcript.
+
+        Two modes, auto-detected:
+        1. Labelled transcripts — lines that begin with a recognisable speaker
+           label ("Interviewer:", "I:", "P:", …) get a badge derived from the
+           label (Q for interviewers, A for interviewees).
+        2. Plain transcripts — no speaker labels present.  Every non-blank
+           paragraph is assigned Q/A by alternating, starting with Q.
+        """
+        if not text:
+            return text
+        import re
+        from markupsafe import Markup, escape
+
+        INTERVIEWER_KEYWORDS = {
+            "interviewer", "moderator", "facilitator", "researcher",
+            "investigator", "int", "i", "mod", "r",
+        }
+
+        # Matches a speaker label at the very start of a line: "Name:"
+        SPEAKER_RE = re.compile(r"^([ \t]*)([A-Za-z0-9 _\.\-]{1,40}):", re.MULTILINE)
+
+        escaped = str(escape(text))
+        all_lines = escaped.splitlines(keepends=True)
+
+        # ── Detect whether this transcript uses explicit speaker labels ───────
+        labelled_count = sum(1 for ln in all_lines if SPEAKER_RE.match(ln))
+        has_labels = labelled_count >= max(1, len([l for l in all_lines if l.strip()]) // 4)
+
+        def make_badge(is_q):
+            cls = "q" if is_q else "a"
+            letter = "Q" if is_q else "A"
+            return (
+                f'<span class="transcript-badge transcript-badge--{cls}">{letter}</span>'
+            )
+
+        result = []
+
+        if has_labels:
+            # ── Mode 1: use explicit speaker labels ───────────────────────────
+            for line in all_lines:
+                m = SPEAKER_RE.match(line)
+                if m:
+                    indent = m.group(1)
+                    speaker = m.group(2)
+                    rest = line[m.end():]
+                    normalised = speaker.strip().lower()
+                    is_q = normalised in INTERVIEWER_KEYWORDS
+                    cls = "q" if is_q else "a"
+                    result.append(
+                        f'{indent}{make_badge(is_q)}'
+                        f'<span class="transcript-speaker transcript-speaker--{cls}">{speaker}</span>'
+                        f'<span class="transcript-colon">:</span>'
+                        f'{rest}'
+                    )
+                else:
+                    result.append(line)
+        else:
+            # ── Mode 2: alternate Q/A on every non-blank paragraph ────────────
+            # Group consecutive non-blank lines into paragraphs.
+            paragraphs = []   # list of (start_idx, end_idx_exclusive, is_blank)
+            i = 0
+            while i < len(all_lines):
+                if all_lines[i].strip():
+                    j = i
+                    while j < len(all_lines) and all_lines[j].strip():
+                        j += 1
+                    paragraphs.append((i, j, False))
+                    i = j
+                else:
+                    # blank run
+                    j = i
+                    while j < len(all_lines) and not all_lines[j].strip():
+                        j += 1
+                    paragraphs.append((i, j, True))
+                    i = j
+
+            turn = 0  # counts non-blank paragraphs; even → Q, odd → A
+            for start, end, is_blank in paragraphs:
+                if is_blank:
+                    result.extend(all_lines[start:end])
+                else:
+                    is_q = (turn % 2 == 0)
+                    badge = make_badge(is_q)
+                    for k, line in enumerate(all_lines[start:end]):
+                        if k == 0:
+                            # Badge only on the first line of the paragraph
+                            result.append(f'{badge}{line}')
+                        else:
+                            # Continuation lines: indent to align with text
+                            result.append(
+                                f'<span class="transcript-badge-spacer"></span>{line}'
+                            )
+                    turn += 1
+
+        return Markup("".join(result))
+
     _register_error_handlers(app)
 
     return app

--- a/Frontend/web/controllers/ingestion.py
+++ b/Frontend/web/controllers/ingestion.py
@@ -227,3 +227,19 @@ def delete_transcript(corpus_id: str, document_id: str):
     except BackendError as exc:
         flash(exc.user_message, "danger")
     return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
+
+
+@bp.get("/<corpus_id>/<document_id>/read")
+def read_transcript(corpus_id: str, document_id: str) -> str:
+    set_active_corpus_id(corpus_id)
+    try:
+        document = _backend().get_document_content(corpus_id, document_id)
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
+
+    return render_template(
+        "ingestion/read.html",
+        document=document,
+        corpus_id=corpus_id,
+    )

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -153,6 +153,10 @@ class BackendClient:
             sub_key="items",
         )
 
+    def get_document_content(self, corpus_id: str, document_id: str) -> dict:
+        """Fetch a single document including its full text content."""
+        return self._get(f"/ingestion/corpora/{corpus_id}/documents/{document_id}")
+
     def delete_document(self, corpus_id: str, document_id: str) -> None:
         """Delete a document from a corpus."""
         path = f"/ingestion/corpora/{corpus_id}/documents/{document_id}"

--- a/Frontend/web/templates/ingestion/list.html
+++ b/Frontend/web/templates/ingestion/list.html
@@ -32,6 +32,9 @@
                 <td>{{ d.title }}</td>
                 <td class="text-secondary">{{ d.created_at }}</td>
                 <td class="text-end">
+                  <a href="{{ url_for('ingestion.read_transcript', corpus_id=corpus_id, document_id=d.id) }}" class="btn btn-sm btn-outline-primary me-1">
+                    <i class="bi bi-file-text"></i> Read
+                  </a>
                   <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteTranscriptModal-{{ d.id }}">
                     <i class="bi bi-trash"></i> Delete
                   </button>

--- a/Frontend/web/templates/ingestion/read.html
+++ b/Frontend/web/templates/ingestion/read.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}Read Transcript: {{ document.title }}{% endblock %}
+
+{% block content %}
+<style>
+  /* ── Transcript speaker badges ──────────────────────────────────────────── */
+  .transcript-content {
+    font-family: system-ui, -apple-system, sans-serif;
+    color: #212529;
+    white-space: pre-wrap;
+    line-height: 1.8;
+  }
+
+  /* Pill badge: Q / A */
+  .transcript-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6em;
+    height: 1.6em;
+    border-radius: 50%;
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    vertical-align: middle;
+    margin-right: 0.4em;
+    flex-shrink: 0;
+  }
+
+  /* Invisible spacer to keep continuation lines aligned with badge lines */
+  .transcript-badge-spacer {
+    display: inline-block;
+    width: calc(1.6em + 0.4em);  /* badge width + margin-right */
+    visibility: hidden;
+  }
+
+  /* Interviewer / Question side — indigo */
+  .transcript-badge--q {
+    background-color: #4f46e5;
+    color: #fff;
+  }
+  .transcript-speaker--q {
+    color: #4338ca;
+    font-weight: 600;
+  }
+
+  /* Interviewee / Answer side — teal */
+  .transcript-badge--a {
+    background-color: #0d9488;
+    color: #fff;
+  }
+  .transcript-speaker--a {
+    color: #0f766e;
+    font-weight: 600;
+  }
+
+  .transcript-colon {
+    color: #6b7280;
+    margin-right: 0.2em;
+  }
+
+  /* Legend row */
+  .transcript-legend {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+  .transcript-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+</style>
+
+  <div class="mb-3">
+    <a href="{{ url_for('ingestion.list_transcripts', corpus_id=corpus_id) }}" class="btn btn-sm btn-outline-secondary">
+      &larr; Back to Transcripts
+    </a>
+  </div>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-header bg-white pb-0 border-bottom-0 pt-4 px-4">
+      <h1 class="h3 mb-2">{{ document.title }}</h1>
+      {% if document.filename and document.filename != document.title %}
+        <p class="text-muted small mb-0"><i class="bi bi-file-earmark"></i> {{ document.filename }}</p>
+      {% endif %}
+
+      {# Legend — only shown if there is content to parse #}
+      {% if document.content %}
+      <div class="transcript-legend mt-3 pb-2">
+        <div class="transcript-legend-item">
+          <span class="transcript-badge transcript-badge--q">Q</span>
+          <span>Interviewer</span>
+        </div>
+        <div class="transcript-legend-item">
+          <span class="transcript-badge transcript-badge--a">A</span>
+          <span>Interviewee</span>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+    <div class="card-body p-4">
+      <div class="transcript-content fs-6">
+{{ document.content | highlight_speakers }}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    command: flask --app web:create_app run --host 0.0.0.0 --port 3000 --reload
     develop:
       watch:
         - action: sync

--- a/test_data/transcripts/transcripts_for_demographic_comma.jsonl
+++ b/test_data/transcripts/transcripts_for_demographic_comma.jsonl
@@ -1,6 +1,12 @@
-{"username":"user_delta","event_type":"human_response","message_index":1,"message_content":"I am user delta in marketing. I analyze campaign performance and audience segments."}
-{"username":"user_delta","event_type":"human_response","message_index":2,"message_content":"We are testing new messaging themes for regional outreach."}
-{"username":"user_epsilon","event_type":"human_response","message_index":1,"message_content":"I am user epsilon from product. I coordinate roadmap priorities across teams."}
-{"username":"user_epsilon","event_type":"human_response","message_index":2,"message_content":"We are preparing a release focused on workflow clarity and reporting."}
-{"username":"user_zeta","event_type":"human_response","message_index":1,"message_content":"I am user zeta in operations. I manage support escalations and process changes."}
-{"username":"user_zeta","event_type":"human_response","message_index":2,"message_content":"We are tracking cycle time and reducing incident response delays."}
+{"username":"user_delta","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_delta","event_type":"human_response","message_index":2,"message_content":"I am user delta in marketing. I analyze campaign performance and audience segments."}
+{"username":"user_delta","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_delta","event_type":"human_response","message_index":4,"message_content":"We are testing new messaging themes for regional outreach."}
+{"username":"user_epsilon","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_epsilon","event_type":"human_response","message_index":2,"message_content":"I am user epsilon from product. I coordinate roadmap priorities across teams."}
+{"username":"user_epsilon","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_epsilon","event_type":"human_response","message_index":4,"message_content":"We are preparing a release focused on workflow clarity and reporting."}
+{"username":"user_zeta","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_zeta","event_type":"human_response","message_index":2,"message_content":"I am user zeta in operations. I manage support escalations and process changes."}
+{"username":"user_zeta","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_zeta","event_type":"human_response","message_index":4,"message_content":"We are tracking cycle time and reducing incident response delays."}

--- a/test_data/transcripts/transcripts_for_demographic_semicolon.jsonl
+++ b/test_data/transcripts/transcripts_for_demographic_semicolon.jsonl
@@ -1,6 +1,12 @@
-{"username":"user_alpha","event_type":"human_response","message_index":1,"message_content":"I am user alpha and I work in engineering. I collaborate closely with design and research."}
-{"username":"user_alpha","event_type":"human_response","message_index":2,"message_content":"My current focus is improving onboarding and reducing operational overhead."}
-{"username":"user_beta","event_type":"human_response","message_index":1,"message_content":"I am user beta from the design team. I lead interface prototyping."}
-{"username":"user_beta","event_type":"human_response","message_index":2,"message_content":"Our biggest challenge is aligning design handoff with engineering timelines."}
-{"username":"user_gamma","event_type":"human_response","message_index":1,"message_content":"I am user gamma and part of research. I run interview studies with participants."}
-{"username":"user_gamma","event_type":"human_response","message_index":2,"message_content":"We synthesize findings and share them with product and engineering weekly."}
+{"username":"user_alpha","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_alpha","event_type":"human_response","message_index":2,"message_content":"I am user alpha and I work in engineering. I collaborate closely with design and research."}
+{"username":"user_alpha","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_alpha","event_type":"human_response","message_index":4,"message_content":"My current focus is improving onboarding and reducing operational overhead."}
+{"username":"user_beta","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_beta","event_type":"human_response","message_index":2,"message_content":"I am user beta from the design team. I lead interface prototyping."}
+{"username":"user_beta","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_beta","event_type":"human_response","message_index":4,"message_content":"Our biggest challenge is aligning design handoff with engineering timelines."}
+{"username":"user_gamma","event_type":"chatbot_response","message_index":1,"message_content":"Can you tell me about your role and what you do?"}
+{"username":"user_gamma","event_type":"human_response","message_index":2,"message_content":"I am user gamma and part of research. I run interview studies with participants."}
+{"username":"user_gamma","event_type":"chatbot_response","message_index":3,"message_content":"What are you currently working on?"}
+{"username":"user_gamma","event_type":"human_response","message_index":4,"message_content":"We synthesize findings and share them with product and engineering weekly."}


### PR DESCRIPTION
- Read button added to the transcript list — clicking it opens the full transcript
- Q/A role badges displayed before each line to visually distinguish the interviewer (indigo Q) from the interviewee (teal A)
Auto-detects transcript format: transcripts with explicit speaker labels (e.g. Interviewer:) use the label to assign the badge; plain transcripts without labels alternate Q/A per paragraph
- Speaker highlighting is done server-side using a Jinja2 template filter with proper HTML escaping (markupsafe) to prevent XSS
- Bugfix: Academic Cloud LLM model updated from gemma-3-27b-it → gemma-4-31b-it (old model was removed from the provider)