### PR TITLE
179 generate codebook button to upload page

### DIFF
--- a/Frontend/tests/test_codebook_controller.py
+++ b/Frontend/tests/test_codebook_controller.py
@@ -135,8 +135,8 @@ def test_unified_upload_page_shows_codebook_card(client, fake_backend):
     assert resp.status_code == 200
     assert b"Upload Codebook" in resp.data
     assert b"CSV" in resp.data
-    assert b"Or enter manually" in resp.data
-    assert b"/codebooks/test-corpus-id/manual" in resp.data
+    assert b"Generate or enter manually" in resp.data
+    assert b"/codebooks/new/test-corpus-id" in resp.data
 
 
 # ---------------------------------------------------------------------------

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -629,15 +629,13 @@
 }
 
 .btn-teal {
-    /* Solid deep teal — matches the dominant start colour of the
-       .upload-card--teal header gradient (same reasoning as .btn-indigo). */
-    background: #0f766e;
+    background: #0d9488;
 }
 .btn-teal:hover,
 .btn-teal:focus {
-    background: #115e59;
+    background: #0f766e;
     color: #fff;
-    box-shadow: 0 6px 14px -6px rgba(15, 118, 110, 0.45);
+    box-shadow: 0 6px 14px -6px rgba(13, 148, 136, 0.45);
 }
 .btn-teal:active {
     transform: translateY(1px);
@@ -645,8 +643,8 @@
 }
 .btn-teal:disabled,
 .btn-teal.disabled {
-    background: #ccfbf1;
-    color: #ecfeff;
+    background: #dcfce7;
+    color: #f0fdf4;
     opacity: 0.85;
     cursor: not-allowed;
     pointer-events: auto;     /* see .btn-indigo:disabled for rationale */

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -224,7 +224,7 @@
             </div>
 
             <div>
-              <button id="codebook-submit-btn" type="submit" class="btn btn-teal" disabled>
+              <button id="codebook-submit-btn" type="submit" class="btn btn-teal w-100" disabled>
                 Upload &amp; preview
               </button>
               <div class="mt-2">

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -228,8 +228,8 @@
                 Upload &amp; preview
               </button>
               <div class="mt-2">
-                <a href="{{ url_for('codebooks.manual_form', corpus_id=corpus_id) }}"
-                   class="small text-secondary">Or enter manually &rarr;</a>
+                <a href="{{ url_for('codebooks.new_codebook_mode_select', corpus_id=corpus_id) }}"
+                   class="small text-secondary">Generate or enter manually &rarr;</a>
               </div>
             </div>
           </form>


### PR DESCRIPTION
The small link below codebook Upload & preview button now directs users to the Codebook Generation Mode selection page instead of the manual entry form.

I also corrected the look of the codebook Upload & preview button while I was at it.