### PR TITLE
Feature/159 codebook application parallelization batching

### DIFF
--- a/Backend/app/llm/pipelines.py
+++ b/Backend/app/llm/pipelines.py
@@ -37,6 +37,7 @@ def analyze_interview(
     if not transcript.strip():
         raise ValueError("Transcript is empty.")
 
+    # LangChain pipes each stage into the next: prompt -> model -> parser.
     chain = build_thematic_analysis_prompt() | (model or build_chat_model()) | StrOutputParser()
     return chain.invoke({"transcript": transcript})
 
@@ -55,8 +56,11 @@ def apply_codebook_to_interview(
         raise ValueError("Codebook context is empty.")
 
     chat_model = model or build_chat_model()
-    # Use JsonOutputParser instead of with_structured_output for broader compatibility
+    # JsonOutputParser keeps the chain compatible with providers that do not
+    # implement LangChain's with_structured_output API.
     parser = JsonOutputParser(pydantic_object=InterviewAnalysisResult)
+    # The prompt receives the input dict, the chat model returns text, and the
+    # parser converts that text into a plain dict matching the Pydantic schema.
     chain = build_codebook_application_prompt() | chat_model | parser
     raw_result = chain.invoke({"transcript": transcript, "codebook": codebook_context})
     return InterviewAnalysisResult(**raw_result)
@@ -67,6 +71,8 @@ def build_codebook_application_with_codes_chain(
     model: BaseChatModel | None = None,
 ) -> Runnable[dict[str, str], dict[str, Any]]:
     chat_model = model or build_chat_model()
+    # The parser validates the model output shape but returns a dict, so callers
+    # still instantiate CodebookApplicationResult explicitly after invocation.
     parser = JsonOutputParser(pydantic_object=CodebookApplicationResult)
     return build_codebook_application_with_codes_prompt() | chat_model | parser
 
@@ -83,6 +89,8 @@ async def apply_codebook_with_codes_to_transcript(
     if not codebook_context.strip():
         raise ValueError("Codebook context is empty.")
 
+    # Accepting an injected chain keeps tests deterministic and avoids rebuilding
+    # the model client for each document.
     runnable = chain or build_codebook_application_with_codes_chain(model=model)
     raw_result = await runnable.ainvoke({"transcript": transcript, "codebook": codebook_context})
     return CodebookApplicationResult(**raw_result)
@@ -104,10 +112,14 @@ async def apply_codebook_with_codes_to_transcripts(
     if not codebook_context.strip():
         raise ValueError("Codebook context is empty.")
 
+    # Reuse one Runnable across the batch; LangChain handles parallel execution
+    # inside abatch according to the optional max_concurrency config below.
     runnable = chain or build_codebook_application_with_codes_chain(model=model)
     config: RunnableConfig | None = (
         {"max_concurrency": max_concurrency} if max_concurrency is not None else None
     )
+    # return_exceptions=True preserves the input order and lets the service retry
+    # only the documents that failed, instead of failing the whole batch.
     raw_results = await runnable.abatch(
         [
             {
@@ -120,6 +132,8 @@ async def apply_codebook_with_codes_to_transcripts(
         return_exceptions=True,
     )
 
+    # Normalize LangChain/provider/parser outcomes into one positional result
+    # list so the service can map each item back to its original document.
     parsed_results: list[CodebookApplicationResult | Exception] = []
     for raw_result in raw_results:
         if isinstance(raw_result, Exception):
@@ -137,6 +151,8 @@ def build_codebook_generation_chain(
     model: BaseChatModel | None = None,
 ) -> Runnable[dict[str, str], dict[str, Any]]:
     chat_model = model or build_chat_model()
+    # See build_codebook_application_with_codes_chain: this Runnable returns
+    # parsed dictionaries that are converted to Pydantic models by callers.
     parser = JsonOutputParser(pydantic_object=PassageCodebookGeneration)
     return build_codebook_generation_prompt() | chat_model | parser
 
@@ -152,6 +168,8 @@ def generate_codebook_for_passage(
     if not passage.strip():
         raise ValueError("Passage is empty.")
 
+    # The generated prompt expects both researcher focus blocks, even when they
+    # are empty, so the template can keep a stable set of variables.
     chain = build_codebook_generation_chain(model=model)
     raw_result = chain.invoke({
         "passage": passage,
@@ -176,6 +194,7 @@ async def generate_codebook_for_passages(
         if not passage.strip():
             raise ValueError("Passage is empty.")
 
+    # The same LangChain Runnable is reused for every passage in the batch.
     runnable = chain or build_codebook_generation_chain(model=model)
     # Researcher focus is constant across the batch, so build the blocks once.
     research_query_block = _build_research_query_block(research_query or "")
@@ -183,6 +202,8 @@ async def generate_codebook_for_passages(
     config: RunnableConfig | None = (
         {"max_concurrency": max_concurrency} if max_concurrency is not None else None
     )
+    # abatch returns results in input order. Keeping exceptions as values lets
+    # the generation service retry or record individual passage failures.
     raw_results = await runnable.abatch(
         [
             {
@@ -196,6 +217,8 @@ async def generate_codebook_for_passages(
         return_exceptions=True,
     )
 
+    # Convert successful dicts to schema objects while leaving failures in the
+    # same positions for the caller's retry bookkeeping.
     parsed_results: list[PassageCodebookGeneration | Exception] = []
     for raw_result in raw_results:
         if isinstance(raw_result, Exception):
@@ -225,6 +248,8 @@ def consolidate_generated_codes(
         ensure_ascii=True,
         indent=2,
     )
+    # Consolidation is a single prompt/model/parser chain because it merges an
+    # already prepared JSON payload, not a list of independent inputs.
     chain = build_code_consolidation_prompt() | chat_model | parser
     raw_result = chain.invoke({"codes": serialized_codes})
     return CodeConsolidationResult(**raw_result)
@@ -248,6 +273,8 @@ def consolidate_generated_themes(
         ensure_ascii=True,
         indent=2,
     )
+    # The constraints string is injected as one prompt variable so callers can
+    # tune how aggressively LangChain asks the model to merge theme paths.
     chain = build_theme_consolidation_prompt() | chat_model | parser
     raw_result = chain.invoke(
         {

--- a/Backend/app/llm/pipelines.py
+++ b/Backend/app/llm/pipelines.py
@@ -88,6 +88,50 @@ async def apply_codebook_with_codes_to_transcript(
     return CodebookApplicationResult(**raw_result)
 
 
+async def apply_codebook_with_codes_to_transcripts(
+    transcripts: list[str],
+    codebook_context: str,
+    *,
+    chain: Runnable[dict[str, str], dict[str, Any]] | None = None,
+    model: BaseChatModel | None = None,
+    max_concurrency: int | None = None,
+) -> list[CodebookApplicationResult | Exception]:
+    if not transcripts:
+        return []
+    for transcript in transcripts:
+        if not transcript.strip():
+            raise ValueError("Transcript is empty.")
+    if not codebook_context.strip():
+        raise ValueError("Codebook context is empty.")
+
+    runnable = chain or build_codebook_application_with_codes_chain(model=model)
+    config: RunnableConfig | None = (
+        {"max_concurrency": max_concurrency} if max_concurrency is not None else None
+    )
+    raw_results = await runnable.abatch(
+        [
+            {
+                "transcript": transcript,
+                "codebook": codebook_context,
+            }
+            for transcript in transcripts
+        ],
+        config=config,
+        return_exceptions=True,
+    )
+
+    parsed_results: list[CodebookApplicationResult | Exception] = []
+    for raw_result in raw_results:
+        if isinstance(raw_result, Exception):
+            parsed_results.append(raw_result)
+            continue
+        try:
+            parsed_results.append(CodebookApplicationResult(**raw_result))
+        except Exception as exc:
+            parsed_results.append(exc)
+    return parsed_results
+
+
 def build_codebook_generation_chain(
     *,
     model: BaseChatModel | None = None,

--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -16,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.exceptions import NotFoundError, UnprocessableError
 from app.llm.pipelines import (
-    apply_codebook_with_codes_to_transcript,
+    apply_codebook_with_codes_to_transcripts,
     build_codebook_application_with_codes_chain,
 )
 from app.models import (
@@ -37,8 +38,10 @@ from app.schemas.llm import CodebookApplicationResult
 from app.services.quote_matching import locate_quote_span
 
 _APPLICATION_MAX_ATTEMPTS = 3
+_APPLICATION_MAX_CONCURRENCY = 8
+_APPLICATION_BATCH_SIZE = 16
 _APPLICATION_RETRY_BASE_DELAY_S = 0.5
-_APPLICATION_RETRY_MAX_DELAY_S = 4.0
+_APPLICATION_RETRY_MAX_DELAY_S = 5.0
 
 
 class CodebookApplicationCancelledError(Exception):
@@ -145,57 +148,61 @@ class CodebookApplicationService:
         documents_coded = 0
         failed_documents: list[dict[str, str]] = []
 
-        for document in documents:
+        for document_indexes in self._chunked(list(range(len(documents))), _APPLICATION_BATCH_SIZE):
             await self._raise_if_cancelled(should_cancel)
-            try:
-                if not document.content.strip():
-                    raise ValueError("Transcript is empty.")
-                result = await self._apply_document_with_retries(
-                    transcript=document.content,
-                    codebook_context=codebook_context,
-                    chain=chain,
-                )
-                await self._persist_successful_document_coding(
-                    application_run_id=application_run_id,
-                    codebook_id=codebook_id,
-                    document=document,
-                    result=result,
-                    themes_by_label=themes_by_label,
-                    codes_by_label=codes_by_label,
-                )
-                documents_coded += 1
-            except CodebookApplicationCancelledError:
-                raise
-            except Exception as exc:
-                await self._session.rollback()
-                logger.warning(
-                    "Codebook application failed for document {} after retries: {}",
-                    document.id,
-                    exc,
-                )
-                await self._persist_failed_document_coding(
-                    application_run_id=application_run_id,
-                    codebook_id=codebook_id,
-                    document=document,
-                    error_message=str(exc),
-                )
-                failed_documents.append(
-                    {
-                        "document_id": str(document.id),
-                        "title": document.title,
-                        "error": str(exc),
-                    }
-                )
-
-            documents_done += 1
-            await self._update_run_counts(
-                application_run_id=application_run_id,
-                documents_coded=documents_coded,
-                documents_failed=len(failed_documents),
-                status="running",
+            batch_results = await self._apply_document_batch_with_retries(
+                documents=[documents[index] for index in document_indexes],
+                codebook_context=codebook_context,
+                chain=chain,
+                should_cancel=should_cancel,
             )
-            if on_progress is not None:
-                await on_progress(documents_done, len(documents))
+            for local_index, result in enumerate(batch_results):
+                document = documents[document_indexes[local_index]]
+                await self._raise_if_cancelled(should_cancel)
+                try:
+                    if isinstance(result, Exception):
+                        raise result
+                    await self._persist_successful_document_coding(
+                        application_run_id=application_run_id,
+                        codebook_id=codebook_id,
+                        document=document,
+                        result=result,
+                        themes_by_label=themes_by_label,
+                        codes_by_label=codes_by_label,
+                    )
+                    documents_coded += 1
+                except CodebookApplicationCancelledError:
+                    raise
+                except Exception as exc:
+                    await self._session.rollback()
+                    logger.warning(
+                        "Codebook application failed for document {} after retries: {}",
+                        document.id,
+                        exc,
+                    )
+                    await self._persist_failed_document_coding(
+                        application_run_id=application_run_id,
+                        codebook_id=codebook_id,
+                        document=document,
+                        error_message=str(exc),
+                    )
+                    failed_documents.append(
+                        {
+                            "document_id": str(document.id),
+                            "title": document.title,
+                            "error": str(exc),
+                        }
+                    )
+
+                documents_done += 1
+                await self._update_run_counts(
+                    application_run_id=application_run_id,
+                    documents_coded=documents_coded,
+                    documents_failed=len(failed_documents),
+                    status="running",
+                )
+                if on_progress is not None:
+                    await on_progress(documents_done, len(documents))
 
         await self._raise_if_cancelled(should_cancel)
         if on_phase is not None:
@@ -434,38 +441,99 @@ class CodebookApplicationService:
                     lines.append(f"  Code definition: {code.description}")
         return "\n".join(lines).strip()
 
-    async def _apply_document_with_retries(
+    async def _apply_document_batch_with_retries(
         self,
         *,
-        transcript: str,
+        documents: list[_DocumentText],
         codebook_context: str,
         chain: Runnable[dict[str, str], dict[str, Any]],
-    ) -> CodebookApplicationResult:
-        last_error: Exception | None = None
-        for attempt in range(1, _APPLICATION_MAX_ATTEMPTS + 1):
-            try:
-                return await apply_codebook_with_codes_to_transcript(
-                    transcript,
-                    codebook_context,
-                    chain=chain,
+        should_cancel: Callable[[], Awaitable[bool]] | None = None,
+    ) -> list[CodebookApplicationResult | Exception]:
+        started_at = time.monotonic()
+
+        total = len(documents)
+        results_by_index: dict[int, CodebookApplicationResult] = {}
+        failures_by_index: dict[int, Exception] = {}
+        attempts_by_index: dict[int, int] = {index: 0 for index in range(total)}
+        pending_indexes: list[int] = []
+
+        for index, document in enumerate(documents):
+            if not document.content.strip():
+                failures_by_index[index] = ValueError("Transcript is empty.")
+            else:
+                pending_indexes.append(index)
+
+        while pending_indexes:
+            await self._raise_if_cancelled(should_cancel)
+            retryable_failure_detected = False
+            retry_indexes: list[int] = []
+
+            batch_results = await apply_codebook_with_codes_to_transcripts(
+                [documents[index].content for index in pending_indexes],
+                codebook_context,
+                chain=chain,
+                max_concurrency=_APPLICATION_MAX_CONCURRENCY,
+            )
+            for local_index, result in enumerate(batch_results):
+                document_index = pending_indexes[local_index]
+                attempts_by_index[document_index] += 1
+                attempt_count = attempts_by_index[document_index]
+
+                if isinstance(result, CodebookApplicationResult):
+                    results_by_index[document_index] = result
+                    continue
+
+                if attempt_count < _APPLICATION_MAX_ATTEMPTS:
+                    retryable_failure_detected = True
+                    retry_indexes.append(document_index)
+                    logger.warning(
+                        "Codebook application LLM call failed on attempt {}/{} for document {}: {}",
+                        attempt_count,
+                        _APPLICATION_MAX_ATTEMPTS,
+                        documents[document_index].id,
+                        result,
+                    )
+                    continue
+
+                failures_by_index[document_index] = UnprocessableError(
+                    f"LLM codebook application failed after {_APPLICATION_MAX_ATTEMPTS} attempts: {result}"
                 )
-            except Exception as exc:
-                last_error = exc
-                if attempt >= _APPLICATION_MAX_ATTEMPTS:
-                    break
-                delay = self._compute_retry_delay(attempt=attempt)
-                logger.warning(
-                    "Codebook application LLM call failed on attempt {}/{}: {}. Retrying in {:.2f}s",
-                    attempt,
-                    _APPLICATION_MAX_ATTEMPTS,
-                    exc,
-                    delay,
+
+            if not retry_indexes:
+                break
+            pending_indexes = retry_indexes
+            if retryable_failure_detected:
+                retry_attempt = max(attempts_by_index[index] for index in retry_indexes)
+                retry_delay = self._compute_retry_delay(attempt=retry_attempt)
+                if retry_delay > 0:
+                    await asyncio.sleep(retry_delay)
+
+        ordered_results: list[CodebookApplicationResult | Exception] = []
+        for index in range(total):
+            result = results_by_index.get(index)
+            if result is not None:
+                ordered_results.append(result)
+            else:
+                ordered_results.append(
+                    failures_by_index.get(index) or UnprocessableError("Codebook application produced no result.")
                 )
-                if delay > 0:
-                    await asyncio.sleep(delay)
-        raise UnprocessableError(
-            f"LLM codebook application failed after {_APPLICATION_MAX_ATTEMPTS} attempts: {last_error}"
+
+        logger.info(
+            "Codebook application batch complete: documents={}, succeeded={}, failed={}, total_attempts={}, "
+            "max_concurrency={}, batch_size={}, elapsed_s={:.2f}",
+            total,
+            len(results_by_index),
+            total - len(results_by_index),
+            sum(attempts_by_index.values()),
+            _APPLICATION_MAX_CONCURRENCY,
+            _APPLICATION_BATCH_SIZE,
+            time.monotonic() - started_at,
         )
+        return ordered_results
+
+    @staticmethod
+    def _chunked(items: list[int], chunk_size: int) -> list[list[int]]:
+        return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
 
     async def _persist_successful_document_coding(
         self,

--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -148,6 +148,8 @@ class CodebookApplicationService:
         documents_coded = 0
         failed_documents: list[dict[str, str]] = []
 
+        # Process fixed-size index batches so result order can be mapped back to
+        # the original document list after LangChain returns the batched output.
         for document_indexes in self._chunked(list(range(len(documents))), _APPLICATION_BATCH_SIZE):
             await self._raise_if_cancelled(should_cancel)
             batch_results = await self._apply_document_batch_with_retries(
@@ -160,6 +162,8 @@ class CodebookApplicationService:
                 document = documents[document_indexes[local_index]]
                 await self._raise_if_cancelled(should_cancel)
                 try:
+                    # Batch calls return exceptions as values so one failed
+                    # document does not prevent successful documents persisting.
                     if isinstance(result, Exception):
                         raise result
                     await self._persist_successful_document_coding(
@@ -194,6 +198,8 @@ class CodebookApplicationService:
                         }
                     )
 
+                # Persist progress after each document, not after each batch, so
+                # the job endpoint remains accurate during long application runs.
                 documents_done += 1
                 await self._update_run_counts(
                     application_run_id=application_run_id,
@@ -457,6 +463,8 @@ class CodebookApplicationService:
         attempts_by_index: dict[int, int] = {index: 0 for index in range(total)}
         pending_indexes: list[int] = []
 
+        # Empty transcripts are deterministic input errors, so they are recorded
+        # immediately and skipped instead of being sent to the LLM.
         for index, document in enumerate(documents):
             if not document.content.strip():
                 failures_by_index[index] = ValueError("Transcript is empty.")
@@ -465,9 +473,10 @@ class CodebookApplicationService:
 
         while pending_indexes:
             await self._raise_if_cancelled(should_cancel)
-            retryable_failure_detected = False
             retry_indexes: list[int] = []
 
+            # Only unresolved documents are sent on each attempt. Successful
+            # documents stay in results_by_index and are never billed again.
             batch_results = await apply_codebook_with_codes_to_transcripts(
                 [documents[index].content for index in pending_indexes],
                 codebook_context,
@@ -484,7 +493,6 @@ class CodebookApplicationService:
                     continue
 
                 if attempt_count < _APPLICATION_MAX_ATTEMPTS:
-                    retryable_failure_detected = True
                     retry_indexes.append(document_index)
                     logger.warning(
                         "Codebook application LLM call failed on attempt {}/{} for document {}: {}",
@@ -502,11 +510,13 @@ class CodebookApplicationService:
             if not retry_indexes:
                 break
             pending_indexes = retry_indexes
-            if retryable_failure_detected:
-                retry_attempt = max(attempts_by_index[index] for index in retry_indexes)
-                retry_delay = self._compute_retry_delay(attempt=retry_attempt)
-                if retry_delay > 0:
-                    await asyncio.sleep(retry_delay)
+
+            # The retry set may contain documents with different attempt counts;
+            # use the highest count so the shared sleep never under-backs off.
+            retry_attempt = max(attempts_by_index[index] for index in retry_indexes)
+            retry_delay = self._compute_retry_delay(attempt=retry_attempt)
+            if retry_delay > 0:
+                await asyncio.sleep(retry_delay)
 
         ordered_results: list[CodebookApplicationResult | Exception] = []
         for index in range(total):
@@ -514,6 +524,8 @@ class CodebookApplicationService:
             if result is not None:
                 ordered_results.append(result)
             else:
+                # This fallback protects the caller from impossible states such
+                # as a shortened LangChain result list.
                 ordered_results.append(
                     failures_by_index.get(index) or UnprocessableError("Codebook application produced no result.")
                 )

--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -520,9 +520,9 @@ class CodebookApplicationService:
 
         ordered_results: list[CodebookApplicationResult | Exception] = []
         for index in range(total):
-            result = results_by_index.get(index)
-            if result is not None:
-                ordered_results.append(result)
+            successful_result = results_by_index.get(index)
+            if successful_result is not None:
+                ordered_results.append(successful_result)
             else:
                 # This fallback protects the caller from impossible states such
                 # as a shortened LangChain result list.

--- a/Backend/tests/test_codebook_application_jobs_api.py
+++ b/Backend/tests/test_codebook_application_jobs_api.py
@@ -133,13 +133,19 @@ def _application_result(quote: str = "manual handoffs slow") -> CodebookApplicat
 
 
 def _patch_application(monkeypatch, single_transcript_fn) -> None:
-    async def _fake_apply(transcript: str, codebook_context: str, *_, **__):
+    async def _fake_apply_batch(transcripts: list[str], codebook_context: str, *_, **__):
         del codebook_context
-        return single_transcript_fn(transcript)
+        results = []
+        for transcript in transcripts:
+            try:
+                results.append(single_transcript_fn(transcript))
+            except Exception as exc:
+                results.append(exc)
+        return results
 
     monkeypatch.setattr(
-        "app.services.codebook_application.apply_codebook_with_codes_to_transcript",
-        _fake_apply,
+        "app.services.codebook_application.apply_codebook_with_codes_to_transcripts",
+        _fake_apply_batch,
     )
     monkeypatch.setattr(
         "app.services.codebook_application.build_codebook_application_with_codes_chain",
@@ -227,6 +233,51 @@ async def test_apply_codebook_job_retries_llm_and_fails_only_one_transcript(clie
     assert statuses == {"coded", "failed"}
 
 
+async def test_apply_codebook_job_uses_generation_parallelization_settings(client, db_engine, monkeypatch) -> None:
+    corpus_id, codebook_id, document_ids = await _seed_corpus_codebook(
+        db_engine,
+        texts=[f"Participant: The manual handoffs slow team {index}." for index in range(17)],
+    )
+    del corpus_id
+
+    batch_sizes: list[int] = []
+    max_concurrency_values: list[int | None] = []
+
+    async def _fake_apply_batch(
+        transcripts: list[str],
+        codebook_context: str,
+        *_,
+        max_concurrency: int | None = None,
+        **__,
+    ):
+        del codebook_context
+        batch_sizes.append(len(transcripts))
+        max_concurrency_values.append(max_concurrency)
+        return [_application_result(quote="manual handoffs slow") for _ in transcripts]
+
+    monkeypatch.setattr(
+        "app.services.codebook_application.apply_codebook_with_codes_to_transcripts",
+        _fake_apply_batch,
+    )
+    monkeypatch.setattr(
+        "app.services.codebook_application.build_codebook_application_with_codes_chain",
+        lambda: object(),
+    )
+
+    create_response = await client.post(
+        f"{API_CODEBOOKS}/{codebook_id}/apply-jobs",
+        json={"transcript_document_ids": document_ids},
+    )
+
+    assert create_response.status_code == 202
+    terminal_job = await _wait_for_terminal_job_status(client, create_response.json()["data"]["id"])
+    assert terminal_job["status"] == "succeeded"
+    assert terminal_job["documents_coded"] == 17
+    assert terminal_job["documents_failed"] == 0
+    assert batch_sizes == [16, 1]
+    assert max_concurrency_values == [8, 8]
+
+
 async def test_apply_codebook_job_creates_new_run_without_overwrite(client, db_engine, monkeypatch) -> None:
     corpus_id, codebook_id, document_ids = await _seed_corpus_codebook(
         db_engine,
@@ -262,14 +313,14 @@ async def test_apply_codebook_job_can_be_cancelled_while_running(client, db_engi
     )
     del corpus_id
 
-    async def _slow_apply(transcript: str, codebook_context: str, *_, **__):
-        del transcript, codebook_context
+    async def _slow_apply_batch(transcripts: list[str], codebook_context: str, *_, **__):
+        del codebook_context
         await asyncio.sleep(0.05)
-        return _application_result()
+        return [_application_result() for _ in transcripts]
 
     monkeypatch.setattr(
-        "app.services.codebook_application.apply_codebook_with_codes_to_transcript",
-        _slow_apply,
+        "app.services.codebook_application.apply_codebook_with_codes_to_transcripts",
+        _slow_apply_batch,
     )
     monkeypatch.setattr(
         "app.services.codebook_application.build_codebook_application_with_codes_chain",

--- a/Backend/tests/test_codebook_pipeline.py
+++ b/Backend/tests/test_codebook_pipeline.py
@@ -8,8 +8,8 @@ import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 
-from app.llm.pipelines import apply_codebook_to_interview
-from app.schemas.llm import InterviewAnalysisResult
+from app.llm.pipelines import apply_codebook_to_interview, apply_codebook_with_codes_to_transcripts
+from app.schemas.llm import CodebookApplicationResult, InterviewAnalysisResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -200,4 +200,40 @@ class TestMultipleInterviews:
         assert theme_to_count["Poor Change Management"] == 1
         assert theme_to_count["Collaboration Benefits"] == 1
         assert "Steep Learning Curve" not in theme_to_count
+
+
+class TestApplyCodebookBatchPipeline:
+    async def test_batch_helper_preserves_order_and_exceptions(self) -> None:
+        class FakeChain:
+            async def abatch(self, inputs, *, config=None, return_exceptions=False):
+                assert config == {"max_concurrency": 8}
+                assert return_exceptions is True
+                return [
+                    {
+                        "summary": "First transcript",
+                        "researcher_notes": None,
+                        "themes": [],
+                        "codes": [],
+                    },
+                    RuntimeError("provider timeout"),
+                    {
+                        "summary": "Third transcript",
+                        "researcher_notes": None,
+                        "themes": [],
+                        "codes": [],
+                    },
+                ]
+
+        results = await apply_codebook_with_codes_to_transcripts(
+            ["first", "second", "third"],
+            SAMPLE_CODEBOOK,
+            chain=FakeChain(),
+            max_concurrency=8,
+        )
+
+        assert isinstance(results[0], CodebookApplicationResult)
+        assert results[0].summary == "First transcript"
+        assert isinstance(results[1], RuntimeError)
+        assert isinstance(results[2], CodebookApplicationResult)
+        assert results[2].summary == "Third transcript"
 


### PR DESCRIPTION
This pull request introduces significant improvements to the codebook application pipeline, focusing on efficient batch processing and parallelization.

**Batch Processing & Parallelization Enhancements:**

- Implemented a new `apply_codebook_with_codes_to_transcripts` function in `pipelines.py` to support batch processing of multiple transcripts with parallel execution and per-document error handling. This function ensures input order is preserved and exceptions are returned as results for individual documents.
- Updated the service layer in `codebook_application.py` to process documents in fixed-size batches (`_APPLICATION_BATCH_SIZE = 16`) and with configurable parallelism (`_APPLICATION_MAX_CONCURRENCY = 8`). The retry logic now operates at the batch level, with independent retries and error tracking for each document.

**Error Handling & Retry Improvements:**

- Enhanced retry logic to handle errors per document within a batch, allowing successful documents to be persisted even if others fail. Retries are managed with exponential backoff and capped attempts, and detailed logging is added for batch outcomes.
- Empty transcripts are detected and skipped before invoking the LLM, immediately marking them as errors without billing or retrying.

**Pipeline and Code Clarity:**

- Added detailed comments throughout the LLM pipeline functions in `pipelines.py` to clarify the flow of data, the responsibilities of each pipeline stage, and the reasoning behind architectural choices such as prompt structure and parser usage.