### PR TITLE
Hotfix/110 wrong success message after ingestion

### DIFF
--- a/Backend/app/routers/ingestion.py
+++ b/Backend/app/routers/ingestion.py
@@ -166,7 +166,9 @@ async def upload_documents(
 ) -> ResponseEnvelope[MultiUploadResultSchema]:
     """Accept one or more uploaded transcripts (.txt / .docx / .pdf / .jsonl) and
     ingest their contents. Each file produces an independent result, so a single
-    bad file does not block the others."""
+    bad file does not block the others. The envelope's top-level `success`
+    reflects the batch as a whole: it is only True if every file ingested
+    cleanly, even though the request itself always returns 201."""
     service = IngestionService(session)
     results = [
         await _process_one_upload(
@@ -177,7 +179,14 @@ async def upload_documents(
         )
         for f in files
     ]
-    return ResponseEnvelope.ok(MultiUploadResultSchema(results=results))
+    payload = MultiUploadResultSchema(results=results)
+    if all(r.success for r in results):
+        return ResponseEnvelope.ok(payload)
+    return ResponseEnvelope[MultiUploadResultSchema](
+        success=False,
+        data=payload,
+        error="One or more files failed to ingest; see results for details.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/Backend/tests/test_ingestion_api.py
+++ b/Backend/tests/test_ingestion_api.py
@@ -430,7 +430,9 @@ async def test_upload_empty_file_rejected(client):
         files={"files": ("empty.txt", b"", "text/plain")},
     )
     log.check(resp.status_code == 201, "endpoint returned 201")
-    result = resp.json()["data"]["results"][0]
+    body = resp.json()
+    log.check(body["success"] is False, "envelope success=False when the only file fails")
+    result = body["data"]["results"][0]
     log.check(result["success"] is False, "0-byte file rejected")
     log.check("empty" in result["error"], f"error mentions empty ({result['error']!r})")
     log.report("Empty-file rejection [empty.txt, 0 bytes]")

--- a/Backend/tests/test_ingestion_api.py
+++ b/Backend/tests/test_ingestion_api.py
@@ -261,7 +261,9 @@ async def test_upload_txt_real_fixture(client):
         files={"files": (_TXT_FIXTURE.name, content, "text/plain")},
     )
     log.check(resp.status_code == 201, f"endpoint returned 201 (got {resp.status_code})")
-    result = resp.json()["data"]["results"][0]
+    body = resp.json()
+    log.check(body["success"] is True, "envelope success=True when every file succeeds")
+    result = body["data"]["results"][0]
     log.check(result["success"] is True, f"per-file success=True for {_TXT_FIXTURE.name}")
     log.check(result["documents_created"] == 1, "exactly one document created")
     log.report(f"Upload .txt real fixture [{_TXT_FIXTURE.name}, {len(content)} bytes]")
@@ -347,7 +349,9 @@ async def test_upload_multiple_files(client):
         ],
     )
     log.check(resp.status_code == 201, "endpoint returned 201")
-    results = resp.json()["data"]["results"]
+    body = resp.json()
+    log.check(body["success"] is True, "envelope success=True when every file succeeds")
+    results = body["data"]["results"]
     log.check(len(results) == 2, f"received per-file result for each input ({len(results)})")
     log.check(all(r["success"] for r in results), "every file reported success")
     log.report("Multi-file upload [2 files]")
@@ -366,7 +370,9 @@ async def test_upload_partial_failure_returns_per_file_results(client):
         ],
     )
     log.check(resp.status_code == 201, "endpoint still returned 201 despite one failure")
-    results = resp.json()["data"]["results"]
+    body = resp.json()
+    log.check(body["success"] is False, "envelope success=False when any file fails")
+    results = body["data"]["results"]
     log.check(results[0]["success"] is True, "good.txt succeeded")
     log.check(results[1]["success"] is False, "bad.csv failed")
     log.check("Unsupported" in results[1]["error"], f"error message mentions unsupported ({results[1]['error']!r})")
@@ -383,7 +389,9 @@ async def test_upload_unsupported_extension(client):
         files={"files": ("data.csv", b"text\nhello", "text/csv")},
     )
     log.check(resp.status_code == 201, "endpoint returned 201 (errors are per-file)")
-    result = resp.json()["data"]["results"][0]
+    body = resp.json()
+    log.check(body["success"] is False, "envelope success=False when the only file fails")
+    result = body["data"]["results"][0]
     log.check(result["success"] is False, "csv rejected")
     log.check("Unsupported" in result["error"], f"error mentions unsupported ({result['error']!r})")
     log.report("Unsupported extension [data.csv]")
@@ -401,7 +409,9 @@ async def test_upload_oversize_file_rejected(client):
         files={"files": ("big.txt", oversize, "text/plain")},
     )
     log.check(resp.status_code == 201, "endpoint returned 201")
-    result = resp.json()["data"]["results"][0]
+    body = resp.json()
+    log.check(body["success"] is False, "envelope success=False when the only file fails")
+    result = body["data"]["results"][0]
     log.check(result["success"] is False, f"{len(oversize)}-byte file rejected")
     log.check(
         "exceeds maximum size" in result["error"],


### PR DESCRIPTION
upload_documents now computes the batch outcome from the per-file results instead of blindly calling ResponseEnvelope.ok(...):


payload = MultiUploadResultSchema(results=results)
if all(r.success for r in results):
    return ResponseEnvelope.ok(payload)
return ResponseEnvelope[MultiUploadResultSchema](
    success=False,
    data=payload,
    error="One or more files failed to ingest; see results for details.",
)


Tests updated:

[Backend/tests/test_ingestion_api.py](vscode-webview://0k6igf664gd5mhfqdqs98dndjnnf6op1fkqq4k4q6uomkst7v4af/Backend/tests/test_ingestion_api.py) now asserts the envelope-level success, not just per-file success, in:

test_upload_txt_real_fixture, test_upload_multiple_files → True on full success
test_upload_partial_failure_returns_per_file_results → False on partial failure
test_upload_unsupported_extension, test_upload_oversize_file_rejected, test_upload_empty_file_rejected → False on total failure