### PR TITLE
Updated Documentation

### DIFF
--- a/Documentation/Backend-Routes.md
+++ b/Documentation/Backend-Routes.md
@@ -1,0 +1,16 @@
+Build, user, and technical documentation
+Software architecture description
+
+Theme model reference:
+- `theme-data-type.md` (theme fields and constraints)
+- includes the theme-frequency list row shape returned by
+  `GET /codebooks/{codebook_id}/themes`
+
+Ingestion pipeline reference:
+- `ingestion-pipeline.md` (data structures, chunking, upload format, API endpoints)
+
+Demographic import pipeline reference:
+- `demographic-pipeline.md` (data structures, CSV validation rules, preview/confirm flow, API endpoints)
+
+Codebook generation reference:
+- `codebook-generation.md` (sync + async generation endpoints, job lifecycle, and selection behavior)

--- a/Documentation/Backend-Software-Architecture-and-Data-Model-Documentation.md
+++ b/Documentation/Backend-Software-Architecture-and-Data-Model-Documentation.md
@@ -1,0 +1,276 @@
+# Backend Software Architecture and Data Model Documentation
+
+Source: generated from the `classes_BackendApp.dot` pyreverse class graph.
+
+This document presents a non-decorative architectural abstraction of the backend. It separates runtime responsibilities from persistence structures and avoids implementation-specific visual clutter.
+
+## 1. Architectural Overview
+
+The backend is organized as a layered application. The observable structure indicates the following principal layers:
+
+1. **Interface layer**: request/response schemas, pagination envelopes, middleware, and validation contracts.
+2. **Application service layer**: procedural business operations for ingestion, demographic processing, theme graph computation, theme reading, and frequency aggregation.
+3. **Domain/data model layer**: SQLAlchemy-backed persistent entities representing corpora, documents, demographic files, codebooks, themes, analyses, and theme occurrences.
+4. **Infrastructure and cross-cutting layer**: configuration, logging, and domain-specific exception classes.
+
+![Layer diagram](software_architecture_mid_release.png)
+
+```mermaid
+flowchart TB
+    subgraph Interface_Layer[Interface Layer]
+        MW[RequestIdMiddleware and RequestLoggingMiddleware]
+        SC[Pydantic Schemas: requests, responses, pagination, envelopes]
+    end
+
+    subgraph Application_Service_Layer[Application Service Layer]
+        IS[IngestionService]
+        DS[DemographicService]
+        TGS[ThemeGraphService]
+        TRS[ThemeReadService]
+        TFS[ThemeFrequencyService]
+        TC[Text Chunking]
+        LLM[LLM Analysis Contracts]
+    end
+
+    subgraph Domain_Data_Model_Layer[Domain and Data Model Layer]
+        IM[Ingestion Models: Corpus, CorpusDocument]
+        DM[Demographic Models: DemographicFiles, DemographicRow]
+        CM[Codebook and Theme Models: Codebook, CodebookGenerationJob, Theme, Code, relationships]
+        AM[Analysis Models: DocumentAnalysis, ThemeOccurrence]
+        BM[Base and Timestamp Mixins]
+    end
+
+    subgraph Infrastructure_Layer[Infrastructure and Cross-Cutting Layer]
+        CFG[Settings]
+        EXC[Application Exceptions]
+        LOG[Logging Configuration]
+        DB[(Relational Database)]
+    end
+
+    MW --> SC
+    SC --> IS
+    SC --> DS
+    SC --> TGS
+    SC --> TRS
+    SC --> TFS
+
+    IS --> TC
+    IS --> IM
+    DS --> DM
+    DS --> IM
+    TGS --> CM
+    TRS --> CM
+    TFS --> AM
+    TFS --> CM
+    LLM --> AM
+
+    IM --> DB
+    DM --> DB
+    CM --> DB
+    AM --> DB
+    BM --> IM
+    BM --> DM
+    BM --> CM
+    BM --> AM
+
+    CFG --> IS
+    CFG --> DS
+    CFG --> LLM
+    EXC --> IS
+    EXC --> DS
+    EXC --> TGS
+    LOG --> MW
+```
+
+## 2. Main Service Responsibilities
+
+| Service or component | Scientific role | Primary data dependency |
+|---|---|---|
+| `IngestionService` | Creates corpora, ingests documents (`.txt`, `.docx`, `.pdf`, `.jsonl`), and lists corpus artifacts. | `Corpus`, `CorpusDocument` |
+| `DemographicService` | Imports demographic CSV-like data, confirms temporary uploads, lists demographic records, and links demographic rows to transcripts. | `DemographicFiles`, `DemographicRow`, `CorpusDocument` |
+| `ThemeGraphService` | Constructs and validates a directed acyclic graph of themes within a codebook. | `Theme`, `ThemeHierarchyRelationship`, `Codebook` |
+| `ThemeReadService` | Provides a readable tree representation of the theme hierarchy. | `Theme`, `ThemeHierarchyRelationship` |
+| `ThemeFrequencyService` | Computes aggregate theme occurrence statistics across analyses. | `ThemeOccurrence`, `Theme`, `DocumentAnalysis` |
+| `CodebookGenerationService` | Splits document content into passages at runtime, invokes the LLM pipeline per passage, and consolidates generated themes and codes into a persisted codebook. | `CodebookGenerationJob`, `Codebook`, `Theme`, `Code` |
+| LLM analysis contracts | Represent structured model output before persistence into analysis tables. | `InterviewAnalysisResult`, `ThemePresence`, `DocumentAnalysis`, `ThemeOccurrence` |
+
+## 3. Persistent Data Model
+
+The following model is a conceptual ERM derived from the class graph and the foreign-key-like attributes visible in the model classes.
+
+![Data Model Diagram](data_model_mid_release.png)
+
+```mermaid
+erDiagram
+    CORPUS ||--o{ CORPUS_DOCUMENT : contains
+    CORPUS ||--o{ CODEBOOK : has
+
+    CORPUS ||--o{ DEMOGRAPHIC_FILES : has
+    CORPUS ||--o{ DEMOGRAPHIC_ROW : has
+    DEMOGRAPHIC_FILES ||--o{ DEMOGRAPHIC_ROW : contains
+    DEMOGRAPHIC_ROW ||--o{ CORPUS_DOCUMENT : may_link_to
+
+    CORPUS_DOCUMENT ||--o{ DOCUMENT_ANALYSIS : has
+    CODEBOOK ||--o{ DOCUMENT_ANALYSIS : constrains
+
+    CODEBOOK ||--o{ CODEBOOK_THEME_RELATIONSHIP : has
+    THEME ||--o{ CODEBOOK_THEME_RELATIONSHIP : participates_in
+
+    CODEBOOK ||--o{ THEME_HIERARCHY_RELATIONSHIP : scopes
+    THEME ||--o{ THEME_HIERARCHY_RELATIONSHIP : parent_role
+    THEME ||--o{ THEME_HIERARCHY_RELATIONSHIP : child_role
+
+    CODEBOOK ||--o{ CODEBOOK_GENERATION_JOB : produced_by
+
+    DOCUMENT_ANALYSIS ||--o{ THEME_OCCURRENCE : produces
+    THEME ||--o{ THEME_OCCURRENCE : observed_as
+
+    CORPUS {
+        UUID id PK
+        UUID project_id
+        string name
+        datetime created_at
+        datetime updated_at
+    }
+
+    CORPUS_DOCUMENT {
+        UUID id PK
+        UUID corpus_id FK
+        UUID demographic_row_id FK
+        string title
+        string filename_optional
+        text content
+        datetime created_at
+        datetime updated_at
+    }
+
+    DEMOGRAPHIC_FILES {
+        UUID id PK
+        UUID corpus_id FK
+        string name
+        list original_columns
+        datetime created_at
+        datetime updated_at
+    }
+
+    DEMOGRAPHIC_ROW {
+        UUID id PK
+        UUID corpus_id FK
+        UUID demographic_file_id FK
+        string interviewee_id
+        int row_number
+        dict data
+    }
+
+    CODEBOOK {
+        UUID id PK
+        UUID corpus_id FK
+        string name
+        string description_optional
+        int version
+        string created_by
+        datetime created_at
+        datetime updated_at
+    }
+
+    CODEBOOK_GENERATION_JOB {
+        UUID id PK
+        string status
+        string codebook_name
+        UUID corpus_id
+        text transcript_document_ids_json
+        bool cancel_requested
+        UUID codebook_id_optional
+        int passages_total
+        int passages_done
+        string error_message_optional
+        datetime started_at_optional
+        datetime finished_at_optional
+        datetime created_at
+        datetime updated_at
+    }
+
+    THEME {
+        UUID id PK
+        UUID codebook_id FK
+        string label
+        string description_optional
+        bool is_active
+        datetime created_at
+        datetime updated_at
+    }
+
+    CODEBOOK_THEME_RELATIONSHIP {
+        UUID id PK
+        UUID codebook_id FK
+        UUID theme_id FK
+        bool is_active
+        datetime created_at
+        datetime updated_at
+    }
+
+    THEME_HIERARCHY_RELATIONSHIP {
+        UUID id PK
+        UUID codebook_id FK
+        UUID parent_theme_id FK
+        UUID child_theme_id FK
+        bool is_active
+        datetime created_at
+        datetime updated_at
+    }
+
+    DOCUMENT_ANALYSIS {
+        UUID id PK
+        UUID document_id FK
+        UUID codebook_id FK
+        string summary_optional
+        string researcher_notes_optional
+        datetime created_at
+        datetime updated_at
+    }
+
+    THEME_OCCURRENCE {
+        UUID id PK
+        UUID analysis_id FK
+        UUID theme_id FK
+        bool is_present
+        float confidence
+        string quote_optional
+        datetime created_at
+        datetime updated_at
+    }
+```
+
+## 4. Entity Catalogue
+
+### 4.1 Corpus and document ingestion
+
+| Entity | Description | Key attributes |
+|---|---|---|
+| `Corpus` | Logical collection of source documents within a project. | `id`, `project_id`, `name` |
+| `CorpusDocument` | A single ingested document or transcript. Stores both metadata and the full document text. It may be linked to one demographic row. | `id`, `corpus_id`, `demographic_row_id`, `title`, `filename`, `content` |
+
+### 4.2 Demographic data
+
+| Entity | Description | Key attributes |
+|---|---|---|
+| `DemographicFiles` | Imported demographic file metadata and original column structure. | `id`, `corpus_id`, `name`, `original_columns` |
+| `DemographicRow` | One normalized row of imported demographic data. | `id`, `corpus_id`, `demographic_file_id`, `interviewee_id`, `row_number`, `data` |
+
+### 4.3 Codebook and theme graph
+
+| Entity | Description | Key attributes |
+|---|---|---|
+| `Codebook` | Versioned coding framework associated with a corpus. | `id`, `corpus_id`, `name`, `description`, `version`, `created_by` |
+| `CodebookGenerationJob` | Background job that generates a codebook from corpus transcripts via the LLM pipeline. | `id`, `status`, `codebook_name`, `corpus_id`, `cancel_requested`, `passages_total`, `passages_done`, `codebook_id`, `error_message` |
+| `Theme` | A node in the codebook hierarchy (theme, subtheme, or code label). | `id`, `codebook_id`, `label`, `description`, `is_active` |
+| `CodebookThemeRelationship` | Association table mapping themes into codebooks. | `id`, `codebook_id`, `theme_id`, `is_active` |
+| `ThemeHierarchyRelationship` | Directed edge between parent and child themes within a codebook. | `id`, `codebook_id`, `parent_theme_id`, `child_theme_id`, `is_active` |
+
+### 4.4 Analysis
+
+| Entity | Description | Key attributes |
+|---|---|---|
+| `DocumentAnalysis` | Analysis result for a document under a specific codebook. | `id`, `document_id`, `codebook_id`, `summary`, `researcher_notes` |
+| `ThemeOccurrence` | Observation of a theme within a document analysis, including evidence and confidence. | `id`, `analysis_id`, `theme_id`, `is_present`, `confidence`, `quote` |
+

--- a/Documentation/Build-&-Deploy.md
+++ b/Documentation/Build-&-Deploy.md
@@ -1,0 +1,308 @@
+
+End-to-end guide for getting the Automated Thematic Analysis stack running, configured, and verified. Synthesises the existing per-service READMEs:
+
+- [Root README](../README.md) — high-level overview and bootstrap scripts
+- [Backend/README.md](../Backend/README.md) — FastAPI service detail
+- [Frontend/README.md](../Frontend/README.md) — Flask UI detail
+
+## Architecture at a glance
+
+Three services are defined in [`docker-compose.yml`](../docker-compose.yml) at the repository root:
+
+| Service | Image / target | Host port | Purpose |
+|---|---|---|---|
+| `db` | `postgres:16-alpine` | `5433` | PostgreSQL 16 with named volume `pgdata` |
+| `api` | `Backend/Dockerfile` → `runtime` | `8000` (`APP_PORT`) | FastAPI backend, async SQLAlchemy, LangChain |
+| `frontend` | `Frontend/Dockerfile` → `runtime` | `3000` (`FRONTEND_PORT`) | Flask + Jinja UI |
+
+Plus two test-only services (`api-test`, `frontend-test`) gated behind the `test` Docker Compose profile.
+
+The frontend talks to the backend over the internal Docker network at `http://api:8000/api/v1` (set on the `frontend` service). The backend reads its DB URL from `Backend/.env` but Compose overrides it to point at `db:5432` inside the network, so a single `Backend/.env` works for both local and containerised runs.
+
+## Prerequisites
+
+Required:
+
+- **Docker Engine** (with Compose v2 — verify with `docker compose version`)
+
+Optional, only needed for native development without Docker:
+
+- **Python 3.11+**
+- **[uv](https://docs.astral.sh/uv/)** (recommended) or `pip`
+- A local PostgreSQL 16 instance if you don't want to run the `db` container
+
+An **LLM API key** is required for codebook generation features. Either:
+
+- **NHR@FAU** gateway — request at <https://hpc.fau.de/request-llm-api-key/> (default)
+- **GWDG Academic Cloud** — alternative provider
+
+You only need one of the two.
+
+## Quick deploy (recommended)
+
+From the repository root:
+
+**Linux / macOS / Git Bash on Windows:**
+
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+
+**Windows PowerShell:**
+
+```powershell
+.\setup.ps1
+```
+
+What the script does:
+
+1. Verifies Docker Engine and Compose v2 are installed and the daemon is running.
+2. Creates `Backend/.env` from `Backend/.env.example` if it doesn't yet exist.
+3. Runs `docker compose build` then `docker compose up -d`.
+4. Polls the API's `/api/v1/health/ready` endpoint until it returns 200, then prints the service URLs.
+
+**One mandatory follow-up:** open `Backend/.env` and set your LLM API key. The bootstrap leaves the placeholder values (`<your_nhr_fau_key_here>` etc.) intentionally so the stack starts even before you've requested a key. Until you fill it in, codebook generation will fail with a clear error in the job runner.
+
+Common bootstrap-script options (run with `--help` for the full list):
+
+| Task | Linux / macOS | Windows PowerShell |
+|---|---|---|
+| Start stack (detached) | `./setup.sh` | `.\setup.ps1` |
+| Start with foreground logs | `./setup.sh -f` | `.\setup.ps1 -Foreground` |
+| Run the test suites | `./setup.sh --test` | `.\setup.ps1 -Test` |
+| Stop the stack | `./setup.sh --down` | `.\setup.ps1 -Down` |
+| Stop and **wipe the DB volume** | `./setup.sh --down-volumes` | `.\setup.ps1 -DownVolumes` |
+
+## Manual deploy
+
+If you'd rather drive Docker Compose directly:
+
+```bash
+# 1. Configure
+cp Backend/.env.example Backend/.env
+# Edit Backend/.env — at minimum set LLM_API_KEY_FAU (or LLM_API_KEY for Academic Cloud)
+
+# 2. Build + start
+docker compose up --build -d
+
+# 3. Wait for the api container to report healthy
+docker compose ps
+
+# 4. Tail logs if anything looks off
+docker compose logs api --tail=50 -f
+```
+
+Once `db`, `api`, and `frontend` are all healthy, the URLs are:
+
+| Surface | URL |
+|---|---|
+| Frontend UI | <http://localhost:3000> |
+| Backend API | <http://localhost:8000> |
+| API docs (Swagger) | <http://localhost:8000/docs> |
+| Health check (ready) | <http://localhost:8000/api/v1/health/ready> |
+
+## Configuration
+
+All configuration is environment-driven via `Backend/.env` (the frontend reads `BACKEND_API_URL` from its Compose environment block; see [docker-compose.yml](../docker-compose.yml)).
+
+### Backend — `Backend/.env`
+
+The full list of variables is documented in [`Backend/.env.example`](../Backend/.env.example). The most important ones:
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `LLM_API_KEY_FAU` | yes (if `SELECTED_API=FAU`) | — | NHR@FAU gateway key |
+| `LLM_API_KEY` | yes (if `SELECTED_API=ACADEMIC`) | — | Academic Cloud key |
+| `SELECTED_API` | no | `FAU` | `FAU` or `ACADEMIC` |
+| `LLM_MODEL_FAU` | no | `gpt-oss-120b` | Override to use a different FAU-hosted model |
+| `LLM_MODEL` | no | `gemma-3-27b-it` | Override for Academic Cloud |
+| `LLM_REQUEST_TIMEOUT_S` | no | `120.0` | Raise if you hit timeouts on large corpora |
+| `DATABASE_URL` | no inside Docker | `postgresql+asyncpg://postgres:postgres@localhost:5433/appdb` | Compose overrides this with `db:5432` automatically |
+| `CORS_ALLOWED_ORIGINS` | no | `["http://localhost:3000"]` | JSON array of allowed origins |
+| `APP_PORT` | no | `8000` | Host port for the API; Compose maps `${APP_PORT}:8000` |
+| `LOG_LEVEL` | no | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
+
+### Frontend (set in Compose, not in a `.env`)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `BACKEND_API_URL` | `http://api:8000/api/v1` | Internal Docker DNS — don't change for in-Compose deploys |
+| `BACKEND_TIMEOUT_S` | `60.0` | HTTP client timeout |
+| `APP_ENV` | `development` | Set to `production` for prod deploys |
+| `SECRET_KEY` | `dev-secret` | **Change for production.** |
+| `MAX_UPLOAD_SIZE_MB` | `10` | Per-file upload cap |
+| `FRONTEND_PORT` | `3000` | Host port |
+
+## Verification
+
+After the stack starts, run through these checks in order. Each fails fast and points to a specific service if something's wrong.
+
+1. **Containers up + healthy.**
+
+   ```bash
+   docker compose ps
+   ```
+
+   `db`, `api`, `frontend` should all read `Up`. The `api` row reports its health check status; wait for `Healthy`.
+
+2. **Backend readiness.**
+
+   ```bash
+   curl -fsS http://localhost:8000/api/v1/health/ready
+   ```
+
+   Returns `{"success": true, "data": {"status": "ready"}, ...}`. A 502 means `api` hasn't finished startup; a connection refused means port mapping is off.
+
+3. **Database schema initialised.**
+
+   ```bash
+   docker compose logs api | grep -E "schema (initialization|verification)"
+   ```
+
+   Look for `Database schema initialization completed`. If you see `Missing tables: ...` you have a schema-drift issue — wipe the volume (see Troubleshooting).
+
+4. **LLM connectivity.** From the `api` container:
+
+   ```bash
+   docker compose cp Backend/scripts/test_nhr_fau_api.py api:/app/test_nhr_fau_api.py
+   docker compose exec api python test_nhr_fau_api.py
+   ```
+
+   Should print `✅ API call succeeded!` plus a short generated sentence. If it fails:
+
+   - `No API key set for SELECTED_API='FAU'` → key missing in `Backend/.env`; edit and `docker compose restart api`.
+   - Connection / timeout → check VPN or campus-only network restrictions.
+   - 401 / 403 → key invalid or expired.
+
+5. **Frontend reachable.**
+
+   ```bash
+   curl -fsS http://localhost:3000/health
+   ```
+
+   Returns `OK`. Open <http://localhost:3000> in a browser to confirm the UI renders.
+
+6. **End-to-end smoke (UI).** From the home page:
+
+   1. **Upload** → drop a small `.txt`, `.jsonl`, `.docx`, or `.pdf` interview file (one of the samples under `Backend/tests/test-data/` works).
+   2. **Codebooks** → "Create New Codebook" → "Fully automatic" → name → Confirm.
+   3. Progress page should tick from `queued` → `running` → `succeeded` and redirect to the codebook list with the new codebook visible.
+
+## Iteration
+
+While developing, you usually want to rebuild only one service:
+
+```bash
+# Backend only
+docker compose build api && docker compose up -d --no-deps api
+
+# Frontend only
+docker compose build frontend && docker compose up -d --no-deps frontend
+```
+
+Compose's `develop.watch` is configured for both services to **sync source changes** (`Backend/app/` and `Frontend/web/`) into the running containers — no rebuild needed for code changes once `docker compose watch` is running.
+
+## Tests
+
+Both services have their own test suites; both run inside Docker via the `test` profile.
+
+```bash
+# Run all tests (both backend and frontend), backed by the live db container
+docker compose --profile test up -d db
+docker compose --profile test run --rm api-test       # backend
+docker compose --profile test run --rm frontend-test  # frontend
+```
+
+Or via the bootstrap script:
+
+```bash
+./setup.sh --test
+```
+
+**Backend** runs `pytest` with coverage; the HTML report is written to `Backend/htmlcov/` on the host via volume mount.
+
+**Frontend** uses a `FakeBackend` fixture so no live backend is required for the test container.
+
+## Stack lifecycle
+
+```bash
+# Stop the stack but keep containers + volumes
+docker compose stop
+
+# Stop and remove containers (DB volume preserved)
+docker compose down
+
+# Stop, remove containers AND wipe the DB volume (loses all uploaded transcripts and codebooks)
+docker compose down -v
+```
+
+## Production considerations
+
+The default Compose file is set up for **local development**: hot reload enabled (`--reload` on uvicorn, `FLASK_DEBUG=1`), default secrets, the API and DB ports exposed on the host. For a production-shaped deploy:
+
+1. **Disable hot reload** by overriding the `api` service `command` to drop `--reload`, and set `FLASK_DEBUG=0`, `APP_ENV=production` on the `frontend` service.
+2. **Set a real `SECRET_KEY`** on the frontend (used to sign Flask sessions).
+3. **Don't expose the DB port** (`5433`) externally — drop the `db.ports` mapping.
+4. **Pin LLM and DB credentials** via your platform's secret store rather than `Backend/.env` on disk.
+5. **Build with `--no-cache`** for repeatable images, and tag explicitly (e.g. `docker build -t ata-api:v1.0 ./Backend`) instead of letting Compose name them.
+6. **Run migrations / schema bootstrap intentionally.** The backend currently uses `Base.metadata.create_all` at startup ([Backend/app/database.py](../Backend/app/database.py)) which only creates *missing* tables — it never alters existing ones. Treat schema changes as a destructive operation (`docker compose down -v`) until Alembic is added. See Troubleshooting for the failure mode this causes.
+7. **Persist `pgdata`** to a managed volume (e.g. mounted cloud disk) rather than the Docker-managed `pgdata` volume.
+
+## Troubleshooting
+
+### Schema drift after pulling new commits
+
+**Symptom:** any request that touches a recently-added column fails with `UndefinedColumnError`, e.g. `column "demographic_row_id" of relation "corpus_documents" does not exist`.
+
+**Cause:** The backend uses `Base.metadata.create_all` at startup. It only creates *missing tables*, never adds new columns to existing ones. If your local `pgdata` volume was created before the schema change, the column will never appear.
+
+**Fix:**
+
+```bash
+docker compose down -v        # destroys the pgdata volume
+docker compose up --build
+```
+
+You lose any local data; reupload your transcripts.
+
+### "Backend unreachable" in the UI
+
+Either the `api` container isn't healthy yet (see Verification step 1), or the `frontend` service has the wrong `BACKEND_API_URL`. Inside the Compose network it must be `http://api:8000/api/v1` (the service name, not `localhost`).
+
+### Cache cleanup if the UI looks stale
+
+Walk down this table from cheap to nuclear. From [Frontend/README.md](../Frontend/README.md#cache-cleanup--if-the-ui-looks-stale):
+
+| # | Layer | Fix |
+|---|---|---|
+| 1 | Browser cache | Hard refresh: `Ctrl + Shift + R` (or Incognito) |
+| 2 | Frontend image | `docker compose build --no-cache frontend && docker compose up -d --no-deps frontend` |
+| 3 | Docker BuildKit cache | `docker builder prune -af`, then redo step 2 |
+| 4 | Python bytecode (local dev only) | `find . -name __pycache__ -type d -exec rm -rf {} +` |
+| 5 | Full reset (keeps DB volume) | `docker compose down && docker builder prune -af && docker compose build --no-cache && docker compose up -d` |
+
+Avoid `docker system prune -af --volumes` unless you actually want a blank database too — it drops `pgdata`.
+
+### Codebook generation fails with `ForeignKeyViolationError`
+
+**Symptom:** the codebook generation job moves from `running` to `failed`, with `error_message` along the lines of `insert or update on table "codes" violates foreign key constraint "codes_codebook_id_fkey"`.
+
+**Cause:** SQLAlchemy unit-of-work autoflush ordering can interleave parent and child INSERTs incorrectly when the model graph lacks explicit `relationship()` declarations. The persistence path in [`Backend/app/services/codebook_generation.py`](../Backend/app/services/codebook_generation.py) uses a layered-flush pattern (`session.flush()` between each dependency layer) to work around this. If you see this error, confirm the patched version is what's deployed; recent versions on `main` include the fix.
+
+### Port already in use
+
+The compose file falls back to defaults `8000` (API) and `3000` (frontend). To override without editing files:
+
+```bash
+APP_PORT=8001 FRONTEND_PORT=3001 docker compose up -d
+```
+
+## Where to look next
+
+- [Backend README](../Backend/README.md) — project structure, response envelope, in-Docker test runs
+- [Frontend README](../Frontend/README.md) — page-by-page routes, error-handling model, Dockerfile build stages
+- [`Documentation/ingestion-pipeline.md`](./ingestion-pipeline.md) — corpus / document / chunk data model and ingest API
+- [`Documentation/codebook-generation.md`](./codebook-generation.md) — sync vs. async generation endpoints, job lifecycle
+- [`Documentation/LLM-cluster-documentation.md`](./LLM-cluster-documentation.md) — FAU GPU cluster vs. Academic Cloud notes
+- [`Documentation/csv-codebook-standard.md`](./csv-codebook-standard.md) — uploadable codebook CSV format

--- a/Documentation/Frontend-and-Routing.md
+++ b/Documentation/Frontend-and-Routing.md
@@ -1,0 +1,430 @@
+## 1. Architectural Overview
+
+The frontend is organized as a layered server-rendered application. The observable structure indicates the following principal layers:
+
+1. **Presentation layer**: Jinja2 templates, Bootstrap-5 styling, page-scoped JavaScript, and shared static assets.
+2. **Controller layer**: Flask blueprints that bind URL paths to request handlers, perform input validation, and orchestrate redirects and flash messages.
+3. **Integration layer**: an HTTP client that wraps every FastAPI backend call behind a typed error taxonomy.
+4. **Infrastructure and cross-cutting layer**: Pydantic-settings configuration, Flask error handlers, request logging, and the app factory.
+
+```mermaid
+flowchart TB
+    subgraph Presentation_Layer[Presentation Layer]
+        BASE[base.html and _flash.html]
+        TPL[Per-feature template trees: ingestion, codebooks, demographic, analysis]
+        ST[Static assets: main.css, codebook_themes.js, team-logo.svg]
+    end
+
+    subgraph Controller_Layer[Controller Layer]
+        MAIN[main blueprint: index, health]
+        ING[ingestion blueprint: transcripts and upload]
+        DEM[demographic blueprint: CSV import + preview + confirm]
+        CB[codebooks blueprint: list, themes]
+        AN[analysis blueprint: placeholder]
+    end
+
+    subgraph Integration_Layer[Integration Layer]
+        BC[BackendClient: pooled httpx.Client]
+        ENV[ResponseEnvelope unwrap]
+        ERR[BackendError taxonomy: Unavailable, NotFound, Validation, ServerError]
+    end
+
+    subgraph Infrastructure_Layer[Infrastructure and Cross-Cutting Layer]
+        FAC[App factory and blueprint registration]
+        CFG[Config: pydantic-settings]
+        EH[Error handlers: 404, 413, generic 500]
+        LOG[Logging via stdlib + Flask logger]
+        API[(FastAPI Backend)]
+    end
+
+    BASE --> TPL
+    ST --> BASE
+
+    MAIN --> BASE
+    ING --> TPL
+    DEM --> TPL
+    CB --> TPL
+    AN --> TPL
+
+    ING --> BC
+    DEM --> BC
+    CB --> BC
+
+    BC --> ENV
+    BC --> ERR
+    BC --> API
+
+    FAC --> MAIN
+    FAC --> ING
+    FAC --> DEM
+    FAC --> CB
+    FAC --> AN
+    FAC --> EH
+    CFG --> BC
+    CFG --> FAC
+    LOG --> BC
+```
+
+## 2. Main Component Responsibilities
+
+| Component | Role | Primary collaborators |
+|---|---|---|
+| App factory (`web/__init__.py`) | Creates the Flask application, registers blueprints under their URL prefixes, installs error handlers, lazily instantiates the shared `BackendClient`, and registers an `atexit` hook to close it on process exit. | `Config`, all blueprints, `BackendClient` |
+| `Config` (`web/config.py`) | Reads runtime configuration from environment variables via `pydantic-settings`. Defines `BACKEND_API_URL`, `BACKEND_TIMEOUT_S`, `SECRET_KEY`, `MAX_UPLOAD_SIZE_MB`, `MAX_UPLOAD_BYTES`, `MAX_CONTENT_LENGTH`, and the default workspace identifiers. | App factory, `BackendClient` |
+| `BackendClient` (`web/services/backend_client.py`) | Single point of contact with the FastAPI backend. Pools connections, unwraps the `ResponseEnvelope` via a single `_unwrap` helper, translates HTTP and network failures into typed `BackendError` subclasses, and logs one structured line per failed request. | All blueprints, FastAPI backend |
+| `main` blueprint | Renders the home page and exposes the container health check. | `templates/index.html` |
+| `ingestion` blueprint | Resolves the workspace corpus, accepts transcript uploads, and lists corpus documents. Its Uploads page also hosts the demographic CSV upload card (the form posts to the `demographic` blueprint). | `BackendClient.ensure_corpus`, `upload_files`, `list_documents`; `templates/ingestion/` |
+| `demographic` blueprint | Manages CSV demographic imports: preview, confirm, list confirmed files, view persisted rows with transcript linking. The upload **entry** lives on the `ingestion` blueprint's Uploads page; the legacy `/demographic/upload` URLs are kept as backwards-compatible redirects. | `BackendClient.upload_demographic`, `confirm_demographic`, `list_demographic_files`, `list_demographic_rows`, `get_demographic_link_summary`; `templates/demographic/` |
+| `codebooks` blueprint | Renders the codebook list and the interactive theme browser. | `BackendClient.list_codebooks`, `get_theme_frequencies`, `get_theme_tree`; `templates/codebooks/` |
+| `analysis` blueprint | Placeholder surface reserved for future analysis features. | `templates/analysis/index.html` |
+| Error handlers (`web/__init__.py`) | Translate uncaught Flask errors into branded pages: 404, 413 (oversized upload — always redirects to home, never to a user-controlled `Referer`), and generic 500 without leaking tracebacks. | `templates/errors/` |
+
+## 3. Route Catalogue
+
+All routes are server-rendered. Where a backend call is made, the client method is listed; routes without one render entirely from configuration or session state.
+
+### 3.1 `main` (no URL prefix)
+
+| Method and path | Purpose | Backend call |
+|---|---|---|
+| `GET /` | Home page with quick-link cards | — |
+| `GET /health` | Container health endpoint, returns `OK` | — |
+
+### 3.2 `ingestion` — prefix `/transcripts`
+
+| Method and path | Purpose | Backend call |
+|---|---|---|
+| `GET /transcripts/` | Resolve the default workspace corpus, then redirect to its corpus-scoped list view. | `ensure_corpus` |
+| `GET /transcripts/upload` | Same resolve-then-redirect pattern, targeting the Uploads page. | `ensure_corpus` |
+| `GET /transcripts/<corpus_id>/upload` | Render the Uploads page, which hosts **two side-by-side cards**: a multi-file picker for interview transcripts and a single-CSV picker for demographic data (the latter posts to the `demographic` blueprint). | — |
+| `POST /transcripts/<corpus_id>/upload` | Validate sizes, forward the files to the backend, render per-file results. | `upload_files` |
+| `GET /transcripts/<corpus_id>/` | List documents in a corpus. | `list_documents` |
+
+### 3.3 `demographic` — prefix `/demographic`
+
+| Method and path | Purpose | Backend call |
+|---|---|---|
+| `GET /demographic/` | Resolve corpus then redirect to its demographic list view. | `ensure_corpus` |
+| `GET /demographic/upload` | **Backwards-compatible redirect** to `/transcripts/.../upload` on the `ingestion` blueprint. The standalone demographic upload page was removed; the entry now lives on the Uploads page. | `ensure_corpus` |
+| `GET /demographic/<corpus_id>/` | List persisted demographic files for the corpus. | `list_demographic_files` |
+| `GET /demographic/<corpus_id>/upload` | **Backwards-compatible redirect** to `/transcripts/<corpus_id>/upload`. | — |
+| `POST /demographic/<corpus_id>/upload` | Submit the CSV from the Uploads page demographic card, obtain a preview with `import_id`, stash the preview in `flask.session` keyed by `import_id`. | `upload_demographic` |
+| `GET /demographic/<corpus_id>/preview/<import_id>` | Render the preview of a pending import. **No backend call** — the preview payload is read from the session entry stashed at upload time. | — |
+| `POST /demographic/<corpus_id>/preview/<import_id>` | Confirm (`action=confirm`) or cancel (`action=discard`) the pending import. Clears the session entry. | `confirm_demographic` |
+| `GET /demographic/<corpus_id>/view/<file_id>` | Paginated view of a confirmed demographic file with transcript-linking badges. Catches `BackendNotFoundError` specifically to surface "That demographic file couldn't be found." | `list_demographic_files`, `list_demographic_rows`, `get_demographic_link_summary` |
+
+### 3.4 `codebooks` — prefix `/codebooks`
+
+| Method and path | Purpose | Backend call |
+|---|---|---|
+| `GET /codebooks/` | List all codebooks. | `list_codebooks` |
+| `GET /codebooks/<codebook_id>/themes` | Interactive theme browser (frequency table + hierarchy tree + detail panel). Catches `BackendNotFoundError` specifically to surface "That codebook couldn't be found." | `get_theme_frequencies`, `get_theme_tree` |
+
+### 3.5 `analysis` — prefix `/analysis`
+
+| Method and path | Purpose | Backend call |
+|---|---|---|
+| `GET /analysis/` | Placeholder page reserved for future analysis features. | — |
+
+## 4. Page Catalogue
+
+Templates are organized by feature under `Frontend/web/templates/`. All templates extend `base.html`, which carries the Bootstrap 5 layout, navbar, footer, favicon, and the `_flash.html` partial.
+
+### 4.1 Shared
+
+| Template | Purpose |
+|---|---|
+| `base.html` | Bootstrap layout, navbar with the NIM+AMOS team logo, 3-column partnership footer (NIM + OSS@FAU), favicon, flash partial inclusion, and a sticky-bottom flex layout so the footer stays at the viewport bottom on short pages |
+| `_flash.html` | Dismissible alert partial with category-specific icons; `success` and `info` auto-dismiss after 5 s, `warning` and `danger` persist until the user closes them |
+| `index.html` | Home page quick-link cards |
+| `errors/404.html` | Branded "page not found" |
+| `errors/500.html` | Branded "server error" — never leaks tracebacks |
+
+### 4.2 Ingestion
+
+| Template | Purpose |
+|---|---|
+| `ingestion/upload.html` | Hosts **two side-by-side cards**: a transcripts card (multi-file picker with dynamic JS-driven file list, per-file size validation, total-size feedback, indigo gradient header, `.btn-indigo` submit) and a demographic card (single-CSV picker, optional import name, teal gradient header, `.btn-teal` submit). Both share the hover-lift and themed-button conventions described in §8. |
+| `ingestion/results.html` | Per-file ingestion result summary returned by the backend |
+| `ingestion/list.html` | Paginated transcript list for one corpus |
+
+### 4.3 Demographic
+
+| Template | Purpose |
+|---|---|
+| `demographic/preview.html` | Pending-import preview with confirm / cancel actions |
+| `demographic/list.html` | List of confirmed demographic files for one corpus; the "Upload CSV" button links back to the Uploads page |
+| `demographic/view.html` | Paginated row view of one demographic file, with transcript-linking badges |
+
+The standalone `demographic/upload.html` was removed; the upload form lives on the Uploads page (see §4.2).
+
+### 4.4 Codebooks
+
+| Template | Purpose |
+|---|---|
+| `codebooks/list.html` | Codebook list |
+| `codebooks/themes.html` | Theme browser: frequency table, hierarchy tree, and detail panel. Driven by `static/js/codebook_themes.js` |
+
+### 4.5 Analysis
+
+| Template | Purpose |
+|---|---|
+| `analysis/index.html` | Placeholder page |
+
+## 5. Backend Integration Surface
+
+`BackendClient` is the only point in the frontend that knows the FastAPI URL shape. It exposes one method per backend interaction.
+
+| Method | Endpoint | Used by |
+|---|---|---|
+| `list_corpora(project_id)` | `GET /ingestion/corpora` | `ensure_corpus` |
+| `create_corpus(project_id, name)` | `POST /ingestion/corpora` | `ensure_corpus` |
+| `ensure_corpus(project_id, name)` | derived | All landing routes |
+| `upload_files(corpus_id, files)` | `POST /ingestion/corpora/{id}/upload` | Transcript upload |
+| `list_documents(corpus_id)` | `GET /ingestion/corpora/{id}/documents` | Transcript list |
+| `list_codebooks()` | `GET /codebooks/` | Codebook list |
+| `get_theme_frequencies(codebook_id)` | `GET /codebooks/{id}/themes` | Theme browser |
+| `get_theme_tree(codebook_id)` | `GET /codebooks/{id}/themes/tree` | Theme browser |
+| `upload_demographic(corpus_id, file, name)` | `POST /demographic/{corpus_id}/upload` | Demographic upload |
+| `confirm_demographic(corpus_id, import_id, confirm)` | `POST /demographic/{corpus_id}/confirm` | Demographic preview |
+| `list_demographic_files(corpus_id)` | `GET /demographic/{corpus_id}/files` | Demographic list |
+| `list_demographic_rows(corpus_id, file_id, page, page_size)` | `GET /demographic/{corpus_id}/rows` | Demographic file view |
+| `get_demographic_link_summary(corpus_id)` | `GET /demographic/{corpus_id}/link-summary` | Demographic linking summary |
+
+Every method passes through a single `_unwrap(response, sub_key=None)` helper that peels the FastAPI `{success, data, error, meta}` envelope. The envelope shape lives in exactly one place; if the backend ever changes it, only `_unwrap` needs updating.
+
+## 6. Error Model
+
+A four-layer model is used. The categorisation lives in `BackendClient`; controllers catch the typed exception and surface `exc.user_message` via `flash`; templates render error- vs. empty-state separately; Flask error handlers catch what escapes.
+
+| Exception class | Raised when | Default user message | Log level |
+|---|---|---|---|
+| `BackendError` (base) | Uncategorised failure: malformed JSON, missing keys | "Something went wrong. Please try again." | `error` |
+| `BackendUnavailableError` | Connect refused, DNS failure, read timeout | "We can't reach the analysis service right now. Please try again in a moment." | `warning` |
+| `BackendNotFoundError` | Backend returns HTTP 404 | "The requested item couldn't be found. It may have been deleted." | `info` |
+| `BackendValidationError` | Backend returns HTTP 422 — FastAPI's structured `detail[].msg` is parsed per field | A per-field message, e.g. `"name: field required; themes: must contain at least 1 item"` | `info` |
+| `BackendServerError` | Backend returns 5xx | "The analysis service had a problem. The team has been notified." | `error` |
+
+Controllers that hit a resource by id (e.g. `codebook_themes`, `demographic.view_data`) catch `BackendNotFoundError` separately to surface a resource-specific message. Generic `BackendError` is the fallback.
+
+Every failed request is logged once at the `BackendClient` boundary at a level matching the exception class.
+
+Data-loading templates follow a three-way conditional so an error alert and an empty-state line never appear together:
+
+```jinja
+{% if error %}
+  <p class="text-secondary">Couldn't load this section.</p>
+{% elif data %}
+  ...
+{% else %}
+  <p class="text-secondary">No items yet.</p>
+{% endif %}
+```
+
+Flask-level error handlers catch what escapes the controllers:
+
+- **404** — renders `errors/404.html`.
+- **413** — flashes "Upload too large…" and redirects to the home page via `url_for("main.index")`. **Always home** — never the `Referer` header — to eliminate the open-redirect class of vulnerability (CWE-601).
+- **Generic `Exception`** — logs the full traceback via `logger.exception`, renders `errors/500.html`. Re-raises `HTTPException` so the 404 and 413 handlers still run for those specific codes.
+
+## 7. Configuration
+
+The frontend reads its configuration from environment variables (or a local `.env`). The values shipped on the `frontend` service in `docker-compose.yml` cover the in-cluster URL; the table below shows the user-meaningful settings.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BACKEND_API_URL` | `http://localhost:8000/api/v1` | Base URL of the FastAPI backend. In Docker this is `http://api:8000/api/v1`. |
+| `BACKEND_TIMEOUT_S` | `60.0` | HTTP client timeout |
+| `SECRET_KEY` | `dev-secret` | Flask session signing key. **Override for production.** |
+| `APP_ENV` | `development` | `development` enables debug-friendly behaviour |
+| `LOG_LEVEL` | `INFO` | Both Flask and `BackendClient` log at this level |
+| `MAX_UPLOAD_SIZE_MB` | `10` | Per-file upload cap; Werkzeug rejects oversized bodies with 413 |
+| `DEFAULT_PROJECT_ID` | `00000000-0000-0000-0000-000000000001` | Single-workspace MVP project identifier |
+| `DEFAULT_CORPUS_NAME` | `Interview Transcripts` | Name used when auto-creating the workspace corpus |
+
+`MAX_CONTENT_LENGTH` (the Flask raw-request-body cap that triggers a 413) is derived as `MAX_UPLOAD_SIZE_MB × 10 × 1024 × 1024` — about 100 MB by default — so Werkzeug rejects oversized payloads before fully buffering them.
+
+## 8. Design System
+
+The frontend uses a small, deliberate visual vocabulary. **New pages should reuse these primitives rather than introducing one-off styling.** If you find yourself reaching for inline styles or a custom class, check §8.8 first.
+
+### 8.1 Bootstrap and stylesheet organisation
+
+Bootstrap 5.3.3 is loaded from `cdn.jsdelivr.net` with an SRI integrity hash, declared in `templates/base.html`. No build step, no Bootstrap Icons, no Bootstrap extensions. We rely on default Bootstrap utility classes (`d-flex`, `gap-2`, `text-secondary`, `mb-3`, `bg-white`, `rounded-3`, etc.) wherever possible, and add custom classes only when Bootstrap can't express the intent.
+
+`static/css/main.css` is the **only** custom stylesheet. It is sectioned with `/* ── Section name ─────── */` headings by feature. New rules go into the matching section, not appended at the end. The current sections (top-to-bottom):
+
+| Section | Purpose |
+|---|---|
+| Theme browser page header | `.theme-page-header`, `.theme-version-badge` |
+| Metric cards | `.metric-card`, `.metric-card--indigo/cyan/teal` |
+| Panel section titles | `.panel-title` |
+| Frequency table | `.theme-table-head`, `.theme-row-*`, `.theme-progress*` |
+| Tree with connector lines | `.tree-*` |
+| Theme Details panel | `.td-*` |
+| Header brand logo | `.navbar-brand-logo`, `.site-navbar` |
+| Sticky-bottom layout | `.site-body`, `.site-main`, `.site-footer` |
+| Site footer | `.footer-*` |
+| Upload cards | `.upload-row`, `.upload-card*` |
+| Themed submit buttons | `.btn-indigo`, `.btn-teal` |
+| File list rows | `.file-list-item`, `.file-list-remove` |
+
+### 8.2 Colour identity
+
+| Role | Colour | Where it appears |
+|---|---|---|
+| Institutional chrome | NIM red `#D7102D` + dark navy `#232B35` | Team logo (navbar + footer + favicon) |
+| Content brand | Indigo `#3730a3 → #4f46e5 → #6366f1` | Theme-browser page header, metric cards, panel-title accents, footer accent line, transcripts upload card |
+| Complementary content brand | Teal `#0f766e → #14b8a6` | Demographic upload card, future analysis-side surfaces |
+| Frequency progress bands | Rose 0–33 %, amber 34–66 %, emerald 67–100 % | Theme-browser coverage bars |
+
+Dominant solid colours pulled from each gradient (used for buttons and accents):
+
+| Token | Hex |
+|---|---|
+| Indigo deep | `#4338ca` |
+| Indigo hover | `#3730a3` |
+| Indigo disabled | `#c7d2fe` |
+| Indigo selected-row tint | `#eef2ff` |
+| Teal deep | `#0f766e` |
+| Teal hover | `#115e59` |
+| Teal disabled | `#ccfbf1` |
+
+### 8.3 Reusable component classes
+
+Full catalogue. Use these first; introduce a new class only when none of these fit.
+
+**Cards and containers**
+
+| Class | When to use |
+|---|---|
+| `.upload-card`, `.upload-card--indigo`, `.upload-card--teal` | Side-by-side upload entry points with gradient header strip, hover-lift, themed accent |
+| `.metric-card`, `.metric-card--indigo`, `.metric-card--cyan`, `.metric-card--teal` | Stat cards with large numeric value and small uppercase label (theme browser) |
+| `.theme-page-header` | Indigo gradient hero for theme-browser-style pages |
+| `.panel-title` | Section heading inside a panel; indigo left-border accent |
+| `.upload-row` | Soft max-width cap (1080 px) for the Uploads page row |
+
+**Buttons**
+
+| Class | When to use |
+|---|---|
+| `.btn-indigo` | Primary submit on an indigo-themed surface |
+| `.btn-teal` | Primary submit on a teal-themed surface |
+
+**File pickers**
+
+| Class | When to use |
+|---|---|
+| `.file-list-item` | Borderless row for a selected file (name + size + hover tint) |
+| `.file-list-remove` | Circular X-icon remove button |
+
+**Tree (theme browser)**
+
+| Class | When to use |
+|---|---|
+| `.tree-root`, `.tree-children`, `.tree-group`, `.tree-child-item` | Hierarchy tree connector lines |
+| `.tree-root-row`, `.tree-child-row` | Tree node rows |
+| `.tree-toggle`, `.tree-toggle-gap` | Expand/collapse arrows |
+
+**Layout chrome**
+
+| Class | When to use |
+|---|---|
+| `.site-body`, `.site-main`, `.site-footer` | Sticky-bottom flex layout on `<body>` |
+| `.site-navbar` | Branded navbar background |
+| `.site-flash` | Flash alert wrapper (auto-dismiss for success/info) |
+
+### 8.4 Themed submit buttons
+
+`.btn-indigo` and `.btn-teal` are flat solid buttons (background pulled from the dominant colour of each gradient — a compressed gradient on a small button reads as washed-out). They share a hover-darkening + soft glow + active-press pattern. The disabled state shows a muted variant and overrides Bootstrap's `pointer-events: none` so the `cursor: not-allowed` indicator actually renders.
+
+### 8.5 File pickers
+
+The `.file-list-item` + `.file-list-remove` pair is the canonical "selected file" affordance: borderless row with file name + size, hover tint, oversize-red tint when over the size cap, circular X-icon remove button. Used by both the transcripts multi-file list and the demographic single-file indicator.
+
+### 8.6 Interaction patterns
+
+| Pattern | What | Where it's used |
+|---|---|---|
+| Hover-lift | `transform: translateY(-4px)` + grown box-shadow on `:hover` | Upload cards |
+| Click-press | `transform: translateY(-2px)` + reduced shadow on `:active` | Upload cards |
+| Disabled cursor | `cursor: not-allowed` + `pointer-events: auto` override on `:disabled` (Bootstrap's default `pointer-events: none` hides the cursor change) | Themed submit buttons |
+| Dismissible flash | `success` and `info` alerts auto-dismiss after 5 s via a small JS snippet in `base.html`; `warning` and `danger` persist | Flash partial |
+| Three-way data-loading conditional | `{% if error %} ... {% elif data %} ... {% else %} empty-state {% endif %}` so error and empty-state never appear together | All data-loading templates |
+
+### 8.7 Icons
+
+We use inline SVG (Lucide / Heroicons style: `viewBox="0 0 24 24"`, `fill="none"`, `stroke="currentColor"`, `stroke-width="1.8"` or `2.4`, `stroke-linecap="round"`). No icon font, no SVG sprite. Convention:
+
+| Use | Size |
+|---|---|
+| Card header | `width/height: 26-32px` |
+| Inline control (remove buttons, toggles) | `width/height: 13-16px` |
+
+Icons currently in use: `document-text` (transcripts upload card), `users` (demographic upload card), `x` (file-list-remove), expand/collapse arrows in the tree (pure CSS triangle, not SVG).
+
+### 8.8 Before adding new CSS — checklist
+
+Run through this before writing a new rule in `main.css`:
+
+1. **Does a Bootstrap utility cover it?** Spacing (`m-*`, `p-*`, `gap-*`), display (`d-flex`, `d-grid`), text (`text-secondary`, `fw-semibold`), borders (`border`, `rounded-2`), colours (`bg-light`, `text-bg-success`). If yes, use that — no new rule needed.
+2. **Does an existing custom class cover it?** Check §8.3. The catalogue is shorter than people think — most pages can be built from `.upload-card` / `.metric-card` / `.panel-title` / themed buttons + Bootstrap utilities.
+3. **Is it a page-specific JS interaction?** If the styling exists only because of a JS state change (selected row, expanded tree node), the *class name* can live in `main.css` (e.g. `.tree-root-row.selected`) but the *event wiring* belongs alongside the JS in the template, not duplicated as CSS.
+
+If all three answers are no, add it to `main.css` under the right `/* ── Section ─ */` heading. If it's a pattern more than one page might want, give it a class name that describes intent (`.upload-card`), not appearance (`.blue-box`). Update §8.3 of this wiki in the same commit so it stays discoverable.
+
+### 8.9 Examples — preferred and discouraged
+
+| Don't | Do |
+|---|---|
+| `<button style="background: #4338ca; color: white;">Save</button>` (inline styles, hard-coded colours) | `<button class="btn btn-indigo">Save</button>` |
+| `.my-feature-blue-button { background: #6366f1; ... }` (one-off class named for the feature) | Use `.btn-indigo` — same colour, intent-based name, already exists |
+| `.feature-x-card { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; }` for a new card | Use the existing Bootstrap utilities `bg-white border rounded-3 p-3` |
+| `style="margin-top: 20px;"` | `class="mt-3"` (Bootstrap utility, consistent spacing scale) |
+| Adding a new icon as a base64-embedded PNG | Inline SVG following the Lucide/Heroicons convention in §8.7 |
+| Duplicating an `.upload-card` lookalike on a new page | Reuse `.upload-card` with a new `.upload-card--<colour>` modifier if you need a different accent |
+## 9. Upload-Flow Contract
+
+Two flow shapes coexist in the app:
+
+| Flow | Used by | Steps | State management |
+|---|---|---|---|
+| **Single-step** | Transcripts upload | Upload → backend persists immediately → render per-file results | None — request/response is self-contained |
+| **Two-step** | Demographic upload | Upload → backend stages a pending file and returns a preview with `import_id` → user confirms or cancels on a separate page → backend persists or discards | The preview payload is stashed in `flask.session` under key `demo_preview_<import_id>`. The preview page reads the session entry; no backend re-fetch happens. The confirm route pops the entry after dispatching to backend. |
+
+The two-step flow exists because the backend enforces strict CSV validation (column membership, username uniqueness, row-count bounds) and the team decided researchers should always see what was parsed before persisting. Future features that need user review before commit should follow the same pattern.
+
+The `import_id` is a UUID that the backend generates on upload and embeds in both the preview page URL and the session key. Pending uploads expire on the backend after `DEMOGRAPHIC_UPLOAD_TTL_SECONDS`; the frontend gracefully handles the missing-session case with a flash + redirect back to the Uploads page.
+
+## 10. Development Workflow
+
+Day-to-day commands, troubleshooting, and the dev/test stack are documented in `Frontend/README.md` in the repository. One environmental gotcha worth highlighting here:
+
+**Schema drift on the Postgres volume.** The project has no migration framework today; schema is created by `SQLAlchemy.create_all()` on app start, which only adds missing tables — not missing columns. Any time the backend team adds a column to an existing model (e.g. the `demographic_row_id` column on `corpus_documents` for the demographic-linking feature), anyone whose local `pgdata` volume predates that commit will see `UndefinedColumnError` on any insert touching the new column. Cure:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+This recreates the volume with the current schema. Loses all locally uploaded test data — re-upload from `demo_data/` to recover.
+
+## 11. Testing Strategy
+
+The frontend test suite lives under `Frontend/tests/`. Tests never hit the network — a `FakeBackend` fixture in `conftest.py` monkey-patches the BackendClient factory in every controller blueprint.
+
+| File | Coverage |
+|---|---|
+| `test_smoke.py` | Health, home, and basic per-route reachability |
+| `test_ingestion.py` | Transcript upload + list flows, including typed-error paths |
+| `test_codebooks.py` | Codebook list + theme browser flows, including `BackendNotFoundError` |
+| `test_demographic.py` | Demographic upload (via Uploads page redirect), preview, confirm/discard, file view, linking |
+| `test_backend_client.py` | Unit tests for `BackendClient` exception categorisation using `httpx.MockTransport` |
+| `test_error_handlers.py` | 404, 413, and generic 500 handlers, including the open-redirect guard on 413 |
+
+To simulate a specific backend exception in a controller test, set the fixture's `raise_on`:
+
+```python
+fake_backend.raise_on = ("upload_demographic", BackendValidationError)
+```
+
+This is the canonical pattern for adding new typed-error tests. The `(method_name, ExceptionClass)` tuple form raises that specific subclass; a bare method-name string raises generic `BackendError`.

--- a/Documentation/User-Documentation.md
+++ b/Documentation/User-Documentation.md
@@ -1,0 +1,42 @@
+# User Documentation
+
+Welcome to the **Automated Thematic Analysis** project! This system automates the extraction and thematic analysis of knowledge from source documents, allowing you to discover deeper insights into your data corpora.
+
+## Getting Started
+
+The platform allows you to upload documents (such as interview transcripts), map them against a Codebook (a hierarchical thematic tree), and explore the resulting thematic knowledge graph.
+
+### Accessing the Platform
+Once the application is running, you can access the following services:
+- **API Server & Endpoints:** [http://localhost:8000](http://localhost:8000)
+- **Interactive API Docs (Swagger):** [http://localhost:8000/docs](http://localhost:8000/docs)
+- **Demo UI:** You can interact visually with the Codebook Selection and explore the thematic graph via the frontend templates.
+
+---
+
+## Core Features
+
+### 1. Corpora Management
+A **Corpus** is a collection of related documents.
+- **Create a Corpus:** Group your research materials logically (e.g., "Customer Interviews 2026").
+- **Upload Documents:** Add unstructured text documents (PDFs, transcripts) to a Corpus. The system automatically breaks these documents down into manageable **Chunks**.
+
+### 2. Codebook Interaction
+A **Codebook** defines the themes you are looking for. It acts as a hierarchical structure of nodes/themes.
+- **Select Codebooks:** Use the UI to explore different Codebook structures.
+- **Thematic Mapping:** The AI pipeline uses Large Language Models (LLMs) to automatically map chunks of text from your documents to relevant themes in the Codebook.
+
+### 3. Graph Exploration
+The system builds a queryable thematic knowledge graph based on your analysis.
+- **Theme Frequency Tracking:** Easily see which themes appear most frequently across your corpus.
+- **Traceability:** Click on a mapped theme to view the exact text snippets (chunks) and source documents that generated the match.
+
+---
+
+## Example Workflow
+
+1. **Setup:** Ensure your administrator has configured the `LLM_API_KEY` to enable the AI pipeline.
+2. **Ingest Data:** Navigate to the API or Demo UI and create a new Corpus. Upload your source files.
+3. **Select/Upload a Codebook:** Provide a hierarchical tree of themes (in JSON or CSV format, depending on your setup) that represents what you want to extract.
+4. **Run Analysis:** Trigger the thematic mapping process. The LangChain pipeline will analyze each text chunk.
+5. **Review Results:** Explore the knowledge graph to discover insights, validate mappings, and track overarching themes across all documents.

--- a/Documentation/csv-codebook-standard.md
+++ b/Documentation/csv-codebook-standard.md
@@ -1,6 +1,6 @@
 # CSV Codebook Standard
 
-The automated thematic analysis platform supports uploading predefined codebooks via CSV files.
+The automated thematic analysis platform supports uploading predefined codebooks via CSV files. 
 
 ## File Format
 
@@ -16,79 +16,30 @@ The CSV must contain the following column headers. The headers are case-insensit
 - `Description`
 - `Parent Name`
 
-## Node Types
-
-Three node types are supported, mapping to two distinct backend entities:
-
-| Node Type  | Backend Entity | Behaviour |
-|------------|---------------|-----------|
-| `THEME`    | `Theme`       | A root-level thematic category. `Parent Name` must be empty. |
-| `SUBTHEME` | `Theme`       | A child theme nested under a `THEME` or another `SUBTHEME`. `Parent Name` is required. |
-| `CODE`     | `Code`        | A specific analytical code. `Parent Name` is optional; if set, must reference a `THEME` or `SUBTHEME`. |
-
-Both `THEME` and `SUBTHEME` are stored as `Theme` objects in the database — a subtheme is simply a `Theme` that has a parent edge in `theme_hierarchy_relationships`. `CODE` nodes are stored as separate `Code` objects in the `codes` table.
-
 ## Rules and Constraints
 
-1. **Node Count**: A codebook must contain between 1 and 50 nodes total (all types combined).
-2. **Name**: Cannot be empty. Names must be unique within the codebook to enable reliable parent references.
-3. **Node Type**: Must be exactly one of `THEME`, `SUBTHEME`, or `CODE` (case-insensitive during upload).
-4. **Parent Name**:
-   - `THEME`: `Parent Name` **must be empty** — root themes have no parent.
-   - `SUBTHEME`: `Parent Name` **must be provided** and must match the `Name` of an existing `THEME` or `SUBTHEME` node defined in the CSV.
-   - `CODE`: `Parent Name` is optional. If provided, it must match the `Name` of a `THEME` or `SUBTHEME` node — **not another `CODE`**. If the referenced parent does not exist or is itself a `CODE`, the link is silently dropped and the code becomes a root-level node. If empty, the code is a standalone root-level node.
+1. **Hierarchy Limits**: A single codebook must contain between 1 and 50 nodes.
+2. **Name**: Cannot be empty. Each name should ideally be unique within the codebook to allow reliable hierarchical referencing.
+3. **Node Type**: Must be exactly one of the following values (case-insensitive during upload):
+   - `THEME`
+   - `SUBTHEME`
+   - `CODE`
+4. **Parent Name**: 
+   - If the `Node Type` is `THEME`, the `Parent Name` **must be empty**.
+   - If the `Node Type` is `SUBTHEME` or `CODE`, the `Parent Name` **must be provided** and must exactly match the `Name` of an existing node defined earlier in the CSV file.
 5. **Description**: Can be empty.
-6. **Node ordering**: CSV row order does **not** affect whether parent references resolve. The parser collects all nodes in a first pass and validates hierarchy references in a second pass, so a node may reference a parent that appears later in the file.
 
 ## Relationship to System Entities
 
-The backend explicitly differentiates between structural themes and specific codes to preserve the semantics of qualitative thematic analysis:
+As noted in the `theme-data-type.md` documentation, a separate `Code` entity also exists in the backend (`codes` table). However, CSV codebook uploads map all node types (`THEME`, `SUBTHEME`, and `CODE`) to `Theme` objects internally for simplicity.
 
-- `THEME` and `SUBTHEME` nodes are stored as `Theme` objects in the database. Their parent-child relationships are mapped using `ThemeHierarchyRelationship` edges.
-- `CODE` nodes are stored as `Code` objects in their own dedicated table. If a `CODE` specifies a `Parent Name`, it is linked to its parent `Theme` via the `ThemeCodeRelationship` junction table.
+All nodes—whether defined as `THEME`, `SUBTHEME`, or `CODE` in the CSV—are stored as `Theme` objects in the database. The node type from the CSV is not preserved as a database field; the hierarchy is expressed entirely through `ThemeHierarchyRelationship` edges derived from the `Parent Name` column.
 
-This hybrid approach allows the frontend to dynamically reconstruct a unified hierarchical tree using Directed Acyclic Graph (DAG) structures while ensuring that `Theme` and `Code` data remain semantically isolated at the database level.
-
-## Upload API
-
-Two endpoints support CSV-based codebook creation:
-
-- `POST /codebooks/parse-csv` — validates and previews a CSV without persisting anything. Returns the parsed node list on success or a `422` error with a human-readable message on failure.
-- `POST /codebooks/` — creates the codebook and persists all nodes atomically. Accepts the same node list as a JSON body (`CodebookCreateRequest`).
-
-## Examples
-
-### Themes only (no codes)
-
-```csv
-Node Type,Name,Description,Parent Name
-THEME,Safety,Matters related to physical or psychological safety,
-THEME,Efficiency,How quickly and effectively tasks are completed,
-THEME,Communication,Issues with team communication and transparency,
-```
-
-### Root-level code (no parent)
-
-```csv
-Node Type,Name,Description,Parent Name
-THEME,Technical Issues,Recurring software problems,
-CODE,Bug Reports,Software bug occurrences reported by users,
-CODE,Unrelated orphan code,A standalone code with no parent,
-```
-
-### Full hierarchy — nested subthemes and codes at multiple levels
+## Example
 
 ```csv
 Node Type,Name,Description,Parent Name
 THEME,Remote work reshapes daily life,Broad changes caused by remote work,
 SUBTHEME,Work-life boundary challenges,Difficulty separating work and personal life,Remote work reshapes daily life
 CODE,Difficulty separating work and home life,Specific struggles to detach from work,Work-life boundary challenges
-CODE,Working longer hours,Working past normal hours,Remote work reshapes daily life
-CODE,Family interruptions during meetings,Family members interrupting video calls,Remote work reshapes daily life
-THEME,Communication barriers,Issues communicating remotely,
-SUBTHEME,Asynchronous communication issues,Delays or misunderstandings in async comms,Communication barriers
-CODE,Missed messages,Messages not seen in time,Asynchronous communication issues
-CODE,Lack of tone in text,Misinterpretation of text tone,Communication barriers
 ```
-
-Note that `Working longer hours` and `Family interruptions during meetings` are attached directly to the root `THEME`, while `Difficulty separating work and home life` is attached to the `SUBTHEME` one level down.

--- a/Documentation/ingestion-pipeline.md
+++ b/Documentation/ingestion-pipeline.md
@@ -1,6 +1,6 @@
 # Ingestion Pipeline
 
-Handles uploading interview data into the system, chunking it for analysis, and exposing it to downstream components.
+Handles uploading interview data into the system and exposing it to downstream components such as codebook generation.
 
 ## Data Structures
 
@@ -9,41 +9,27 @@ Handles uploading interview data into the system, chunking it for analysis, and 
 Top-level container grouping documents for one analytical project.
 
 - `id` (`uuid`, primary key)
-- `project_id` (`uuid`, indexed) — references the owning project (JUST PLACEHOLDER FOR NOW. Project structure not set up yet)
+- `project_id` (`uuid`, indexed) — references the owning project (placeholder; full project structure not yet implemented)
 - `name` (`string`)
 - `created_at`, `updated_at` (`timestamp`)
 
 ### CorpusDocument (`corpus_documents`)
 
-One source document within a corpus. Stores only metadata — the actual text lives in chunks.
+One source document within a corpus. Stores both metadata and the full document text.
 
 - `id` (`uuid`, primary key)
 - `corpus_id` (`uuid`, FK -> `corpora.id`, CASCADE DELETE)
+- `demographic_row_id` (`uuid | null`, FK -> `demographic_row.id`, SET NULL) — linked interviewee demographics, if available
 - `title` (`string`)
+- `filename` (`string | null`) — original uploaded filename after collision resolution; null for body-ingested docs
+- `content` (`text`) — full text of the document
 - `created_at`, `updated_at` (`timestamp`)
 
-### CorpusChunk (`corpus_chunks`)
+## Supported Upload Formats
 
-A fixed-size word-window slice of a document. This is the unit consumed by thematic analysis.
+The upload endpoint accepts `.txt`, `.docx`, `.pdf`, and `.jsonl` files.
 
-- `id` (`uuid`, primary key)
-- `document_id` (`uuid`, FK -> `corpus_documents.id`, CASCADE DELETE)
-- `chunk_index` (`int`) — zero-based position within the parent document
-- `text` (`text`)
-- `created_at`, `updated_at` (`timestamp`)
-- Unique constraint on `(document_id, chunk_index)`
-
-## Chunking
-
-Text is split into overlapping word windows:
-
-- `chunk_size_words` — maximum words per chunk (configured via `INGESTION_CHUNK_SIZE_WORDS`)
-- `overlap_words` — words shared between consecutive chunks (configured via `INGESTION_CHUNK_OVERLAP_WORDS`)
-- `stride = chunk_size_words - overlap_words`
-
-## Supported Upload Format
-
-Only `.jsonl` files are accepted via the upload endpoint. Each line must be a JSON object representing one message from a chatbot interview session:
+For **`.jsonl`** files, each line must be a JSON object representing one message from a chatbot interview session:
 
 ```json
 {"username": "p001", "event_type": "human_response", "message_index": 2, "message_content": "I feel..."}
@@ -53,6 +39,8 @@ Only `.jsonl` files are accepted via the upload endpoint. Each line must be a JS
 - Only `human_response` events are included in the document text; chatbot turns are excluded.
 - Messages are ordered by `message_index` before joining.
 - Participants with no non-blank human responses are skipped.
+
+For **`.txt`**, **`.docx`**, and **`.pdf`** files, the extracted text is stored directly as one `CorpusDocument` per uploaded file.
 
 Documents can also be submitted directly via the bulk JSON endpoint without a file upload.
 
@@ -66,15 +54,13 @@ All routes are under `/api/v1/ingestion`.
 | `GET` | `/corpora` | List corpora (filter by `project_id`) |
 | `GET` | `/corpora/{corpus_id}` | Get a single corpus |
 | `POST` | `/corpora/{corpus_id}/documents/bulk` | Ingest documents from JSON body |
-| `POST` | `/corpora/{corpus_id}/upload` | Ingest from a `.jsonl` file upload |
+| `POST` | `/corpora/{corpus_id}/upload` | Ingest from a `.txt`, `.docx`, `.pdf`, or `.jsonl` file upload |
 | `GET` | `/corpora/{corpus_id}/documents` | List documents (paginated) |
-| `DELETE` | `/corpora/{corpus_id}/documents/{document_id}` | Delete a single document |
-| `GET` | `/corpora/{corpus_id}/chunks` | List chunks (paginated, filterable by `document_id`) |
 
 All responses are wrapped in `{"success": true, "data": ...}`. Paginated responses include a `meta` object with `total`, `page`, `page_size`, and `pages`.
 
 ## Notes
 
 - Documents with empty text are silently skipped during ingestion.
-- The full document text is not stored — only the chunks. Reconstruct the original by joining chunks in `chunk_index` order.
-- Chunks are exposed to LangChain consumers via `load_corpus_chunks_as_langchain_documents`, which returns `langchain_core.documents.Document` objects with `corpus_id`, `document_id`, `chunk_id`, and `chunk_index` in metadata.
+- The full document text is stored in `CorpusDocument.content`. Codebook generation splits the content into in-memory passages at analysis time — passages are not persisted as separate database rows.
+- Chunks are exposed to LangChain consumers via `load_corpus_chunks_as_langchain_documents`, which returns `langchain_core.documents.Document` objects with `corpus_id`, `document_id`, and `chunk_index` in metadata.

--- a/Documentation/theme-data-type.md
+++ b/Documentation/theme-data-type.md
@@ -1,121 +1,37 @@
-# Theme and Code Data Types
+# Theme Data Type and Constraints
 
-This backend supports thematic analysis through explicitly separated `Theme` and `Code` entities. This separation ensures that high-level thematic structures remain distinct from specific, granular analytical codes.
+This backend supports thematic analysis through `Theme` and its relationships. A `Code` entity also exists in the backend (`codes` table), but note that CSV codebook uploads map all node types (`THEME`, `SUBTHEME`, and `CODE`) to `Theme` objects internally — see [csv-codebook-standard.md](csv-codebook-standard) for details.
 
-## Entities
+## Theme (`themes`)
 
-### Theme (`themes`)
 Core fields:
-- `id` (`uuid`, primary key; `sqlalchemy.Uuid`)
-- `codebook_id` (`uuid`, FK → `codebooks.id`, CASCADE DELETE)
-- `label` (`string`, indexed; unique within codebook via `uq_theme_codebook_label`)
-- `description` (`string`, nullable)
+- `id` (`uuid`, primary key; PostgreSQL `UUID`)
+- `codebook_id` (`uuid`, FK -> `codebooks.id`, CASCADE DELETE, indexed)
+- `label` (`string`, indexed) — unique within one codebook
+- `description` (`text`, optional)
 - `is_active` (`boolean`, default `true`)
-
-### Code (`codes`)
-Core fields:
-- `id` (`uuid`, primary key; `sqlalchemy.Uuid`)
-- `codebook_id` (`uuid`, FK → `codebooks.id`, CASCADE DELETE)
-- `label` (`string`, indexed; unique within codebook via `uq_code_codebook_label`)
-- `description` (`string`, nullable)
-- `is_active` (`boolean`, default `true`)
-
-### Codebook (`codebooks`)
-Core fields:
-- `id` (`uuid`, primary key; `sqlalchemy.Uuid`)
-- `corpus_id` (`uuid`, FK → `corpora.id`, CASCADE DELETE)
-- `name` (`string`)
-- `description` (`string`, nullable)
-- `version` (`int`)
-- `created_by` (`string`)
-
-## UUID Column Type
-
-All UUID columns use `sqlalchemy.Uuid(as_uuid=True)` — the generic, dialect-agnostic UUID type. This ensures compatibility with both PostgreSQL (production) and SQLite (testing). Do **not** use `sqlalchemy.dialects.postgresql.UUID`.
 
 ## Relationship Constraints
 
-### Codebook Memberships
-Both Themes and Codes have active membership junction tables linking them to Codebooks:
-- `codebook_theme_relationships` (1 codebook : n Themes)
-- `codebook_code_relationships` (1 codebook : n Codes)
-
-### Hierarchical Relationships (DAG)
-The system uses Directed Acyclic Graph (DAG) structures to model relationships:
-- `theme_hierarchy_relationships`: Maps `Theme` → `Theme` relationships (i.e. Subthemes nested under Themes or other Subthemes).
-- `theme_code_relationships`: Maps `Theme` → `Code` relationships, allowing Codes to be structurally nested under Themes.
+### Codebook-Theme Membership (`codebook_theme_relationships`)
+1 codebook : n Themes
+- `id` (`uuid`, primary key; PostgreSQL `UUID`)
+- Foreign keys:
+  - `codebook_id` (`uuid`) -> `codebooks.id`
+  - `theme_id` (`uuid`) -> `themes.id`
+- `is_active` (`boolean`, default `true`)
 
 ## Notes
 
-- This hybrid design ensures `Theme` and `Code` remain isolated at the database level while seamlessly combining into unified hierarchy trees for frontend rendering and analysis.
-- A Subtheme is simply a Theme with a parent — there is no separate `Subtheme` database table. Whether a Theme is a root theme or subtheme is derived from the presence/absence of a parent in `theme_hierarchy_relationships`.
-- Subtheme nesting is arbitrary depth: a SUBTHEME may have another SUBTHEME as a parent, forming multi-level hierarchies.
+- This is an intentionally simplified design for sprint scope reduction.
+- If stricter behavior is needed later (e.g., uniqueness per active membership), add constraints in a follow-up migration.
 
-## Response Schema: Codebook Detail
+## API Endpoint
 
-`GET /codebooks/{codebook_id}` and `POST /codebooks/` return a `CodebookDetailSchema`:
-
-```json
-{
-  "id": "<uuid>",
-  "corpus_id": "<uuid>",
-  "name": "My Codebook",
-  "description": null,
-  "version": 1,
-  "created_by": "researcher",
-  "themes": [
-    {
-      "id": "<uuid>",
-      "node_type": "THEME",
-      "name": "Remote work reshapes daily life",
-      "description": "...",
-      "children": [
-        {
-          "id": "<uuid>",
-          "node_type": "SUBTHEME",
-          "name": "Work-life boundary challenges",
-          "description": "...",
-          "children": [
-            {
-              "id": "<uuid>",
-              "node_type": "CODE",
-              "name": "Difficulty separating work and home life",
-              "description": "..."
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "codes": [
-    {
-      "id": "<uuid>",
-      "node_type": "CODE",
-      "name": "Root-level orphan code",
-      "description": "..."
-    }
-  ]
-}
-```
-
-The `themes` array contains only root `Theme` nodes (those without a parent). Each node recursively embeds its `children`, which may be `SUBTHEME` or `CODE` nodes. The `codes` array contains only `Code` nodes that have no parent theme (root-level orphan codes).
-
-## Frontend Statistics
-
-The frontend calculates theme statistics (root themes, total themes, sub-themes) by filtering out Code nodes. Only nodes where `node_type !== 'CODE'` are counted in theme metrics. Codes have their own separate counter.
-
-## API Endpoints
-
-- `GET /codebooks/{codebook_id}`
-  - Returns `CodebookDetailSchema`: the full nested theme+code tree and the flat list of root-level orphan codes (see schema above).
-- `POST /codebooks/`
-  - Creates a new codebook from a `CodebookCreateRequest` and returns `CodebookDetailSchema`.
 - `GET /codebooks/{codebook_id}/themes`
-  - Returns a flat list of all active `Theme` nodes (excludes `Code` nodes).
-  - Each item contains `theme_name`, `occurrence_count`, and `interview_coverage_percentage`.
-  - `occurrence_count` and `interview_coverage_percentage` are currently placeholder `0` values.
+  - Returns a flat list of all active codebook themes.
+  - Each list item contains `theme_name`, `occurrence_count`, and `interview_coverage_percentage`.
+  - For now, `occurrence_count` and `interview_coverage_percentage` are placeholder `0` values.
 - `GET /codebooks/{codebook_id}/themes/tree`
-  - Returns the recursive theme tree for the selected codebook (excludes `Code` nodes).
-  - Optional query param: `root_theme_id` to return only one subtree.
-- `DELETE /codebooks/{codebook_id}`
-  - Deletes a codebook and cascades deletion to all associated themes, codes, and relationships. Returns `200 OK` on success, or `404 Not Found` if the codebook doesn't exist.
+  - Returns the theme tree for the selected codebook.
+  - Optional query param: `root_theme_id`.


### PR DESCRIPTION
Home.md

• Fixed three broken quick links (Backend-API-Reference, System-Architecture, LLM-Infrastructure → real page names)
• Replaced "Gemma4" with "Gemma 3, GPT-OSS" to match the actual configured models

ingestion-pipeline.md

• Removed the CorpusChunk data structure. it does not exist as a model or database table; the backend has no CorpusChunk class and no corpus_chunks table
• Added content field to CorpusDocument. the full document text is stored directly on the document, not in chunks
• Corrected the "full text not stored" note. it was the opposite of the truth; content is stored, passages are split in-memory at analysis time
• Extended upload formats from .jsonl-only to .txt, .docx, .pdf, .jsonl
• Removed the /chunks endpoint and the chunking config variables (INGESTION_CHUNK_SIZE_WORDS, INGESTION_CHUNK_OVERLAP_WORDS) which don't exist in config.py

Backend-Software-Architecture-and-Data-Model-Documentation.md

• Removed CORPUS_CHUNK from the ERM and all references to ChunkSpan/CorpusChunk in the services table
• Fixed CODEBOOK.project_id to corpus_id (the actual FK in the Codebook model)
• Added the missing CORPUS ||--o{ CODEBOOK relationship to the ERM
• Added CodebookGenerationJob to the ERM and entity catalogue
• Added content field to CORPUS_DOCUMENT in the ERM
• Updated Theme to show its codebook_id FK and description field
• Replaced the text-chunking service row with CodebookGenerationService

theme-data-type.md

• Added missing codebook_id FK and description fields to the Theme core fields list

csv-codebook-standard.md

• Removed the false claim that "dedicated code-related backend tables were intentionally removed". Code, CodebookCodeRelationship, and ThemeCodeRelationship all exist in the current codebase
• Corrected the claim that NodeType is "preserved". the node type from CSV is not stored as a database field; only the hierarchy is captured via ThemeHierarchyRelationship
