### PR TITLE
Update Corpus deletion and analysis view

### DIFF
--- a/Backend/app/models/analysis.py
+++ b/Backend/app/models/analysis.py
@@ -25,6 +25,8 @@ class CodebookApplicationRun(Base, TimestampMixin):
     __tablename__ = "codebook_application_runs"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    custom_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     corpus_id: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True), ForeignKey("corpora.id", ondelete="CASCADE"), index=True
     )
@@ -112,6 +114,8 @@ class CodebookApplicationJob(Base, TimestampMixin):
     __tablename__ = "codebook_application_jobs"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    custom_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     status: Mapped[str] = mapped_column(String(32), index=True, default="queued")
     phase: Mapped[str] = mapped_column(String(64), default="queued")
     corpus_id: Mapped[uuid.UUID] = mapped_column(

--- a/Backend/app/routers/codebook_applications.py
+++ b/Backend/app/routers/codebook_applications.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from sqlalchemy import desc, select
+from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.dependencies import DbSession
@@ -16,6 +16,7 @@ from app.models import (
     Codebook,
     CodebookApplicationJob,
     CodebookApplicationRun,
+    Corpus,
     CorpusDocument,
     DocumentCoding,
     ThemeAssignment,
@@ -64,6 +65,8 @@ def _compute_progress_percent(job: CodebookApplicationJob) -> int:
 def _to_job_schema(job: CodebookApplicationJob) -> CodebookApplicationJobSchema:
     return CodebookApplicationJobSchema(
         id=job.id,
+        name=job.name,
+        custom_id=job.custom_id,
         status=job.status,
         phase=job.phase,
         progress_percent=_compute_progress_percent(job),
@@ -84,8 +87,11 @@ def _to_job_schema(job: CodebookApplicationJob) -> CodebookApplicationJobSchema:
     )
 
 
-def _to_run_schema(run: CodebookApplicationRun) -> CodebookApplicationRunSchema:
-    return CodebookApplicationRunSchema.model_validate(run)
+def _to_run_schema(run: CodebookApplicationRun, transcript_document_ids: list[UUID] | None = None) -> CodebookApplicationRunSchema:
+    schema = CodebookApplicationRunSchema.model_validate(run)
+    if transcript_document_ids is not None:
+        schema.transcript_document_ids = transcript_document_ids
+    return schema
 
 
 def _to_document_coding_schema(
@@ -166,8 +172,32 @@ async def create_apply_codebook_job(
     session: DbSession,
 ) -> JSONResponse:
     corpus_id = await _validate_job_create_payload(codebook_id=codebook_id, payload=payload, session=session)
+
+    # Auto-generate name and custom_id if empty
+    name = payload.name
+    custom_id = payload.custom_id
+
+    if not name or not custom_id:
+        # Get run count for this corpus to generate incrementing ID
+        run_count_query = select(func.count(CodebookApplicationRun.id)).where(CodebookApplicationRun.corpus_id == corpus_id)
+        run_count = await session.scalar(run_count_query) or 0
+        run_number = run_count + 1
+
+        if not custom_id:
+            custom_id = f"RUN-{run_number:03d}"
+
+        if not name:
+            corpus = await session.get(Corpus, corpus_id)
+            corpus_name = corpus.name if corpus else "Corpus"
+            if run_number == 1:
+                name = f"{corpus_name} Analysis"
+            else:
+                name = f"{corpus_name} Analysis {run_number}"
+
     job = CodebookApplicationJob(
         id=uuid4(),
+        name=name,
+        custom_id=custom_id,
         status="queued",
         phase="queued",
         corpus_id=corpus_id,
@@ -257,8 +287,28 @@ async def list_codebook_application_runs(
         .order_by(desc(CodebookApplicationRun.created_at))
     )
     runs = list((await session.scalars(stmt)).all())
+
+    if not runs:
+        return JSONResponse(content=ResponseEnvelope.ok([]).model_dump(mode="json"))
+
+    run_ids = [run.id for run in runs]
+
+    docs_stmt = select(DocumentCoding.application_run_id, DocumentCoding.document_id).where(
+        DocumentCoding.application_run_id.in_(run_ids)
+    )
+    docs_result = await session.execute(docs_stmt)
+
+    run_to_docs: dict[UUID, list[UUID]] = {run_id: [] for run_id in run_ids}
+    for run_id, document_id in docs_result:
+        run_to_docs[run_id].append(document_id)
+
+    schemas = [
+        _to_run_schema(run, transcript_document_ids=run_to_docs[run.id])
+        for run in runs
+    ]
+
     return JSONResponse(
-        content=ResponseEnvelope.ok([_to_run_schema(run) for run in runs]).model_dump(mode="json")
+        content=ResponseEnvelope.ok(schemas).model_dump(mode="json")
     )
 
 
@@ -275,8 +325,9 @@ async def get_codebook_application_run(
     if run is None:
         raise NotFoundError(f"Codebook application run '{run_id}' not found")
     document_codings = await _load_document_coding_schemas(run_id=run_id, session=session)
+    transcript_ids = [dc.document_id for dc in document_codings]
     detail = CodebookApplicationRunDetailSchema(
-        **_to_run_schema(run).model_dump(),
+        **_to_run_schema(run, transcript_document_ids=transcript_ids).model_dump(),
         document_codings=document_codings,
     )
     return JSONResponse(content=ResponseEnvelope.ok(detail).model_dump(mode="json"))

--- a/Backend/app/schemas/codebook_application.py
+++ b/Backend/app/schemas/codebook_application.py
@@ -13,6 +13,8 @@ RunStatus = Literal["running", "succeeded", "failed", "cancelled"]
 
 
 class CodebookApplicationJobCreateRequest(BaseSchema):
+    name: str | None = Field(default=None, description="User-defined name for the analysis run.")
+    custom_id: str | None = Field(default=None, description="User-defined ID for the analysis run.")
     corpus_id: UUID | None = Field(
         default=None,
         description="Deprecated. The application corpus is resolved from the selected codebook.",
@@ -39,6 +41,8 @@ class CodebookApplicationJobCreateRequest(BaseSchema):
 
 class CodebookApplicationJobSchema(BaseSchema):
     id: UUID
+    name: str | None = None
+    custom_id: str | None = None
     status: JobStatus
     phase: str
     progress_percent: int
@@ -60,6 +64,8 @@ class CodebookApplicationJobSchema(BaseSchema):
 
 class CodebookApplicationRunSchema(BaseSchema):
     id: UUID
+    name: str | None = None
+    custom_id: str | None = None
     corpus_id: UUID
     codebook_id: UUID
     status: RunStatus
@@ -70,6 +76,7 @@ class CodebookApplicationRunSchema(BaseSchema):
     updated_at: datetime
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    transcript_document_ids: list[UUID] = Field(default_factory=list)
 
 
 class ThemeAssignmentSchema(BaseSchema):

--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -89,6 +89,8 @@ class CodebookApplicationService:
     async def apply_codebook(
         self,
         *,
+        name: str | None = None,
+        custom_id: str | None = None,
         corpus_id: UUID,
         codebook_id: UUID,
         transcript_document_ids: list[UUID] | None,
@@ -120,6 +122,8 @@ class CodebookApplicationService:
 
         application_run = CodebookApplicationRun(
             id=uuid.uuid4(),
+            name=name,
+            custom_id=custom_id,
             corpus_id=corpus_id,
             codebook_id=codebook_id,
             status="running",

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -123,6 +123,8 @@ class CodebookApplicationJobRunner:
 
             try:
                 summary = await service.apply_codebook(
+                    name=job.name,
+                    custom_id=job.custom_id,
                     corpus_id=job.corpus_id,
                     codebook_id=job.codebook_id,
                     transcript_document_ids=transcript_document_ids,

--- a/Documentation/User-Documentation.md
+++ b/Documentation/User-Documentation.md
@@ -20,6 +20,7 @@ Once the application is running, you can access the following services:
 A **Corpus** is a collection of related documents.
 - **Create a Corpus:** Group your research materials logically (e.g., "Customer Interviews 2026").
 - **Upload Documents:** Add unstructured text documents (PDFs, transcripts) to a Corpus. The system automatically breaks these documents down into manageable **Chunks**.
+- **Delete Corpus:** Note that deleting a corpus is a permanent action and is ONLY accessible from the "Upload" view of your selected corpus.
 
 ### 2. Codebook Interaction
 A **Codebook** defines the themes you are looking for. It acts as a hierarchical structure of nodes/themes.
@@ -38,5 +39,5 @@ The system builds a queryable thematic knowledge graph based on your analysis.
 1. **Setup:** Ensure your administrator has configured the `LLM_API_KEY` to enable the AI pipeline.
 2. **Ingest Data:** Navigate to the API or Demo UI and create a new Corpus. Upload your source files.
 3. **Select/Upload a Codebook:** Provide a hierarchical tree of themes (in JSON or CSV format, depending on your setup) that represents what you want to extract.
-4. **Run Analysis:** Trigger the thematic mapping process. The LangChain pipeline will analyze each text chunk.
-5. **Review Results:** Explore the knowledge graph to discover insights, validate mappings, and track overarching themes across all documents.
+4. **Run Analysis:** Navigate to the "Trigger Analysis" page. You can optionally name your run. You may choose a specific Codebook and select the transcripts you wish to run against from the list. *Note: The system will warn you if you attempt to submit a run with the exact same Codebook and Transcripts as a previous run.*
+5. **Review Results:** You can track the progress and status of your analysis runs in the "Previous Analysis Runs" table located beneath the trigger form. Explore the knowledge graph to discover insights, validate mappings, and track overarching themes across all documents.

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -251,7 +251,14 @@ class FakeBackend:
 
     # ---- Analysis Jobs ------------------------------------------------------
     
-    def trigger_analysis(self, corpus_id: str, codebook_id: str) -> dict:
+    def trigger_analysis(
+        self,
+        corpus_id: str,
+        codebook_id: str,
+        name: str | None = None,
+        custom_id: str | None = None,
+        transcript_document_ids: list[str] | None = None,
+    ) -> dict:
         self._maybe_raise("trigger_analysis")
         import uuid
         job_id = str(uuid.uuid4())
@@ -260,8 +267,11 @@ class FakeBackend:
             "status": "queued",
             "corpus_id": corpus_id,
             "codebook_id": codebook_id,
-            "passages_total": 5,
-            "passages_done": 0,
+            "name": name,
+            "custom_id": custom_id,
+            "transcript_document_ids": transcript_document_ids or [],
+            "documents_total": 5,
+            "documents_done": 0,
         }
         if not hasattr(self, "analysis_jobs"):
             self.analysis_jobs = {}
@@ -271,8 +281,12 @@ class FakeBackend:
     def get_analysis_job(self, job_id: str) -> dict:
         self._maybe_raise("get_analysis_job")
         if not hasattr(self, "analysis_jobs") or job_id not in self.analysis_jobs:
-            return {"id": job_id, "status": "succeeded", "passages_total": 5, "passages_done": 5}
+            return {"id": job_id, "status": "succeeded", "documents_total": 5, "documents_done": 5}
         return self.analysis_jobs[job_id]
+
+    def list_codebook_application_runs(self, codebook_id: str) -> list[dict]:
+        self._maybe_raise("list_codebook_application_runs")
+        return []
 
     # ---- Internal -----------------------------------------------------------
 

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -86,7 +86,7 @@ def test_trigger_analysis_missing_data(client, fake_backend):
 def test_analysis_wait_page(client):
     resp = client.get("/analysis/job/test-job")
     assert resp.status_code == 200
-    assert b"Analysis in Progress" in resp.data
+    assert b"Applying Codebook" in resp.data
 
 def test_analysis_job_status(client, fake_backend):
     job = fake_backend.trigger_analysis("test", "cb1")

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -23,24 +23,41 @@ def index() -> str:
     except BackendError:
         active_corpus_id = None
         
+    transcripts = []
+    codebooks = []
+    previous_runs = []
+
     if not active_corpus_id:
         disabled_reason = "No active corpus selected."
     else:
         try:
-            # Fetch at most 1 document since we only need to check if the corpus is empty
-            docs_resp = client.list_documents(active_corpus_id, page_size=1)
-            transcripts_count = len(docs_resp)
+            # Fetch all documents to populate the dropdown
+            docs_resp = client.list_documents(active_corpus_id, page_size=1000)
+            transcripts = docs_resp
+            transcripts_count = len(transcripts)
             
             codebooks = client.list_codebooks(active_corpus_id)
             if not codebooks:
                 disabled_reason = "Please configure a codebook for this corpus."
             else:
-                codebook = codebooks[0]
+                codebook = codebooks[0] # Default selection
                 
                 if transcripts_count == 0:
                     disabled_reason = "Corpus has no transcripts."
                 else:
                     can_run_analysis = True
+                
+                # Fetch runs for all codebooks
+                for cb in codebooks:
+                    runs = client.list_codebook_application_runs(cb["id"])
+                    # Attach codebook name to each run for display
+                    for r in runs:
+                        r["codebook_name"] = cb["name"]
+                    previous_runs.extend(runs)
+                
+                # Sort runs by created_at descending
+                previous_runs.sort(key=lambda x: x.get("created_at", ""), reverse=True)
+                
         except BackendError as exc:
             disabled_reason = f"Error fetching prerequisites: {exc.user_message}"
             
@@ -49,7 +66,10 @@ def index() -> str:
         can_run_analysis=can_run_analysis,
         disabled_reason=disabled_reason,
         codebook=codebook,
+        codebooks=codebooks,
+        transcripts=transcripts,
         transcripts_count=transcripts_count,
+        previous_runs=previous_runs,
         active_corpus_id=active_corpus_id,
         corpus_options=corpus_options if active_corpus_id else [],
     )
@@ -58,6 +78,9 @@ def index() -> str:
 def trigger_analysis():
     corpus_id = request.form.get("corpus_id")
     codebook_id = request.form.get("codebook_id")
+    name = request.form.get("name")
+    custom_id = request.form.get("custom_id")
+    transcript_ids = request.form.getlist("transcript_document_ids")
     
     if not corpus_id or not codebook_id:
         flash("Missing corpus or codebook ID.", "danger")
@@ -65,7 +88,13 @@ def trigger_analysis():
         
     client = _backend()
     try:
-        job = client.trigger_analysis(corpus_id, codebook_id)
+        job = client.trigger_analysis(
+            corpus_id=corpus_id, 
+            codebook_id=codebook_id,
+            name=name,
+            custom_id=custom_id,
+            transcript_document_ids=transcript_ids if transcript_ids else None
+        )
         return redirect(url_for("analysis.wait", job_id=job["id"]))
     except BackendError as exc:
         flash(f"Failed to trigger analysis: {exc.user_message}", "danger")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -284,34 +284,34 @@ class BackendClient:
         except (json.JSONDecodeError, KeyError) as exc:
             self._handle_exc(exc, path, "DELETE", started_at)
 
-    # ---- Analysis Jobs (Mocked for Issue #10) -------------------------------
+    # ---- Analysis Jobs ------------------------------------------------------
 
-    def trigger_analysis(self, corpus_id: str, codebook_id: str) -> dict:
-        import uuid
-        job_id = str(uuid.uuid4())
-        # Store a fake start time on the class to simulate progress across requests
-        if not hasattr(self.__class__, "_mock_analysis_jobs"):
-            self.__class__._mock_analysis_jobs = {}
-        self.__class__._mock_analysis_jobs[job_id] = {"start_time": time.time(), "total": 10}
-        return {"id": job_id, "status": "queued"}
+    def trigger_analysis(
+        self,
+        corpus_id: str,
+        codebook_id: str,
+        name: str | None = None,
+        custom_id: str | None = None,
+        transcript_document_ids: list[str] | None = None,
+    ) -> dict:
+        payload: dict = {}
+        if name:
+            payload["name"] = name
+        if custom_id:
+            payload["custom_id"] = custom_id
+        if transcript_document_ids:
+            payload["transcript_document_ids"] = transcript_document_ids
+            
+        return self._post(f"/codebooks/{codebook_id}/apply-jobs", json=payload)
 
     def get_analysis_job(self, job_id: str) -> dict:
-        if not hasattr(self.__class__, "_mock_analysis_jobs") or job_id not in self.__class__._mock_analysis_jobs:
-            return {"id": job_id, "status": "succeeded", "passages_done": 10, "passages_total": 10}
-        
-        job_data = self.__class__._mock_analysis_jobs[job_id]
-        elapsed = time.time() - job_data["start_time"]
-        
-        # Simulate 1 passage done per second
-        done = min(int(elapsed * 2), job_data["total"])
-        status = "succeeded" if done >= job_data["total"] else "running"
-        
-        return {
-            "id": job_id,
-            "status": status,
-            "passages_done": done,
-            "passages_total": job_data["total"]
-        }
+        return self._get(f"/codebooks/apply-jobs/{job_id}")
+
+    def list_codebook_application_runs(self, codebook_id: str) -> list[dict]:
+        result = self._get(f"/codebooks/{codebook_id}/application-runs")
+        if isinstance(result, list):
+            return result
+        return result.get("items", result) if isinstance(result, dict) else []
 
     # ---- Codebook Upload & Parsing ------------------------------------------
 

--- a/Frontend/web/templates/_corpus_select.html
+++ b/Frontend/web/templates/_corpus_select.html
@@ -15,7 +15,7 @@
           </option>
         {% endfor %}
       </select>
-      {% if active_corpus_id %}
+      {% if active_corpus_id and show_delete_corpus %}
       <button type="button" class="btn btn-outline-danger shadow-none" data-bs-toggle="modal" data-bs-target="#deleteCorpusModal-{{ active_corpus_id }}">
         <i class="bi bi-trash"></i> Delete
       </button>

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -44,20 +44,136 @@
       </li>
     </ul>
 
-    <form method="POST" action="{{ url_for('analysis.trigger_analysis') }}" class="mt-4">
+    <form method="POST" action="{{ url_for('analysis.trigger_analysis') }}" class="mt-4" id="analysis-form">
       <input type="hidden" name="corpus_id" value="{{ active_corpus_id }}">
-      {% if codebook %}
-      <input type="hidden" name="codebook_id" value="{{ codebook.id }}">
-      {% endif %}
+      
+      <div class="row mb-4">
+        <div class="col-md-6">
+          <label for="name" class="form-label fw-semibold">Run Name (Optional)</label>
+          <input type="text" class="form-control" id="name" name="name" placeholder="E.g. Initial Run">
+        </div>
+        <div class="col-md-6">
+          <label for="codebook_id" class="form-label fw-semibold">Select Codebook</label>
+          <select class="form-select" id="codebook_id" name="codebook_id" required>
+            {% for cb in codebooks %}
+              <option value="{{ cb.id }}">{{ cb.name }} (v{{ cb.version }})</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <label class="form-label fw-semibold">Select Transcripts</label>
+        <div class="form-text mb-2">Select the transcripts to analyze. If none are selected, all transcripts will be used.</div>
+        <div class="ata-selectable-list border rounded-2" data-selectable-list>
+          <div class="table-responsive" style="max-height: 400px; overflow-y: auto;">
+            <table class="table table-sm table-hover align-middle mb-0">
+              <thead class="table-light sticky-top">
+                <tr>
+                  <th class="ata-selectable-list__checkbox-cell ps-3" scope="col">
+                    <input class="form-check-input" type="checkbox" id="selectAllTranscripts" aria-label="Select all transcripts" checked>
+                  </th>
+                  <th>Filename</th>
+                  <th>Title</th>
+                  <th>Uploaded</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for t in transcripts %}
+                  <tr class="ata-selectable-list__row" data-selectable-list-row data-item-id="{{ t.id }}">
+                    <td class="ata-selectable-list__checkbox-cell ps-3">
+                      <input class="form-check-input transcript-checkbox"
+                             type="checkbox"
+                             name="transcript_document_ids"
+                             value="{{ t.id }}"
+                             data-selectable-list-checkbox
+                             aria-label="Select transcript {{ t.title }}" checked>
+                    </td>
+                    <td>{{ t.get('filename') or '—' }}</td>
+                    <td>{{ t.get('title', 'Unknown') }}</td>
+                    <td class="text-secondary">{{ (t.get('created_at') or '')[:10] }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
       
       <div class="d-grid gap-2 d-md-flex justify-content-md-start">
         <span {% if not can_run_analysis %}data-bs-toggle="tooltip" title="{{ disabled_reason }}" tabindex="0"{% endif %}>
-          <button type="submit" class="btn {% if can_run_analysis %}btn-primary{% else %}btn-outline-primary{% endif %} px-4 py-2 fw-semibold rounded-3" {% if not can_run_analysis %}disabled style="pointer-events: none;"{% endif %}>
+          <button type="submit" id="submit-analysis-btn" class="btn {% if can_run_analysis %}btn-primary{% else %}btn-outline-primary{% endif %} px-4 py-2 fw-semibold rounded-3" {% if not can_run_analysis %}disabled style="pointer-events: none;"{% endif %}>
             Run Analysis
           </button>
         </span>
       </div>
     </form>
+  </div>
+</div>
+
+<!-- Table of previous runs -->
+<div class="card shadow-sm border-0 mb-4">
+  <div class="card-body p-4">
+    <h5 class="card-title fw-bold mb-3">Previous Analysis Runs</h5>
+    {% if previous_runs %}
+    <div class="table-responsive">
+      <table class="table table-hover align-middle">
+        <thead class="table-light">
+          <tr>
+            <th>Name</th>
+            <th>Run ID</th>
+            <th>Codebook</th>
+            <th>Status</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for run in previous_runs %}
+          <tr>
+            <td>{{ run.name or '-' }}</td>
+            <td>{{ run.custom_id or '-' }}</td>
+            <td>{{ run.codebook_name }}</td>
+            <td>
+              {% if run.status == 'succeeded' %}
+                <span class="badge bg-success">Succeeded</span>
+              {% elif run.status == 'failed' %}
+                <span class="badge bg-danger">Failed</span>
+              {% elif run.status == 'cancelled' %}
+                <span class="badge bg-secondary">Cancelled</span>
+              {% else %}
+                <span class="badge bg-primary">Running</span>
+              {% endif %}
+            </td>
+            <td>{{ run.created_at[:10] }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="text-muted mb-0">No previous analysis runs found for this corpus.</p>
+    {% endif %}
+  </div>
+</div>
+
+<!-- Warning Modal -->
+<div class="modal fade" id="duplicateWarningModal" tabindex="-1" aria-labelledby="duplicateWarningModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header text-warning">
+        <h5 class="modal-title" id="duplicateWarningModalLabel">
+          <i class="bi bi-exclamation-triangle-fill me-2"></i>Duplicate Warning
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="duplicateWarningModalMessage">
+        An analysis run with this Codebook and set of Transcripts already exists for this corpus. Are you sure you want to run it again?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-warning" id="confirmSubmitBtn">Proceed Anyway</button>
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}
@@ -68,7 +184,65 @@
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
     var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
       return new bootstrap.Tooltip(tooltipTriggerEl)
-    })
+    });
+
+    const previousRuns = {{ previous_runs | tojson | safe }};
+    const form = document.getElementById('analysis-form');
+    const duplicateModal = new bootstrap.Modal(document.getElementById('duplicateWarningModal'));
+    let forceSubmit = false;
+
+    const selectAllCb = document.getElementById('selectAllTranscripts');
+    const transcriptCbs = document.querySelectorAll('.transcript-checkbox');
+    
+    if (selectAllCb) {
+      selectAllCb.addEventListener('change', function(e) {
+        transcriptCbs.forEach(cb => cb.checked = e.target.checked);
+      });
+    }
+
+    if (form) {
+      form.addEventListener('submit', function(e) {
+        if (forceSubmit) return;
+
+        const selectedCodebookId = document.getElementById('codebook_id').value;
+        const selectedTranscriptCheckboxes = document.querySelectorAll('.transcript-checkbox:checked');
+        let selectedTranscriptIds = Array.from(selectedTranscriptCheckboxes).map(cb => cb.value);
+
+        // If no transcripts are selected, the backend assumes ALL transcripts are selected.
+        if (selectedTranscriptIds.length === 0) {
+            selectedTranscriptIds = Array.from(transcriptCbs).map(cb => cb.value);
+        }
+
+        selectedTranscriptIds.sort();
+
+        const isDuplicate = previousRuns.some(run => {
+          if (run.codebook_id !== selectedCodebookId) return false;
+          
+          let runTranscripts = run.transcript_document_ids || [];
+          let runTranscriptIds = [...runTranscripts].sort();
+          
+          if (runTranscriptIds.length !== selectedTranscriptIds.length) return false;
+          
+          return selectedTranscriptIds.every((val, index) => val === runTranscriptIds[index]);
+        });
+
+        if (isDuplicate) {
+          e.preventDefault();
+          document.getElementById('duplicateWarningModalMessage').textContent = 
+            'An analysis run with the exact same Codebook and Transcripts already exists. Are you sure you want to run it again?';
+          duplicateModal.show();
+        }
+      });
+    }
+
+    const confirmBtn = document.getElementById('confirmSubmitBtn');
+    if (confirmBtn) {
+      confirmBtn.addEventListener('click', function() {
+        forceSubmit = true;
+        duplicateModal.hide();
+        form.submit();
+      });
+    }
   });
 </script>
 {% endblock %}

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -1,90 +1,172 @@
 {% extends "base.html" %}
-
-{% block title %}Analysis in Progress{% endblock %}
-
-{% block head_extra %}
-<style>
-  .wait-container {
-    max-width: 600px;
-    margin: 4rem auto;
-    text-align: center;
-  }
-  .spinner-border {
-    width: 4rem;
-    height: 4rem;
-    color: var(--bs-primary);
-  }
-</style>
-{% endblock %}
-
+{% block title %}Applying Codebook{% endblock %}
 {% block content %}
-<div class="wait-container">
-  <div class="spinner-border mb-4" role="status">
-    <span class="visually-hidden">Loading...</span>
+  <div class="mb-4">
+    <h1 class="h3 mb-1">Applying Codebook</h1>
+    <p class="text-secondary mb-0 d-flex align-items-center gap-2">
+      <span id="status-spinner"
+            class="spinner-border spinner-border-sm text-secondary"
+            role="status"
+            aria-hidden="true"></span>
+      <span id="status-line">Starting analysis run&hellip;</span>
+    </p>
   </div>
-  
-  <h2 class="h3 mb-3">Analysis in Progress</h2>
-  <p class="text-secondary mb-4">
-    The system is now tagging your transcripts based on the codebook. This may take a few minutes depending on the size of the corpus.
-  </p>
 
-  <div class="progress mb-3" style="height: 1.5rem;">
-    <div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
+  <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
+       data-job-id="{{ job_id }}"
+       data-status-url="{{ url_for('analysis.job_status', job_id=job_id) }}"
+       data-list-url="{{ url_for('analysis.index') }}"
+       id="progress-app">
+
+    <div class="progress mb-3" role="progressbar" aria-label="Analysis progress">
+      <div id="progress-bar"
+           class="progress-bar progress-bar-striped progress-bar-animated"
+           style="width: 0%">0%</div>
+    </div>
+
+    <div class="text-secondary small mb-3">
+      <span id="progress-counts">Preparing&hellip;</span>
+    </div>
+
+    <div id="progress-error" class="alert alert-danger d-none" role="alert"></div>
+
+    <form id="cancel-form" method="post" action="">
+      <button type="button" id="cancel-btn" class="btn btn-outline-secondary">Cancel</button>
+    </form>
   </div>
-  
-  <div id="progress-text" class="text-muted small">Initializing...</div>
-</div>
-{% endblock %}
 
-{% block scripts %}
-<script>
-  (function() {
-    const jobId = "{{ job_id }}";
-    const statusUrl = "{{ url_for('analysis.job_status', job_id=job_id) }}";
-    const progressBar = document.getElementById("progress-bar");
-    const progressText = document.getElementById("progress-text");
+  <script>
+    (() => {
+      const app = document.getElementById("progress-app");
+      const jobId = app.dataset.jobId;
+      const statusUrl = app.dataset.statusUrl;
+      const listUrl = app.dataset.listUrl;
 
-    async function poll() {
-      try {
-        const response = await fetch(statusUrl, { headers: { "Accept": "application/json" } });
-        if (!response.ok) throw new Error("Network response was not ok");
-        const status = await response.json();
+      const statusLine = document.getElementById("status-line");
+      const statusSpinner = document.getElementById("status-spinner");
+      const bar = document.getElementById("progress-bar");
+      const counts = document.getElementById("progress-counts");
+      const errorEl = document.getElementById("progress-error");
+      const cancelBtn = document.getElementById("cancel-btn");
 
-        if (status.status === "succeeded") {
-          progressBar.style.width = "100%";
-          progressBar.textContent = "100%";
-          progressBar.classList.remove("progress-bar-animated");
-          progressBar.classList.add("bg-success");
-          progressText.textContent = "Analysis complete! Redirecting...";
-          
-          setTimeout(() => {
-            // Replace with actual results page when ready
-            window.location.href = "{{ url_for('analysis.index') }}";
-          }, 1500);
-          return;
-        } else if (status.status === "failed") {
-          progressBar.classList.remove("progress-bar-animated");
-          progressBar.classList.add("bg-danger");
-          progressText.textContent = "Analysis failed: " + (status.error_message || "Unknown error");
-          return;
-        }
+      let pollIntervalMs = 600;
+      const MAX_INTERVAL_MS = 1800;
 
-        const total = status.passages_total || 0;
-        const done = status.passages_done || 0;
-        if (total > 0) {
-          const pct = Math.round((done / total) * 100);
-          progressBar.style.width = pct + "%";
-          progressBar.textContent = pct + "%";
-          progressText.textContent = `Processed ${done} of ${total} passages...`;
-        }
+      let stopped = false;
+      let tickCount = 0;
 
-      } catch (err) {
-        console.error("Polling error:", err);
+      function showError(message) {
+        errorEl.textContent = message;
+        errorEl.classList.remove("d-none");
       }
-      setTimeout(poll, 1000);
-    }
 
-    setTimeout(poll, 500);
-  })();
-</script>
+      function setBar(pct) {
+        bar.style.width = pct + "%";
+        bar.textContent = pct + "%";
+        bar.setAttribute("aria-valuenow", String(pct));
+      }
+
+      function paint(job) {
+        const total = job.documents_total || 0;
+        const done = job.documents_done || 0;
+
+        if (job.status === "queued") {
+          setBar(0);
+          counts.textContent = "Preparing…";
+          statusLine.textContent = "Waiting for a worker…";
+          return;
+        }
+
+        if (job.status === "running" && done === 0) {
+          setBar(2);
+          counts.textContent = total > 0
+            ? ("0 / " + total + " transcripts")
+            : "Connected — waiting to process first transcript…";
+          statusLine.textContent = "Connected to worker — initializing analysis…";
+          return;
+        }
+
+        if (job.status === "running") {
+          const raw = total > 0 ? Math.round((done / total) * 100) : 2;
+          const pct = Math.min(99, Math.max(2, raw));
+          setBar(pct);
+          counts.textContent = done + " / " + total + " transcripts";
+          statusLine.textContent = total > 0
+            ? "Applying codebook — " + done + " of " + total + " transcripts analyzed…"
+            : "Applying codebook…";
+          return;
+        }
+
+        if (job.status === "succeeded") {
+          setBar(100);
+          counts.textContent = (done || total) + " / " + (total || done) + " transcripts";
+          statusLine.textContent = "Done. Redirecting to results…";
+        } else {
+          statusLine.textContent = "Status: " + job.status;
+        }
+      }
+
+      function stopAnimation() {
+        bar.classList.remove("progress-bar-animated", "progress-bar-striped");
+        statusSpinner.classList.add("d-none");
+      }
+
+      function redirectFor(job) {
+        window.location = listUrl;
+      }
+
+      function onTerminal(job) {
+        stopped = true;
+        if (job.status === "succeeded") {
+          setBar(100);
+          statusLine.textContent = "Done. Redirecting to results…";
+          cancelBtn.disabled = true;
+          setTimeout(() => redirectFor(job), 1000);
+          return;
+        }
+        stopAnimation();
+        cancelBtn.disabled = true;
+        if (job.status === "failed") {
+          showError(job.error_message || "Analysis failed.");
+        } else if (job.status === "cancelled") {
+          showError("Analysis was cancelled.");
+        }
+      }
+
+      async function tick() {
+        if (stopped) return;
+        try {
+          const r = await fetch(statusUrl, { headers: { "Accept": "application/json" } });
+          const job = await r.json();
+          if (job.error) {
+            stopAnimation();
+            showError(job.error);
+            return;
+          }
+          paint(job);
+          if (["succeeded", "failed", "cancelled"].includes(job.status)) {
+            onTerminal(job);
+            return;
+          }
+        } catch (e) {
+        }
+        tickCount += 1;
+        if (tickCount >= 5 && pollIntervalMs < MAX_INTERVAL_MS) {
+          pollIntervalMs = MAX_INTERVAL_MS;
+        }
+        setTimeout(tick, pollIntervalMs);
+      }
+
+      cancelBtn.addEventListener("click", async () => {
+        cancelBtn.disabled = true;
+        try {
+          // Send cancel request to the job cancellation endpoint
+          await fetch("/api/v1/codebooks/apply-jobs/" + jobId + "/cancel", { method: "POST" });
+        } catch (e) {
+        }
+      });
+
+      tick();
+    })();
+  </script>
 {% endblock %}

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -12,6 +12,7 @@
   {% set switch_template_url = url_for('ingestion.upload_form', corpus_id='__CORPUS_ID__') %}
   {% set helper_text = 'This selection applies to both transcript and demographic uploads on this page.' %}
   {% set show_create_form = True %}
+  {% set show_delete_corpus = True %}
   {% include "_corpus_select.html" %}
 
   <div class="row g-4 upload-row">


### PR DESCRIPTION
## Overview
This pull request introduces significant enhancements to the analysis run flow, making it more robust and user-friendly. It allows users to name their runs, specifically select which transcripts to process, and track progress during execution. Additionally, it contains a minor UX improvement regarding corpus deletion.

## Key Changes
* **Frontend Enhancements:** 
  * Updated the analysis page to include a new input for run names.
  * Added a transcript selection table to explicitly choose which transcripts to analyze.
  * Introduced a progress bar for better visual feedback during analysis execution.
* **Backend Updates:** 
  * Added support for `run_name` and an auto-generated `run_id` for codebook applications.
  * Updated the codebook application routes and schemas to handle transcript selection.
* **UX/UI Improvements:** 
  * Restricted Corpus deletion exclusively to the upload page to prevent accidental deletions from other areas of the application.
* **Testing & Documentation:** 
  * Fixed and updated frontend tests (`conftest.py`, `test_analysis.py`) to accommodate the new analysis run features.
  * Updated the User Documentation to reflect the new capabilities and workflow.
