### PR TITLE
181 finish codebook application and updating frontend

### DIFF
--- a/Backend/tests/conftest.py
+++ b/Backend/tests/conftest.py
@@ -36,6 +36,10 @@ async def db_engine():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield engine
+    from app.services.codebook_application_jobs import codebook_application_job_runner
+    from app.services.codebook_generation_jobs import codebook_generation_job_runner
+    await codebook_application_job_runner.stop()
+    await codebook_generation_job_runner.stop()
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
     await engine.dispose()

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -13,7 +13,7 @@ Frontend/
 │   │   ├── main.py                    # / (home), /health
 │   │   ├── ingestion.py               # /transcripts, /transcripts/upload
 │   │   ├── codebooks.py               # /codebooks, /codebooks/<id>/themes
-│   │   └── analysis.py                # /analysis (placeholder)
+│   │   └── analysis.py                # /analysis
 │   ├── services/
 │   │   └── backend_client.py          # HTTP client wrapping all FastAPI calls
 │   ├── templates/
@@ -31,7 +31,8 @@ Frontend/
 │   │   │   ├── list.html              # Codebook listing table
 │   │   │   └── themes.html            # Theme browser (table + tree + detail panel)
 │   │   └── analysis/
-│   │       └── index.html             # Analysis page (placeholder)
+│   │       ├── index.html             # Trigger analysis form (transcript + codebook selection)
+│   │       └── wait.html              # Live progress page (polls job status)
 │   └── static/
 │       ├── css/main.css               # All custom styles
 │       ├── img/team-logo.svg          # NIM+AMOS team logo (navbar + footer + favicon)
@@ -41,6 +42,7 @@ Frontend/
 │   ├── test_smoke.py                  # Basic route smoke tests
 │   ├── test_ingestion.py              # Ingestion route tests (incl. typed-error paths)
 │   ├── test_codebooks.py              # Codebook route tests (incl. typed-error paths)
+│   ├── test_analysis.py               # Analysis trigger + wait page tests
 │   ├── test_backend_client.py         # Unit tests for BackendClient exception categorisation
 │   └── test_error_handlers.py         # Flask 404 / 413 / 500 handler tests
 ├── Dockerfile                         # Multi-stage build (runtime + test targets)
@@ -59,7 +61,10 @@ Frontend/
 | `POST /transcripts/upload` | Upload results | Submits files to the backend; shows per-file result |
 | `GET /codebooks/` | Codebook list | Table of all available codebooks |
 | `GET /codebooks/<id>/themes` | Theme browser | Full interactive theme browser for a codebook |
-| `GET /analysis/` | Analysis | Placeholder — ready for backend analysis routes |
+| `GET /analysis/` | Trigger Analysis | Select transcripts, codebook, and trigger a codebook application job |
+| `POST /analysis/trigger` | — | Submits the form; creates a backend apply-job and redirects to the wait page |
+| `GET /analysis/job/<job_id>` | Applying Codebook | Live progress page that polls job status until completion |
+| `GET /analysis/job/<job_id>/status` | — | JSON endpoint returning current job status (used by the wait page) |
 
 ## Theme browser
 

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -66,7 +66,10 @@ def test_trigger_analysis_success(client, fake_backend):
         
     resp = client.post("/analysis/trigger", data={
         "corpus_id": corpus_id,
-        "codebook_id": "cb1"
+        "codebook_id": "cb1",
+        "name": "Test Run",
+        "custom_id": "custom-123",
+        "transcript_document_ids": ["doc1"]
     })
     
     assert resp.status_code == 302


### PR DESCRIPTION
Finish codebook application frontend integration

what we did:
update README
extend test coverage for analysis trigger,
and fix flaky CI cancellation test by stopping job runners on teardown

viewing our results is currently possible: codebooks -> view themes
 