### PR TITLE
Feature/178 add theme descriptions

### DIFF
--- a/Backend/app/schemas/theme_graph.py
+++ b/Backend/app/schemas/theme_graph.py
@@ -14,6 +14,7 @@ class ThemeNodeView(BaseSchema):
     label: str
     is_active: bool
     node_type: str = "THEME"
+    description: str | None = None
 
 
 class ThemeEdgeView(BaseSchema):

--- a/Backend/app/services/theme_graph.py
+++ b/Backend/app/services/theme_graph.py
@@ -178,14 +178,16 @@ class ThemeGraphService:
                 id=theme.id,
                 label=theme.label,
                 is_active=theme.is_active,
-                node_type="THEME"
+                node_type="THEME",
+                description=theme.description,
             )
         for code in codes:
             nodes[code.id] = ThemeNodeView(
                 id=code.id,
                 label=code.label,
                 is_active=code.is_active,
-                node_type="CODE"
+                node_type="CODE",
+                description=code.description,
             )
         return nodes
 

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -80,12 +80,13 @@
     const subThemesValue    = document.getElementById("sub-themes-value");
     const codesValue        = document.getElementById("codes-value");
     const themesTableBody   = document.getElementById("themes-table-body");
-    const themeDetailsEmpty   = document.getElementById("theme-details-empty");
-    const themeDetailsContent = document.getElementById("theme-details-content");
-    const themeDetailsName    = document.getElementById("theme-details-name");
-    const themeDetailsId      = document.getElementById("theme-details-id");
-    const themeDetailsOccur   = document.getElementById("theme-details-occurrences");
-    const themeDetailsCoverage = document.getElementById("theme-details-coverage");
+    const themeDetailsEmpty       = document.getElementById("theme-details-empty");
+    const themeDetailsContent     = document.getElementById("theme-details-content");
+    const themeDetailsName        = document.getElementById("theme-details-name");
+    const themeDetailsDescription = document.getElementById("theme-details-description");
+    const themeDetailsId          = document.getElementById("theme-details-id");
+    const themeDetailsOccur       = document.getElementById("theme-details-occurrences");
+    const themeDetailsCoverage    = document.getElementById("theme-details-coverage");
 
     // Guard: table body is absent when an error or empty-state is rendered.
     if (!themesTableBody) return;
@@ -136,6 +137,7 @@
                 theme_name:                    cur.theme_name ?? t.label,
                 occurrence_count:              cur.occurrence_count ?? 0,
                 interview_coverage_percentage: cur.interview_coverage_percentage ?? 0,
+                description:                   t.description ?? null,
             };
         }
         return map;
@@ -179,10 +181,11 @@
         selectedThemeId = null;
         themeDetailsEmpty.classList.remove("d-none");
         themeDetailsContent.classList.add("d-none");
-        themeDetailsName.textContent     = "";
-        themeDetailsId.textContent       = "";
-        themeDetailsOccur.textContent    = "";
-        themeDetailsCoverage.textContent = "";
+        themeDetailsName.textContent        = "";
+        themeDetailsDescription.textContent = "";
+        themeDetailsId.textContent          = "";
+        themeDetailsOccur.textContent       = "";
+        themeDetailsCoverage.textContent    = "";
     }
 
     // Sync the visual selection highlight across both the table and tree.
@@ -207,6 +210,8 @@
         if (matchedDetailTopic) {
             themeDetailsName.appendChild(makeTopicBadge(matchedDetailTopic));
         }
+        themeDetailsDescription.textContent = info.description ?? "";
+        themeDetailsDescription.classList.toggle("d-none", !info.description);
         themeDetailsId.textContent       = info.theme_id   ?? "-";
         themeDetailsOccur.textContent    = String(info.occurrence_count ?? 0);
         themeDetailsCoverage.textContent = formatCoverage(info.interview_coverage_percentage ?? 0);

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -102,6 +102,37 @@
       </div>
     </div>
 
+    {# Detail panel #}
+    <div class="row g-3 mb-3">
+      <div class="col-12">
+        <div class="bg-white border rounded-3 p-3">
+          <h2 class="h6 panel-title">Theme Details</h2>
+
+          <p id="theme-details-empty" class="text-secondary mb-0 text-center py-3">
+            Select a theme from the table or tree to view details.
+          </p>
+
+          <div id="theme-details-content" class="d-none">
+            <p id="theme-details-name" class="td-name mb-1"></p>
+            <p id="theme-details-description" class="text-secondary mb-2"></p>
+            <p id="theme-details-id"   class="td-uuid mb-3"></p>
+            <hr class="my-0 mb-3">
+            <div class="td-stats">
+              <div class="text-center">
+                <p id="theme-details-occurrences" class="td-stat-number mb-0"></p>
+                <p class="td-stat-label mb-0">Occurrences</p>
+              </div>
+              <div class="text-center">
+                <p id="theme-details-coverage" class="td-stat-number mb-0"></p>
+                <p class="td-stat-label mb-0">Interview Coverage</p>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
     {# Main panels #}
     <div class="row g-3 align-items-stretch">
 
@@ -130,36 +161,6 @@
         </div>
       </div>
 
-    </div>
-
-    {# Detail panel #}
-    <div class="row g-3 mt-1">
-      <div class="col-12">
-        <div class="bg-white border rounded-3 p-3">
-          <h2 class="h6 panel-title">Theme Details</h2>
-
-          <p id="theme-details-empty" class="text-secondary mb-0 text-center py-3">
-            Select a theme from the table or tree to view details.
-          </p>
-
-          <div id="theme-details-content" class="d-none">
-            <p id="theme-details-name" class="td-name mb-1"></p>
-            <p id="theme-details-id"   class="td-uuid mb-3"></p>
-            <hr class="my-0 mb-3">
-            <div class="td-stats">
-              <div class="text-center">
-                <p id="theme-details-occurrences" class="td-stat-number mb-0"></p>
-                <p class="td-stat-label mb-0">Occurrences</p>
-              </div>
-              <div class="text-center">
-                <p id="theme-details-coverage" class="td-stat-number mb-0"></p>
-                <p class="td-stat-label mb-0">Interview Coverage</p>
-              </div>
-            </div>
-          </div>
-
-        </div>
-      </div>
     </div>
 
   {% else %}


### PR DESCRIPTION

<img width="1720" height="402" alt="image" src="https://github.com/user-attachments/assets/13b7db12-a577-4992-8184-fa0e55e85350" />


Threads the AI-generated theme description from the database through to the Codebooks viewing page so researchers can understand what each theme represents when they click it.

Changes:

ThemeNodeView schema: added description field
ThemeGraphService: passes description from Theme and Code models when building tree nodes
themes.html: moved the Theme Details panel above the frequency/hierarchy panels; added description element between the theme name and UUID
codebook_themes.js: wires description through buildThemeInfoMap, showThemeDetails (hidden when null), and clearThemeDetails