### PR TITLE
Feature/15 theme drilldown

### DIFF
--- a/Backend/app/routers/themes.py
+++ b/Backend/app/routers/themes.py
@@ -7,11 +7,12 @@ from fastapi.responses import JSONResponse
 
 from app.dependencies import DbSession
 from app.exceptions import NotFoundError, UnprocessableError
-from app.schemas.common import ResponseEnvelope
+from app.schemas.common import Page, ResponseEnvelope
 from app.schemas.theme_graph import ThemeTreeNode
-from app.schemas.theme_views import ThemeFrequencyItem
+from app.schemas.theme_views import ThemeFrequencyItem, ThemeQuoteItem
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import ThemeGraphService, ThemeNotFoundError, ThemeValidationError
+from app.services.theme_quotes import ThemeQuotesService
 
 router = APIRouter(prefix="/codebooks/{codebook_id}/themes", tags=["themes"])
 
@@ -64,4 +65,24 @@ async def get_theme_tree(
         raise UnprocessableError(str(exc)) from exc
 
     # Wrap successful payloads in response envelope
+    return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
+
+
+@router.get("/{theme_id}/quotes", response_model=ResponseEnvelope[Page[ThemeQuoteItem]])
+async def list_theme_quotes(
+    codebook_id: UUID,
+    theme_id: UUID,
+    session: DbSession,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    application_run_id: UUID | None = Query(default=None),
+) -> JSONResponse:
+    service = ThemeQuotesService(session)
+    payload = await service.list_theme_quotes(
+        codebook_id=codebook_id,
+        theme_id=theme_id,
+        page=page,
+        page_size=page_size,
+        application_run_id=application_run_id,
+    )
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))

--- a/Backend/app/schemas/theme_views.py
+++ b/Backend/app/schemas/theme_views.py
@@ -23,3 +23,13 @@ class ThemeFrequencyItem(BaseSchema):
     theme_name: str
     occurrence_count: int = Field(ge=0)
     interview_coverage_percentage: float = Field(ge=0.0, le=100.0)
+
+
+class ThemeQuoteItem(BaseSchema):
+    """One quote assigned to a theme, with its source document and interviewee."""
+
+    quote: str
+    confidence: float
+    document_id: UUID
+    document_title: str
+    interviewee_id: str | None

--- a/Backend/app/services/theme_quotes.py
+++ b/Backend/app/services/theme_quotes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import math
+from uuid import UUID
+
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import CodebookApplicationRun, CorpusDocument, DocumentCoding, ThemeAssignment
+from app.models.demographic import DemographicRow
+from app.schemas.common import Page, PageMeta
+from app.schemas.theme_views import ThemeQuoteItem
+
+
+class ThemeQuotesService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_theme_quotes(
+        self,
+        *,
+        codebook_id: UUID,
+        theme_id: UUID,
+        page: int = 1,
+        page_size: int = 20,
+        application_run_id: UUID | None = None,
+    ) -> Page[ThemeQuoteItem]:
+        run_id = await self._resolve_run_id(codebook_id, application_run_id)
+        if run_id is None:
+            return Page(items=[], meta=PageMeta(total=0, page=page, page_size=page_size, pages=0))
+
+        base_filter = (
+            DocumentCoding.application_run_id == run_id,
+            ThemeAssignment.theme_id == theme_id,
+            ThemeAssignment.is_present.is_(True),
+            ThemeAssignment.quote.is_not(None),
+        )
+
+        total: int = (
+            await self._session.execute(
+                select(func.count())
+                .select_from(ThemeAssignment)
+                .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+                .where(*base_filter)
+            )
+        ).scalar_one()
+
+        pages = math.ceil(total / page_size) if total > 0 else 0
+        offset = (page - 1) * page_size
+
+        rows = (
+            await self._session.execute(
+                select(
+                    ThemeAssignment.quote,
+                    ThemeAssignment.confidence,
+                    DocumentCoding.document_id,
+                    CorpusDocument.title,
+                    DemographicRow.interviewee_id,
+                )
+                .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+                .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
+                .outerjoin(DemographicRow, CorpusDocument.demographic_row_id == DemographicRow.id)
+                .where(*base_filter)
+                .order_by(desc(ThemeAssignment.confidence))
+                .offset(offset)
+                .limit(page_size)
+            )
+        ).all()
+
+        items = [
+            ThemeQuoteItem(
+                quote=row.quote,
+                confidence=row.confidence,
+                document_id=row.document_id,
+                document_title=row.title,
+                interviewee_id=row.interviewee_id,
+            )
+            for row in rows
+        ]
+
+        return Page(items=items, meta=PageMeta(total=total, page=page, page_size=page_size, pages=pages))
+
+    async def _resolve_run_id(self, codebook_id: UUID, application_run_id: UUID | None) -> UUID | None:
+        if application_run_id is not None:
+            return application_run_id
+        return (
+            await self._session.execute(
+                select(CodebookApplicationRun.id)
+                .where(
+                    CodebookApplicationRun.codebook_id == codebook_id,
+                    CodebookApplicationRun.status == "succeeded",
+                )
+                .order_by(desc(CodebookApplicationRun.finished_at), desc(CodebookApplicationRun.created_at))
+                .limit(1)
+            )
+        ).scalar_one_or_none()

--- a/Backend/tests/test_theme_quotes_service.py
+++ b/Backend/tests/test_theme_quotes_service.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Codebook, CorpusDocument, Theme
+from app.models.analysis import CodebookApplicationRun, DocumentCoding, ThemeAssignment
+from app.services.theme_quotes import ThemeQuotesService
+
+AIOSQLITE_AVAILABLE = importlib.util.find_spec("aiosqlite") is not None
+
+_CORPUS_ID = UUID("a1b2c3d4-0000-0000-0000-000000000001")
+
+
+@dataclass(slots=True, frozen=True)
+class _QuoteSeed:
+    codebook_id: UUID
+    theme_id: UUID
+    run_id: UUID
+
+
+async def _seed_base(session: AsyncSession, *, run_status: str = "succeeded") -> _QuoteSeed:
+    """Insert the minimal rows needed to test ThemeQuotesService."""
+    codebook_id = uuid4()
+    theme_id = uuid4()
+    run_id = uuid4()
+
+    session.add(
+        Codebook(
+            id=codebook_id,
+            corpus_id=_CORPUS_ID,
+            name="Quote Test Codebook",
+            description="Fixture",
+            version=1,
+            created_by="system",
+        )
+    )
+    session.add(Theme(id=theme_id, codebook_id=codebook_id, label="Test Theme", is_active=True))
+    session.add(
+        CodebookApplicationRun(
+            id=run_id,
+            corpus_id=_CORPUS_ID,
+            codebook_id=codebook_id,
+            status=run_status,
+        )
+    )
+    await session.flush()
+    return _QuoteSeed(codebook_id=codebook_id, theme_id=theme_id, run_id=run_id)
+
+
+async def _add_document_with_assignment(
+    session: AsyncSession,
+    seed: _QuoteSeed,
+    *,
+    is_present: bool,
+    confidence: float,
+    quote: str | None,
+) -> None:
+    doc_id = uuid4()
+    coding_id = uuid4()
+    session.add(
+        CorpusDocument(
+            id=doc_id,
+            corpus_id=_CORPUS_ID,
+            title=f"Interview {doc_id.hex[:6]}",
+            content="...",
+        )
+    )
+    session.add(
+        DocumentCoding(
+            id=coding_id,
+            application_run_id=seed.run_id,
+            document_id=doc_id,
+            codebook_id=seed.codebook_id,
+        )
+    )
+    session.add(
+        ThemeAssignment(
+            id=uuid4(),
+            document_coding_id=coding_id,
+            theme_id=seed.theme_id,
+            is_present=is_present,
+            confidence=confidence,
+            quote=quote,
+        )
+    )
+
+
+@unittest.skipUnless(AIOSQLITE_AVAILABLE, "These tests require aiosqlite.")
+class ThemeQuotesServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.engine.dispose()
+
+    async def test_returns_empty_page_when_no_succeeded_run_exists(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session, run_status="running")
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.9, quote="some quote"
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        self.assertEqual(result.meta.total, 0)
+        self.assertEqual(result.items, [])
+
+    async def test_excludes_absent_theme_assignments(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            await _add_document_with_assignment(
+                session, seed, is_present=False, confidence=0.9, quote="ignored quote"
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        self.assertEqual(result.meta.total, 0)
+
+    async def test_excludes_null_quote_assignments(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.9, quote=None
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        self.assertEqual(result.meta.total, 0)
+
+    async def test_returns_quotes_ordered_by_confidence_descending(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            for conf, text in [(0.7, "low"), (0.95, "high"), (0.82, "mid")]:
+                await _add_document_with_assignment(
+                    session, seed, is_present=True, confidence=conf, quote=text
+                )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        self.assertEqual([item.quote for item in result.items], ["high", "mid", "low"])
+
+    async def test_pagination_returns_correct_slice_and_metadata(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            for i in range(5):
+                await _add_document_with_assignment(
+                    session, seed, is_present=True, confidence=float(i) / 10, quote=f"q{i}"
+                )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_id,
+                page=2,
+                page_size=2,
+            )
+
+        self.assertEqual(result.meta.total, 5)
+        self.assertEqual(result.meta.pages, 3)
+        self.assertEqual(result.meta.page, 2)
+        self.assertEqual(len(result.items), 2)
+
+    async def test_uses_explicit_run_id_and_ignores_latest_succeeded(self) -> None:
+        async with self.session_factory() as session:
+            # One succeeded run with a quote
+            seed = await _seed_base(session, run_status="succeeded")
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.9, quote="from succeeded run"
+            )
+
+            # Second run (different id) — no assignments
+            other_run_id = uuid4()
+            session.add(
+                CodebookApplicationRun(
+                    id=other_run_id,
+                    corpus_id=_CORPUS_ID,
+                    codebook_id=seed.codebook_id,
+                    status="succeeded",
+                )
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_id,
+                application_run_id=other_run_id,
+            )
+
+        # Explicit run has no assignments → empty even though another run has quotes
+        self.assertEqual(result.meta.total, 0)

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -298,7 +298,6 @@ def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 502
     except Exception:
-        current_app.logger.exception("Unexpected error fetching theme quotes")
         return jsonify({"error": "An unexpected error occurred."}), 500
 
 

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -296,7 +296,10 @@ def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
         result = _backend().get_theme_quotes(codebook_id, theme_id, page, page_size)
         return jsonify(result)
     except BackendError as exc:
-        return jsonify({"error": exc.user_message})
+        return jsonify({"error": exc.user_message}), 502
+    except Exception:
+        current_app.logger.exception("Unexpected error fetching theme quotes")
+        return jsonify({"error": "An unexpected error occurred."}), 500
 
 
 @bp.get("/<corpus_id>/<codebook_id>/export")

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -285,6 +285,20 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         researcher_topics=researcher_topics,
     )
 
+@bp.get("/<corpus_id>/<codebook_id>/themes/<theme_id>/quotes.json")
+def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+        page_size = max(1, min(100, int(request.args.get("page_size", 20))))
+    except (TypeError, ValueError):
+        page, page_size = 1, 20
+    try:
+        result = _backend().get_theme_quotes(codebook_id, theme_id, page, page_size)
+        return jsonify(result)
+    except BackendError as exc:
+        return jsonify({"error": exc.user_message})
+
+
 @bp.get("/<corpus_id>/<codebook_id>/export")
 def export_codebook(corpus_id: str, codebook_id: str) -> Response | str:
     """Export a codebook and its hierarchical themes as a CSV file."""

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -192,6 +192,14 @@ class BackendClient:
     def get_theme_tree(self, codebook_id: str) -> list[dict]:
         return self._get(f"/codebooks/{codebook_id}/themes/tree")
 
+    def get_theme_quotes(
+        self, codebook_id: str, theme_id: str, page: int = 1, page_size: int = 20
+    ) -> dict:
+        return self._get(
+            f"/codebooks/{codebook_id}/themes/{theme_id}/quotes",
+            params={"page": page, "page_size": page_size},
+        )
+
     # ---- Demographic --------------------------------------------------------
 
     def upload_demographic(

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -3,9 +3,11 @@
     if (!appRoot) return;
 
     // Data is embedded server-side as JSON — no extra HTTP requests needed.
-    const frequencies = JSON.parse(appRoot.dataset.frequencies || "[]");
-    const tree        = JSON.parse(appRoot.dataset.tree        || "[]");
-    const codes       = JSON.parse(appRoot.dataset.codes       || "[]");
+    const frequencies       = JSON.parse(appRoot.dataset.frequencies || "[]");
+    const tree              = JSON.parse(appRoot.dataset.tree        || "[]");
+    const codes             = JSON.parse(appRoot.dataset.codes       || "[]");
+    const quotesUrlTemplate = appRoot.dataset.quotesUrlTemplate || "";
+    const readUrlTemplate   = appRoot.dataset.readUrlTemplate   || "";
 
     // Topics the researcher asked the AI to focus on.
     const researcherTopics = (() => {
@@ -375,4 +377,142 @@
     // Auto-select the top theme by frequency on load.
     const top = sortByFrequency(frequencies)[0];
     if (top) showThemeDetails(top.theme_id);
+
+    // ------------------------------------------------------------------
+    // Quotes modal
+    // ------------------------------------------------------------------
+
+    const quotesModal      = document.getElementById("quotes-modal");
+    const quotesLoading    = document.getElementById("quotes-loading");
+    const quotesError      = document.getElementById("quotes-error");
+    const quotesList       = document.getElementById("quotes-list");
+    const quotesEmpty      = document.getElementById("quotes-empty");
+    const quotesTotal      = document.getElementById("quotes-modal-total");
+    const quotesLabel      = document.getElementById("quotes-modal-label");
+    const quotesPagination = document.getElementById("quotes-pagination");
+    const quotesPageInfo   = document.getElementById("quotes-page-info");
+    const quotesPrev       = document.getElementById("quotes-prev");
+    const quotesNext       = document.getElementById("quotes-next");
+    const viewQuotesBtn    = document.getElementById("theme-details-view-quotes");
+
+    if (!quotesModal || !viewQuotesBtn) return;
+
+    const bsModal = new bootstrap.Modal(quotesModal);
+
+    let activeQuoteThemeId = null;
+    let activeQuotePage    = 1;
+    const PAGE_SIZE        = 20;
+
+    function quotesUrl(themeId, page) {
+        return quotesUrlTemplate.replace("__THEME__", themeId)
+            + "?page=" + page + "&page_size=" + PAGE_SIZE;
+    }
+
+    function interviewUrl(documentId) {
+        return readUrlTemplate.replace("__DOC__", documentId);
+    }
+
+    function setQuotesLoading() {
+        quotesLoading.classList.remove("d-none");
+        quotesError.classList.add("d-none");
+        quotesList.classList.add("d-none");
+        quotesEmpty.classList.add("d-none");
+        quotesPagination.classList.add("d-none");
+    }
+
+    function renderQuotes(data, themeName) {
+        quotesLoading.classList.add("d-none");
+
+        const items = data.items || [];
+        const meta  = data.meta  || {};
+        const total = meta.total  ?? 0;
+        const page  = meta.page   ?? 1;
+        const pages = meta.pages  ?? 0;
+
+        quotesLabel.textContent = "Quotes for: " + (themeName || "Theme");
+        quotesTotal.textContent = total === 1 ? "1 quote across corpus" : total + " quotes across corpus";
+
+        if (items.length === 0) {
+            quotesEmpty.classList.remove("d-none");
+            quotesPagination.classList.add("d-none");
+            return;
+        }
+
+        quotesList.replaceChildren();
+
+        for (const item of items) {
+            const card = document.createElement("div");
+            card.className = "border rounded-2 p-3 mb-2";
+
+            // Quote text — textContent prevents XSS on any user-supplied content.
+            const quoteEl = document.createElement("blockquote");
+            quoteEl.className = "mb-2 fst-italic text-body";
+            quoteEl.textContent = "“" + item.quote + "”";
+            card.appendChild(quoteEl);
+
+            const meta = document.createElement("div");
+            meta.className = "d-flex align-items-center justify-content-between flex-wrap gap-2";
+
+            const interviewee = document.createElement("span");
+            interviewee.className = "text-secondary small";
+            interviewee.textContent = "Interviewee: " + (item.interviewee_id || "Unknown");
+            meta.appendChild(interviewee);
+
+            const link = document.createElement("a");
+            link.href      = interviewUrl(item.document_id);
+            link.className = "btn btn-sm btn-outline-secondary";
+            link.textContent = "View Interview";
+            meta.appendChild(link);
+
+            card.appendChild(meta);
+            quotesList.appendChild(card);
+        }
+
+        quotesList.classList.remove("d-none");
+
+        // Pagination
+        activeQuotePage = page;
+        quotesPageInfo.textContent = "Page " + page + " of " + pages;
+        quotesPrev.disabled = page <= 1;
+        quotesNext.disabled = page >= pages;
+        quotesPagination.classList.toggle("d-none", pages <= 1);
+    }
+
+    async function loadQuotes(themeId, page) {
+        activeQuoteThemeId = themeId;
+        activeQuotePage    = page;
+        setQuotesLoading();
+
+        const themeName = (currentThemeInfoById[themeId] || {}).theme_name || "";
+
+        try {
+            const response = await fetch(quotesUrl(themeId, page));
+            if (!response.ok) throw new Error("HTTP " + response.status);
+            const data = await response.json();
+            if (data.error) throw new Error(data.error);
+            renderQuotes(data, themeName);
+        } catch (err) {
+            quotesLoading.classList.add("d-none");
+            quotesError.textContent = "Could not load quotes: " + err.message;
+            quotesError.classList.remove("d-none");
+        }
+    }
+
+    viewQuotesBtn.addEventListener("click", () => {
+        if (!selectedThemeId) return;
+        bsModal.show();
+        loadQuotes(selectedThemeId, 1);
+    });
+
+    quotesPrev.addEventListener("click", () => {
+        if (activeQuoteThemeId && activeQuotePage > 1) {
+            loadQuotes(activeQuoteThemeId, activeQuotePage - 1);
+        }
+    });
+
+    quotesNext.addEventListener("click", () => {
+        if (activeQuoteThemeId) {
+            loadQuotes(activeQuoteThemeId, activeQuotePage + 1);
+        }
+    });
 })();

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -487,9 +487,8 @@
 
         try {
             const response = await fetch(quotesUrl(themeId, page));
-            if (!response.ok) throw new Error("HTTP " + response.status);
             const data = await response.json();
-            if (data.error) throw new Error(data.error);
+            if (!response.ok || data.error) throw new Error(data.error || "HTTP " + response.status);
             renderQuotes(data, themeName);
         } catch (err) {
             quotesLoading.classList.add("d-none");

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -6,7 +6,11 @@
      data-frequencies='{{ frequencies | tojson }}'
      data-tree='{{ tree | tojson }}'
      data-codes='{{ codes | tojson }}'
-     data-researcher-topics='{{ researcher_topics | tojson }}'>
+     data-researcher-topics='{{ researcher_topics | tojson }}'
+     data-codebook-id="{{ codebook_id }}"
+     data-corpus-id="{{ corpus_id }}"
+     data-quotes-url-template="{{ url_for('codebooks.theme_quotes_json', corpus_id=corpus_id, codebook_id=codebook_id, theme_id='__THEME__') }}"
+     data-read-url-template="{{ url_for('ingestion.read_transcript', corpus_id=corpus_id, document_id='__DOC__') }}">
 
   {% if corpus_id and corpus_options %}
     {% set active_corpus_id = corpus_id %}

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -131,6 +131,11 @@
                 <p class="td-stat-label mb-0">Interview Coverage</p>
               </div>
             </div>
+            <div class="mt-3">
+              <button id="theme-details-view-quotes" class="btn btn-sm btn-outline-primary">
+                View Quotes
+              </button>
+            </div>
           </div>
 
         </div>
@@ -171,6 +176,36 @@
     <p class="text-secondary">No themes found for this codebook.</p>
   {% endif %}
 
+</div>
+
+{# Quotes modal #}
+<div class="modal fade" id="quotes-modal" tabindex="-1" aria-labelledby="quotes-modal-label" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div>
+          <h5 class="modal-title mb-0" id="quotes-modal-label">Quotes</h5>
+          <p class="text-secondary small mb-0" id="quotes-modal-total"></p>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="quotes-modal-body">
+        <div id="quotes-loading" class="text-center py-5">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading quotes…</span>
+          </div>
+        </div>
+        <div id="quotes-error" class="d-none alert alert-danger"></div>
+        <div id="quotes-list" class="d-none"></div>
+        <p id="quotes-empty" class="d-none text-secondary text-center py-4">No quotes found for this theme.</p>
+      </div>
+      <div class="modal-footer d-none" id="quotes-pagination">
+        <button class="btn btn-sm btn-outline-secondary" id="quotes-prev">&#8592; Previous</button>
+        <span class="text-secondary small" id="quotes-page-info"></span>
+        <button class="btn btn-sm btn-outline-secondary" id="quotes-next">Next &#8594;</button>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Changes made:

Backend

New ThemeQuoteItem schema and ThemeQuotesService that queries ThemeAssignment → DocumentCoding → CorpusDocument → DemographicRow, filtering for is_present=True with non-null quotes, ordered by confidence
New GET /codebooks/{codebook_id}/themes/{theme_id}/quotes endpoint with pagination (page, page_size) and optional application_run_id; defaults to the latest succeeded run
New Flask proxy route /<corpus_id>/<codebook_id>/themes/<theme_id>/quotes.json that forwards to the backend endpoint


Frontend

"View Quotes" button added to the theme detail panel
Bootstrap 5 modal opens on click, fetches quotes via the proxy route, and renders each quote as a card with the quote text, interviewee ID, and a "View Interview" link
Pagination controls (previous/next) appear when results span multiple pages; total quote count shown in the modal header
URL templates for the quotes endpoint and the interview read view are passed via data-* attributes on the app root element, following the existing pattern in the codebase



<img width="1674" height="445" alt="image" src="https://github.com/user-attachments/assets/a8ae55dc-6b92-4cfa-a78d-389fd35c3ee4" />


<img width="1195" height="813" alt="image" src="https://github.com/user-attachments/assets/2127f46b-b087-4574-85c8-2b5867092445" />
