### PR TITLE
feat: add selectable LLM provider (FAU NHR / Academic Cloud)

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -24,17 +24,20 @@ CORS_ALLOWED_ORIGINS=["http://localhost:3000"]
 
 # -----------------------------------------------------------------------------
 # LLM
-# Set SELECTED_API to choose the active provider, then fill in the matching key.
+# SELECTED_API is the DEFAULT provider used until one is chosen in the UI.
+# The active provider can be switched live from the Home page (LLM Provider
+# card); that choice is stored server-side and read by every AI task at run
+# start. Configure the key for any provider you might select.
 # Base URLs and model names have sensible defaults in config.py — only override
 # them here if you need to point to a different endpoint or use a different model.
 #
-# SELECTED_API=FAU       → uses LLM_API_KEY_FAU + NHR@FAU gateway
-# SELECTED_API=ACADEMIC  → uses LLM_API_KEY    + Academic Cloud
+# SELECTED_API=FAU       → defaults to LLM_API_KEY_FAU + NHR@FAU gateway
+# SELECTED_API=ACADEMIC  → defaults to LLM_API_KEY    + Academic Cloud
 # -----------------------------------------------------------------------------
 SELECTED_API=FAU
 
 # NHR@FAU — required: your API key (https://hpc.fau.de/request-llm-api-key/)
 LLM_API_KEY_FAU=<your_nhr_fau_key_here>
 
-# Academic Cloud — required: your API key (only needed if SELECTED_API=ACADEMIC)
+# Academic Cloud — required to select the Academic Cloud provider in the UI
 LLM_API_KEY=<your_academic_cloud_key_here>

--- a/Backend/app/llm/client.py
+++ b/Backend/app/llm/client.py
@@ -1,30 +1,35 @@
 from langchain_openai import ChatOpenAI
 
 from app.config import Settings, get_settings
+from app.llm import providers
 
 
 def build_chat_model(
     settings: Settings | None = None,
     *,
+    provider: str | None = None,
     model: str | None = None,
     temperature: float | None = None,
 ) -> ChatOpenAI:
     cfg = settings or get_settings()
 
-    # Resolve credentials based on SELECTED_API
-    if cfg.SELECTED_API.upper() == "FAU":
-        api_key  = cfg.LLM_API_KEY_FAU
-        base_url = cfg.LLM_BASE_URL_FAU
-        default_model = cfg.LLM_MODEL_FAU
-    else:  # "ACADEMIC" or any other value falls back to the Academic Cloud config
-        api_key  = cfg.LLM_API_KEY
-        base_url = cfg.LLM_BASE_URL
-        default_model = cfg.LLM_MODEL
+    # Resolve which provider to use: an explicit argument (e.g. the active
+    # provider read from the DB at job-run start) wins; otherwise fall back to
+    # the env-configured SELECTED_API default so existing callers and scripts
+    # keep working with zero config.
+    provider_id = providers.normalize(provider) or providers.resolve_default(cfg)
+    spec = providers.get_provider(provider_id)
+    # resolve_default always returns a known id, so spec is never None here.
+    assert spec is not None  # noqa: S101 - registry invariant
+
+    api_key = getattr(cfg, spec.api_key_attr)
+    base_url = getattr(cfg, spec.base_url_attr)
+    default_model = getattr(cfg, spec.model_attr)
 
     if not api_key:
         raise RuntimeError(
-            f"No API key set for SELECTED_API='{cfg.SELECTED_API}'. "
-            "Set LLM_API_KEY_FAU (for FAU) or LLM_API_KEY (for ACADEMIC) in your .env file."
+            f"No API key set for LLM provider '{provider_id}' ({spec.label}). "
+            f"Set {spec.api_key_attr} in your .env file."
         )
     return ChatOpenAI(
         model=model or default_model,

--- a/Backend/app/llm/pipelines.py
+++ b/Backend/app/llm/pipelines.py
@@ -69,8 +69,9 @@ def apply_codebook_to_interview(
 def build_codebook_application_with_codes_chain(
     *,
     model: BaseChatModel | None = None,
+    provider: str | None = None,
 ) -> Runnable[dict[str, str], dict[str, Any]]:
-    chat_model = model or build_chat_model()
+    chat_model = model or build_chat_model(provider=provider)
     # The parser validates the model output shape but returns a dict, so callers
     # still instantiate CodebookApplicationResult explicitly after invocation.
     parser = JsonOutputParser(pydantic_object=CodebookApplicationResult)
@@ -149,8 +150,9 @@ async def apply_codebook_with_codes_to_transcripts(
 def build_codebook_generation_chain(
     *,
     model: BaseChatModel | None = None,
+    provider: str | None = None,
 ) -> Runnable[dict[str, str], dict[str, Any]]:
-    chat_model = model or build_chat_model()
+    chat_model = model or build_chat_model(provider=provider)
     # See build_codebook_application_with_codes_chain: this Runnable returns
     # parsed dictionaries that are converted to Pydantic models by callers.
     parser = JsonOutputParser(pydantic_object=PassageCodebookGeneration)

--- a/Backend/app/llm/providers.py
+++ b/Backend/app/llm/providers.py
@@ -1,0 +1,104 @@
+"""Central registry of the LLM providers the app can route AI tasks to.
+
+The app supports two pre-configured providers whose credentials live in
+``Settings`` (env / .env):
+
+* ``FAU``      → NHR@FAU gateway   (``LLM_*_FAU`` settings)
+* ``ACADEMIC`` → Academic Cloud    (``LLM_*`` settings)
+
+This module is the single source of truth for the provider id, its
+human-readable label, and which ``Settings`` attributes hold its credentials.
+Both the LLM client and the settings API/UI read from here so labels and ids
+never drift between layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.config import Settings
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Static description of one selectable LLM provider."""
+
+    id: str  # canonical, stored/transported value (always upper-case)
+    label: str  # human-readable name shown in the UI
+    description: str  # short, non-technical explanation for tooltips
+    api_key_attr: str  # Settings attribute holding the API key
+    base_url_attr: str  # Settings attribute holding the base URL
+    model_attr: str  # Settings attribute holding the default model name
+
+
+# Order matters: the first entry is treated as the built-in default when no
+# stored selection and no env override resolve to a known provider.
+PROVIDERS: tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        id="FAU",
+        label="FAU NHR",
+        description=(
+            "The university's NHR@FAU gateway. This is the default and uses the "
+            "setup the team has relied on so far."
+        ),
+        api_key_attr="LLM_API_KEY_FAU",
+        base_url_attr="LLM_BASE_URL_FAU",
+        model_attr="LLM_MODEL_FAU",
+    ),
+    ProviderSpec(
+        id="ACADEMIC",
+        label="Academic Cloud",
+        description=(
+            "The GWDG Academic Cloud chat-ai endpoint. Use this to route AI "
+            "tasks through the Academic Cloud models instead of FAU NHR."
+        ),
+        api_key_attr="LLM_API_KEY",
+        base_url_attr="LLM_BASE_URL",
+        model_attr="LLM_MODEL",
+    ),
+)
+
+_PROVIDERS_BY_ID: dict[str, ProviderSpec] = {spec.id: spec for spec in PROVIDERS}
+
+DEFAULT_PROVIDER_ID: str = PROVIDERS[0].id
+
+
+def available_providers() -> tuple[ProviderSpec, ...]:
+    """Return every selectable provider, in display order."""
+    return PROVIDERS
+
+
+def is_known_provider(value: str | None) -> bool:
+    """True when ``value`` (case-insensitive) names a registered provider."""
+    return bool(value) and value.strip().upper() in _PROVIDERS_BY_ID
+
+
+def normalize(value: str | None) -> str | None:
+    """Return the canonical provider id for ``value`` or ``None`` if unknown."""
+    if not value:
+        return None
+    candidate = value.strip().upper()
+    return candidate if candidate in _PROVIDERS_BY_ID else None
+
+
+def get_provider(value: str | None) -> ProviderSpec | None:
+    """Return the :class:`ProviderSpec` for ``value`` or ``None`` if unknown."""
+    canonical = normalize(value)
+    return _PROVIDERS_BY_ID.get(canonical) if canonical else None
+
+
+def resolve_default(settings: Settings) -> str:
+    """Resolve the env-configured default provider, falling back to FAU.
+
+    Mirrors the historic ``SELECTED_API`` semantics: any unrecognised value
+    falls back to the built-in default so the app always has a valid provider.
+    """
+    return normalize(settings.SELECTED_API) or DEFAULT_PROVIDER_ID
+
+
+def has_api_key(settings: Settings, provider_id: str) -> bool:
+    """True when the credentials for ``provider_id`` include a non-empty key."""
+    spec = get_provider(provider_id)
+    if spec is None:
+        return False
+    return bool(getattr(settings, spec.api_key_attr, None))

--- a/Backend/app/llm/providers.py
+++ b/Backend/app/llm/providers.py
@@ -70,7 +70,7 @@ def available_providers() -> tuple[ProviderSpec, ...]:
 
 def is_known_provider(value: str | None) -> bool:
     """True when ``value`` (case-insensitive) names a registered provider."""
-    return bool(value) and value.strip().upper() in _PROVIDERS_BY_ID
+    return value is not None and value.strip().upper() in _PROVIDERS_BY_ID
 
 
 def normalize(value: str | None) -> str | None:

--- a/Backend/app/models/__init__.py
+++ b/Backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.analysis import (
     DocumentCoding,
     ThemeAssignment,
 )
+from app.models.app_settings import ACTIVE_LLM_PROVIDER_KEY, AppSetting
 from app.models.base import Base, IdMixin, TimestampMixin
 from app.models.code import Code, CodebookCodeRelationship, ThemeCodeRelationship
 from app.models.codebook import Codebook
@@ -24,6 +25,8 @@ __all__ = [
     "Base",
     "IdMixin",
     "TimestampMixin",
+    "AppSetting",
+    "ACTIVE_LLM_PROVIDER_KEY",
     "Code",
     "Codebook",
     "CodebookGenerationJob",

--- a/Backend/app/models/app_settings.py
+++ b/Backend/app/models/app_settings.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class AppSetting(Base, TimestampMixin):
+    """Single-row-per-key store for mutable, app-wide settings.
+
+    Used for runtime configuration that the UI can change without a redeploy,
+    such as the active LLM provider. Keeping it as a generic key/value table
+    means new global toggles don't each need their own table or migration —
+    relevant because the schema is created via ``create_all`` (no Alembic).
+    """
+
+    __tablename__ = "app_settings"
+
+    key: Mapped[str] = mapped_column(String(64), primary_key=True)
+    value: Mapped[str] = mapped_column(Text())
+
+
+# Well-known setting keys.
+ACTIVE_LLM_PROVIDER_KEY = "active_llm_provider"

--- a/Backend/app/routers/__init__.py
+++ b/Backend/app/routers/__init__.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
 
 from app.config import Settings
-from app.routers import codebook_applications, codebooks, demographic, health, ingestion, themes
+from app.routers import (
+    codebook_applications,
+    codebooks,
+    demographic,
+    health,
+    ingestion,
+    settings as settings_router,
+    themes,
+)
 
 
 def register_routers(app: FastAPI, settings: Settings) -> None:
@@ -12,3 +20,4 @@ def register_routers(app: FastAPI, settings: Settings) -> None:
     app.include_router(codebooks.router, prefix=prefix)
     app.include_router(codebook_applications.router, prefix=prefix)
     app.include_router(themes.router, prefix=prefix)
+    app.include_router(settings_router.router, prefix=prefix)

--- a/Backend/app/routers/__init__.py
+++ b/Backend/app/routers/__init__.py
@@ -7,8 +7,10 @@ from app.routers import (
     demographic,
     health,
     ingestion,
-    settings as settings_router,
     themes,
+)
+from app.routers import (
+    settings as settings_router,
 )
 
 

--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -23,6 +23,7 @@ from app.schemas.codebook import (
     NodeInput,
 )
 from app.schemas.common import ResponseEnvelope
+from app.services.app_settings import get_active_provider
 from app.services.codebook import CodebookService
 from app.services.codebook_generation import CodebookGenerationService
 from app.services.codebook_generation_jobs import codebook_generation_job_runner
@@ -118,6 +119,10 @@ async def generate_codebook(
     payload: CodebookGenerateRequest,
     session: DbSession,
 ) -> JSONResponse:
+    # Use the globally selected LLM provider, matching the async generate-jobs
+    # path, so this endpoint never silently runs on a different provider than
+    # the one chosen in the UI.
+    active_provider = await get_active_provider(session)
     service = CodebookGenerationService(session)
     generated_codebook = await service.generate_codebook(
         codebook_name=payload.codebook_name,
@@ -125,6 +130,7 @@ async def generate_codebook(
         transcript_document_ids=payload.transcript_document_ids,
         research_query=payload.research_query,
         researcher_topics=payload.researcher_topics,
+        provider=active_provider,
     )
     return JSONResponse(
         status_code=201,

--- a/Backend/app/routers/settings.py
+++ b/Backend/app/routers/settings.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.config import Settings
+from app.dependencies import AppSettings, DbSession
+from app.llm import providers
+from app.schemas.common import ResponseEnvelope
+from app.schemas.settings import (
+    LlmProviderOption,
+    LlmProviderState,
+    LlmProviderUpdateRequest,
+)
+from app.services.app_settings import get_active_provider, set_active_provider
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+def _build_state(*, active: str, settings: Settings) -> LlmProviderState:
+    return LlmProviderState(
+        active=active,
+        default=providers.resolve_default(settings),
+        available=[
+            LlmProviderOption(
+                id=spec.id,
+                label=spec.label,
+                description=spec.description,
+                has_api_key=providers.has_api_key(settings, spec.id),
+            )
+            for spec in providers.available_providers()
+        ],
+    )
+
+
+@router.get(
+    "/llm-provider",
+    response_model=ResponseEnvelope[LlmProviderState],
+    summary="Get the active LLM provider and available options",
+)
+async def get_llm_provider(session: DbSession, settings: AppSettings) -> JSONResponse:
+    active = await get_active_provider(session, settings=settings)
+    state = _build_state(active=active, settings=settings)
+    return JSONResponse(content=ResponseEnvelope.ok(state).model_dump(mode="json"))
+
+
+@router.put(
+    "/llm-provider",
+    response_model=ResponseEnvelope[LlmProviderState],
+    summary="Set the active LLM provider",
+)
+async def update_llm_provider(
+    payload: LlmProviderUpdateRequest,
+    session: DbSession,
+    settings: AppSettings,
+) -> JSONResponse:
+    # set_active_provider validates the id and key presence, raising
+    # UnprocessableError (422) with a user-friendly message on failure.
+    active = await set_active_provider(session, payload.provider, settings=settings)
+    state = _build_state(active=active, settings=settings)
+    return JSONResponse(content=ResponseEnvelope.ok(state).model_dump(mode="json"))

--- a/Backend/app/schemas/settings.py
+++ b/Backend/app/schemas/settings.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from app.schemas.common import BaseSchema
+
+
+class LlmProviderOption(BaseSchema):
+    """One selectable LLM provider as exposed to the UI."""
+
+    id: str = Field(description="Canonical provider id, e.g. 'FAU' or 'ACADEMIC'.")
+    label: str = Field(description="Human-readable provider name.")
+    description: str = Field(description="Short, non-technical explanation for tooltips.")
+    has_api_key: bool = Field(
+        description="Whether the server has an API key configured for this provider."
+    )
+
+
+class LlmProviderState(BaseSchema):
+    """Current active provider plus the available options and the env default."""
+
+    active: str = Field(description="Canonical id of the currently active provider.")
+    default: str = Field(description="Env-configured fallback provider id.")
+    available: list[LlmProviderOption] = Field(
+        default_factory=list, description="All selectable providers, in display order."
+    )
+
+
+class LlmProviderUpdateRequest(BaseSchema):
+    """Payload for selecting the active LLM provider."""
+
+    provider: str = Field(description="Canonical provider id to activate.")

--- a/Backend/app/services/app_settings.py
+++ b/Backend/app/services/app_settings.py
@@ -1,0 +1,75 @@
+"""Read/write access to mutable, app-wide settings.
+
+Currently this covers the active LLM provider: a single global value that
+every AI task reads at run start. Resolution order when reading:
+
+    stored DB value (if a known provider) → env ``SELECTED_API`` default → FAU
+
+Writes validate against the provider registry so an unknown id can never be
+persisted.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings, get_settings
+from app.exceptions import UnprocessableError
+from app.llm import providers
+from app.models.app_settings import ACTIVE_LLM_PROVIDER_KEY, AppSetting
+
+
+async def get_active_provider(
+    session: AsyncSession,
+    *,
+    settings: Settings | None = None,
+) -> str:
+    """Return the canonical id of the active LLM provider.
+
+    Falls back to the env default when nothing is stored yet, or when a
+    previously stored value is no longer a registered provider.
+    """
+    cfg = settings or get_settings()
+    stored = (
+        await session.execute(
+            select(AppSetting.value).where(AppSetting.key == ACTIVE_LLM_PROVIDER_KEY)
+        )
+    ).scalar_one_or_none()
+    return providers.normalize(stored) or providers.resolve_default(cfg)
+
+
+async def set_active_provider(
+    session: AsyncSession,
+    provider: str,
+    *,
+    settings: Settings | None = None,
+) -> str:
+    """Persist the active LLM provider and return its canonical id.
+
+    Raises :class:`UnprocessableError` when the provider is unknown or has no
+    API key configured — surfaced to the user so they don't select a provider
+    that would fail at task time.
+    """
+    cfg = settings or get_settings()
+    canonical = providers.normalize(provider)
+    if canonical is None:
+        known = ", ".join(spec.id for spec in providers.available_providers())
+        raise UnprocessableError(
+            f"Unknown LLM provider '{provider}'. Choose one of: {known}."
+        )
+    if not providers.has_api_key(cfg, canonical):
+        spec = providers.get_provider(canonical)
+        label = spec.label if spec else canonical
+        raise UnprocessableError(
+            f"{label} has no API key configured on the server. "
+            "Add the matching key to the backend configuration before selecting it."
+        )
+
+    existing = await session.get(AppSetting, ACTIVE_LLM_PROVIDER_KEY)
+    if existing is None:
+        session.add(AppSetting(key=ACTIVE_LLM_PROVIDER_KEY, value=canonical))
+    else:
+        existing.value = canonical
+    await session.commit()
+    return canonical

--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -94,6 +94,7 @@ class CodebookApplicationService:
         corpus_id: UUID,
         codebook_id: UUID,
         transcript_document_ids: list[UUID] | None,
+        provider: str | None = None,
         on_progress: Callable[[int, int], Awaitable[None]] | None = None,
         on_phase: Callable[[str], Awaitable[None]] | None = None,
         on_run_created: Callable[[UUID], Awaitable[None]] | None = None,
@@ -147,7 +148,7 @@ class CodebookApplicationService:
         if on_phase is not None:
             await on_phase("coding_documents")
 
-        chain = build_codebook_application_with_codes_chain()
+        chain = build_codebook_application_with_codes_chain(provider=provider)
         documents_done = 0
         documents_coded = 0
         failed_documents: list[dict[str, str]] = []

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -91,8 +91,11 @@ class CodebookApplicationJobRunner:
 
             transcript_document_ids = [UUID(raw) for raw in json.loads(job.transcript_document_ids_json)]
             # Bind the globally selected LLM provider at run start so the whole
-            # job uses one consistent provider even if the setting changes mid-run.
-            active_provider = await get_active_provider(session)
+            # job uses one consistent provider even if the setting changes
+            # mid-run. Read it via a short-lived session so this lookup doesn't
+            # leave a transaction open on the long-lived job session.
+            async with session_factory() as provider_session:
+                active_provider = await get_active_provider(provider_session)
             service = CodebookApplicationService(session)
 
             async def _on_progress(done: int, total: int) -> None:

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_session_factory
 from app.models import CodebookApplicationJob, CodebookApplicationRun
+from app.services.app_settings import get_active_provider
 from app.services.codebook_application import (
     CodebookApplicationCancelledError,
     CodebookApplicationService,
@@ -89,6 +90,9 @@ class CodebookApplicationJobRunner:
             await session.commit()
 
             transcript_document_ids = [UUID(raw) for raw in json.loads(job.transcript_document_ids_json)]
+            # Bind the globally selected LLM provider at run start so the whole
+            # job uses one consistent provider even if the setting changes mid-run.
+            active_provider = await get_active_provider(session)
             service = CodebookApplicationService(session)
 
             async def _on_progress(done: int, total: int) -> None:
@@ -128,6 +132,7 @@ class CodebookApplicationJobRunner:
                     corpus_id=job.corpus_id,
                     codebook_id=job.codebook_id,
                     transcript_document_ids=transcript_document_ids,
+                    provider=active_provider,
                     on_progress=_on_progress,
                     on_phase=_on_phase,
                     on_run_created=_on_run_created,

--- a/Backend/app/services/codebook_generation.py
+++ b/Backend/app/services/codebook_generation.py
@@ -81,6 +81,7 @@ class CodebookGenerationService:
         transcript_document_ids: list[UUID] | None,
         research_query: str | None = None,
         researcher_topics: str | None = None,
+        provider: str | None = None,
         on_progress: Callable[[int, int], Awaitable[None]] | None = None,
         on_phase: Callable[[str], Awaitable[None]] | None = None,
         should_cancel: Callable[[], Awaitable[bool]] | None = None,
@@ -117,6 +118,7 @@ class CodebookGenerationService:
             passages,
             research_query=research_query,
             researcher_topics=researcher_topics,
+            provider=provider,
             on_progress=on_progress,
             should_cancel=should_cancel,
         )
@@ -258,13 +260,14 @@ class CodebookGenerationService:
         *,
         research_query: str | None = None,
         researcher_topics: str | None = None,
+        provider: str | None = None,
         on_progress: Callable[[int, int], Awaitable[None]] | None = None,
         should_cancel: Callable[[], Awaitable[bool]] | None = None,
     ) -> tuple[list[PassageCodebookGeneration], list[GeneratedCodebookResponse.PassageFailure]]:
         started_at = time.monotonic()
 
         total = len(passages)
-        chain = build_codebook_generation_chain()
+        chain = build_codebook_generation_chain(provider=provider)
         completed = 0
         generation_by_index: dict[int, PassageCodebookGeneration] = {}
         parse_failures_by_index: dict[int, Exception] = {}

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -141,8 +141,11 @@ class CodebookGenerationJobRunner:
 
             transcript_document_ids = [UUID(raw) for raw in json.loads(job.transcript_document_ids_json)]
             # Bind the globally selected LLM provider at run start so the whole
-            # job uses one consistent provider even if the setting changes mid-run.
-            active_provider = await get_active_provider(session)
+            # job uses one consistent provider even if the setting changes
+            # mid-run. Read it via a short-lived session so this lookup doesn't
+            # leave a transaction open on the long-lived job session.
+            async with session_factory() as provider_session:
+                active_provider = await get_active_provider(provider_session)
             service = CodebookGenerationService(session)
 
             async def _on_progress(done: int, total: int) -> None:

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_session_factory
 from app.models import CodebookGenerationJob
+from app.services.app_settings import get_active_provider
 from app.services.codebook_generation import (
     CodebookGenerationCancelledError,
     CodebookGenerationService,
@@ -139,6 +140,9 @@ class CodebookGenerationJobRunner:
             await session.commit()
 
             transcript_document_ids = [UUID(raw) for raw in json.loads(job.transcript_document_ids_json)]
+            # Bind the globally selected LLM provider at run start so the whole
+            # job uses one consistent provider even if the setting changes mid-run.
+            active_provider = await get_active_provider(session)
             service = CodebookGenerationService(session)
 
             async def _on_progress(done: int, total: int) -> None:
@@ -168,6 +172,7 @@ class CodebookGenerationJobRunner:
                     transcript_document_ids=transcript_document_ids,
                     research_query=job.research_query,
                     researcher_topics=job.researcher_topics,
+                    provider=active_provider,
                     on_progress=_on_progress,
                     on_phase=_on_phase,
                     should_cancel=_should_cancel,

--- a/Backend/tests/conftest.py
+++ b/Backend/tests/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 # Must be set before any app module is imported so Settings() can validate.
@@ -40,8 +41,17 @@ async def db_engine():
     from app.services.codebook_generation_jobs import codebook_generation_job_runner
     await codebook_application_job_runner.stop()
     await codebook_generation_job_runner.stop()
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+    except OperationalError:
+        # Each test uses its own uniquely-named shared-cache in-memory DB that
+        # is discarded once all connections close on dispose() below, so this
+        # explicit drop is just tidy-up. A lingering background-job connection
+        # can briefly hold a shared-cache table lock and make drop_all raise
+        # "database table is locked"; that's harmless here, so don't fail
+        # teardown over it.
+        pass
     await engine.dispose()
 
 

--- a/Backend/tests/test_app_settings_service.py
+++ b/Backend/tests/test_app_settings_service.py
@@ -1,0 +1,67 @@
+"""Tests for the app-settings service (active LLM provider get/set)."""
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings
+from app.exceptions import UnprocessableError
+from app.services.app_settings import get_active_provider, set_active_provider
+
+pytestmark = pytest.mark.asyncio
+
+
+def _settings(**overrides) -> Settings:
+    base = dict(
+        DATABASE_URL="sqlite+aiosqlite:///:memory:",
+        LLM_API_KEY_FAU="fau-key",
+        LLM_API_KEY="academic-key",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+async def test_get_active_provider_defaults_to_env(db_session) -> None:
+    cfg = _settings(SELECTED_API="ACADEMIC")
+    assert await get_active_provider(db_session, settings=cfg) == "ACADEMIC"
+
+
+async def test_get_active_provider_default_fau_when_unset(db_session) -> None:
+    cfg = _settings(SELECTED_API="FAU")
+    assert await get_active_provider(db_session, settings=cfg) == "FAU"
+
+
+async def test_set_then_get_round_trip(db_session) -> None:
+    cfg = _settings(SELECTED_API="FAU")
+    result = await set_active_provider(db_session, "academic", settings=cfg)
+    assert result == "ACADEMIC"
+    # Stored value overrides the env default on subsequent reads.
+    assert await get_active_provider(db_session, settings=cfg) == "ACADEMIC"
+
+
+async def test_set_updates_existing_row(db_session) -> None:
+    cfg = _settings()
+    await set_active_provider(db_session, "ACADEMIC", settings=cfg)
+    await set_active_provider(db_session, "FAU", settings=cfg)
+    assert await get_active_provider(db_session, settings=cfg) == "FAU"
+
+
+async def test_set_unknown_provider_raises(db_session) -> None:
+    cfg = _settings()
+    with pytest.raises(UnprocessableError, match="Unknown LLM provider"):
+        await set_active_provider(db_session, "litellm", settings=cfg)
+
+
+async def test_set_provider_without_key_raises(db_session) -> None:
+    cfg = _settings(LLM_API_KEY=None)  # Academic Cloud has no key
+    with pytest.raises(UnprocessableError, match="no API key configured"):
+        await set_active_provider(db_session, "ACADEMIC", settings=cfg)
+
+
+async def test_get_falls_back_when_stored_value_unknown(db_session) -> None:
+    # Simulate a stale stored value by writing directly, then reading.
+    from app.models.app_settings import ACTIVE_LLM_PROVIDER_KEY, AppSetting
+
+    db_session.add(AppSetting(key=ACTIVE_LLM_PROVIDER_KEY, value="LITELLM"))
+    await db_session.commit()
+    cfg = _settings(SELECTED_API="ACADEMIC")
+    assert await get_active_provider(db_session, settings=cfg) == "ACADEMIC"

--- a/Backend/tests/test_codebook_application_jobs_api.py
+++ b/Backend/tests/test_codebook_application_jobs_api.py
@@ -149,7 +149,7 @@ def _patch_application(monkeypatch, single_transcript_fn) -> None:
     )
     monkeypatch.setattr(
         "app.services.codebook_application.build_codebook_application_with_codes_chain",
-        lambda: object(),
+        lambda **_: object(),
     )
     monkeypatch.setattr(
         CodebookApplicationService,
@@ -260,7 +260,7 @@ async def test_apply_codebook_uses_application_parallelization_settings(db_engin
     )
     monkeypatch.setattr(
         "app.services.codebook_application.build_codebook_application_with_codes_chain",
-        lambda: object(),
+        lambda **_: object(),
     )
 
     session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
@@ -323,7 +323,7 @@ async def test_apply_codebook_job_can_be_cancelled_while_running(client, db_engi
     )
     monkeypatch.setattr(
         "app.services.codebook_application.build_codebook_application_with_codes_chain",
-        lambda: object(),
+        lambda **_: object(),
     )
     monkeypatch.setattr(
         CodebookApplicationService,

--- a/Backend/tests/test_codebook_generation_api.py
+++ b/Backend/tests/test_codebook_generation_api.py
@@ -562,6 +562,34 @@ async def test_generate_codebook_returns_404_for_unknown_corpus(client) -> None:
     assert response.json()["success"] is False
 
 
+async def test_sync_generate_uses_active_provider(client, db_engine, monkeypatch) -> None:
+    """The synchronous /generate endpoint must run on the UI-selected provider."""
+    from app.exceptions import UnprocessableError
+    from app.models.app_settings import ACTIVE_LLM_PROVIDER_KEY, AppSetting
+
+    factory = async_sessionmaker(db_engine, expire_on_commit=False, class_=AsyncSession)
+    async with factory() as setup_session:
+        setup_session.add(AppSetting(key=ACTIVE_LLM_PROVIDER_KEY, value="ACADEMIC"))
+        await setup_session.commit()
+
+    captured: dict = {}
+
+    async def _capture_generate(self, **kwargs):
+        captured.update(kwargs)
+        # Short-circuit before any real generation; we only assert the wiring.
+        raise UnprocessableError("stop after capturing provider")
+
+    monkeypatch.setattr(CodebookGenerationService, "generate_codebook", _capture_generate)
+
+    response = await client.post(
+        f"{API_CODEBOOKS}/generate",
+        json={"codebook_name": "Provider Wiring", "corpus_id": str(uuid4())},
+    )
+
+    assert response.status_code == 422
+    assert captured["provider"] == "ACADEMIC"
+
+
 async def test_generate_codebook_uses_all_corpus_documents_when_ids_omitted(
     client,
     monkeypatch,

--- a/Backend/tests/test_llm_client.py
+++ b/Backend/tests/test_llm_client.py
@@ -149,18 +149,31 @@ class TestOverrides:
 
 
 # ---------------------------------------------------------------------------
-# Unknown / future providers fall back to ACADEMIC
+# Unknown / future providers fall back to the default provider (FAU)
 # ---------------------------------------------------------------------------
 
 class TestUnknownProvider:
-    def test_unknown_selected_api_falls_back_to_academic(self) -> None:
-        """Any unrecognised SELECTED_API value falls back to Academic Cloud credentials."""
+    def test_unknown_selected_api_falls_back_to_default(self) -> None:
+        """Any unrecognised SELECTED_API value falls back to the default provider (FAU)."""
         cfg = _settings(
             SELECTED_API="LITELLM",           # hypothetical future value
-            LLM_API_KEY="academic-fallback",
+            LLM_API_KEY_FAU="fau-fallback",
+            LLM_BASE_URL_FAU="https://hub.nhr.fau.de/api/llmgw/v1",
+            LLM_MODEL_FAU="gpt-oss-120b",
+        )
+        with patch("app.llm.client.ChatOpenAI") as mock_cls:
+            build_chat_model(settings=cfg)
+            assert mock_cls.call_args.kwargs["api_key"] == "fau-fallback"
+
+    def test_explicit_provider_overrides_selected_api(self) -> None:
+        """An explicit provider argument wins over the env SELECTED_API default."""
+        cfg = _settings(
+            SELECTED_API="FAU",
+            LLM_API_KEY_FAU="fau-key",
+            LLM_API_KEY="academic-key",
             LLM_BASE_URL="https://chat-ai.academiccloud.de/v1",
             LLM_MODEL="gemma-3-27b-it",
         )
         with patch("app.llm.client.ChatOpenAI") as mock_cls:
-            build_chat_model(settings=cfg)
-            assert mock_cls.call_args.kwargs["api_key"] == "academic-fallback"
+            build_chat_model(settings=cfg, provider="ACADEMIC")
+            assert mock_cls.call_args.kwargs["api_key"] == "academic-key"

--- a/Backend/tests/test_llm_providers.py
+++ b/Backend/tests/test_llm_providers.py
@@ -1,0 +1,52 @@
+"""Unit tests for the LLM provider registry (app.llm.providers)."""
+from __future__ import annotations
+
+from app.config import Settings
+from app.llm import providers
+
+
+def _settings(**overrides) -> Settings:
+    base = dict(DATABASE_URL="sqlite+aiosqlite:///:memory:")
+    base.update(overrides)
+    return Settings(**base)
+
+
+def test_available_providers_contains_both_modes() -> None:
+    ids = [spec.id for spec in providers.available_providers()]
+    assert ids == ["FAU", "ACADEMIC"]
+
+
+def test_default_provider_is_fau() -> None:
+    assert providers.DEFAULT_PROVIDER_ID == "FAU"
+
+
+def test_normalize_is_case_insensitive() -> None:
+    assert providers.normalize("fau") == "FAU"
+    assert providers.normalize("Academic") == "ACADEMIC"
+
+
+def test_normalize_unknown_returns_none() -> None:
+    assert providers.normalize("litellm") is None
+    assert providers.normalize("") is None
+    assert providers.normalize(None) is None
+
+
+def test_is_known_provider() -> None:
+    assert providers.is_known_provider("FAU")
+    assert not providers.is_known_provider("nope")
+    assert not providers.is_known_provider(None)
+
+
+def test_resolve_default_uses_selected_api() -> None:
+    assert providers.resolve_default(_settings(SELECTED_API="ACADEMIC")) == "ACADEMIC"
+
+
+def test_resolve_default_falls_back_to_fau_for_unknown() -> None:
+    assert providers.resolve_default(_settings(SELECTED_API="LITELLM")) == "FAU"
+
+
+def test_has_api_key_reflects_settings() -> None:
+    cfg = _settings(LLM_API_KEY_FAU="key", LLM_API_KEY=None)
+    assert providers.has_api_key(cfg, "FAU") is True
+    assert providers.has_api_key(cfg, "ACADEMIC") is False
+    assert providers.has_api_key(cfg, "UNKNOWN") is False

--- a/Backend/tests/test_pipeline_provider.py
+++ b/Backend/tests/test_pipeline_provider.py
@@ -1,0 +1,36 @@
+"""The chain builders must forward the selected provider to build_chat_model.
+
+This is the seam that carries the user's provider choice from a job runner all
+the way to the LLM client, so it's worth pinning down directly.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.llm.pipelines import (
+    build_codebook_application_with_codes_chain,
+    build_codebook_generation_chain,
+)
+
+
+def test_application_chain_forwards_provider() -> None:
+    with patch("app.llm.pipelines.build_chat_model") as mock_build:
+        mock_build.return_value = MagicMock()
+        build_codebook_application_with_codes_chain(provider="ACADEMIC")
+        mock_build.assert_called_once_with(provider="ACADEMIC")
+
+
+def test_generation_chain_forwards_provider() -> None:
+    with patch("app.llm.pipelines.build_chat_model") as mock_build:
+        mock_build.return_value = MagicMock()
+        build_codebook_generation_chain(provider="FAU")
+        mock_build.assert_called_once_with(provider="FAU")
+
+
+def test_chain_uses_injected_model_over_provider() -> None:
+    # When an explicit model is injected (tests, batching), build_chat_model is
+    # not called at all — the provider is irrelevant in that path.
+    sentinel_model = MagicMock()
+    with patch("app.llm.pipelines.build_chat_model") as mock_build:
+        build_codebook_application_with_codes_chain(model=sentinel_model, provider="ACADEMIC")
+        mock_build.assert_not_called()

--- a/Backend/tests/test_settings_api.py
+++ b/Backend/tests/test_settings_api.py
@@ -1,0 +1,126 @@
+"""Integration tests for the LLM provider settings API.
+
+Uses a dedicated app client that overrides both the DB session and Settings so
+the test controls which providers have API keys configured, independent of the
+ambient .env.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.config import Settings
+
+pytestmark = pytest.mark.asyncio
+
+PREFIX = "/api/v1/settings/llm-provider"
+
+
+def _settings(**overrides) -> Settings:
+    base = dict(
+        DATABASE_URL="sqlite+aiosqlite:///:memory:",
+        LLM_API_KEY_FAU="fau-key",
+        LLM_API_KEY="academic-key",
+        SELECTED_API="FAU",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+@pytest_asyncio.fixture
+async def provider_client(db_engine) -> AsyncGenerator[tuple[AsyncClient, Settings], None]:
+    factory = async_sessionmaker(db_engine, expire_on_commit=False, class_=AsyncSession)
+    test_settings = _settings()
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as session:
+            try:
+                yield session
+            except Exception:
+                await session.rollback()
+                raise
+
+    with (
+        patch("app.database.check_db_connection", new=AsyncMock(return_value=True)),
+        patch("app.database.init_db", new=AsyncMock()),
+        patch("app.database.dispose_engine", new=AsyncMock()),
+    ):
+        from app.config import get_settings
+        from app.database import get_session
+        from app.main import create_app
+
+        app = create_app()
+        app.dependency_overrides[get_session] = override_session
+        app.dependency_overrides[get_settings] = lambda: test_settings
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            yield client, test_settings
+
+
+async def test_get_returns_default_and_options(provider_client) -> None:
+    client, _ = provider_client
+    resp = await client.get(PREFIX)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+    assert data["active"] == "FAU"
+    assert data["default"] == "FAU"
+    ids = [opt["id"] for opt in data["available"]]
+    assert ids == ["FAU", "ACADEMIC"]
+    assert all("has_api_key" in opt and "label" in opt for opt in data["available"])
+
+
+async def test_put_switches_active_provider(provider_client) -> None:
+    client, _ = provider_client
+    resp = await client.put(PREFIX, json={"provider": "academic"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["active"] == "ACADEMIC"
+
+    # Persisted: a follow-up GET reflects the new active provider.
+    follow_up = await client.get(PREFIX)
+    assert follow_up.json()["data"]["active"] == "ACADEMIC"
+
+
+async def test_put_unknown_provider_is_422(provider_client) -> None:
+    client, _ = provider_client
+    resp = await client.put(PREFIX, json={"provider": "litellm"})
+    assert resp.status_code == 422
+    assert resp.json()["success"] is False
+
+
+async def test_put_provider_without_key_is_422(db_engine) -> None:
+    # Build a client whose Academic Cloud key is missing.
+    factory = async_sessionmaker(db_engine, expire_on_commit=False, class_=AsyncSession)
+    test_settings = _settings(LLM_API_KEY=None)
+
+    async def override_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as session:
+            yield session
+
+    with (
+        patch("app.database.check_db_connection", new=AsyncMock(return_value=True)),
+        patch("app.database.init_db", new=AsyncMock()),
+        patch("app.database.dispose_engine", new=AsyncMock()),
+    ):
+        from app.config import get_settings
+        from app.database import get_session
+        from app.main import create_app
+
+        app = create_app()
+        app.dependency_overrides[get_session] = override_session
+        app.dependency_overrides[get_settings] = lambda: test_settings
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(PREFIX, json={"provider": "ACADEMIC"})
+            assert resp.status_code == 422
+            assert "no api key" in resp.json()["error"].lower()

--- a/Documentation/Build-&-Deploy.md
+++ b/Documentation/Build-&-Deploy.md
@@ -114,7 +114,7 @@ The full list of variables is documented in [`Backend/.env.example`](../Backend/
 |---|---|---|---|
 | `LLM_API_KEY_FAU` | yes (if `SELECTED_API=FAU`) | — | NHR@FAU gateway key |
 | `LLM_API_KEY` | yes (if `SELECTED_API=ACADEMIC`) | — | Academic Cloud key |
-| `SELECTED_API` | no | `FAU` | `FAU` or `ACADEMIC` |
+| `SELECTED_API` | no | `FAU` | **Default** provider (`FAU` or `ACADEMIC`). Used only when no provider has been selected in the UI — the active provider can be switched live from the Home page (**LLM Provider** card) and is stored server-side in the `app_settings` table. Any AI task (codebook generation / analysis) reads the active provider at run start. |
 | `LLM_MODEL_FAU` | no | `gpt-oss-120b` | Override to use a different FAU-hosted model |
 | `LLM_MODEL` | no | `gemma-3-27b-it` | Override for Academic Cloud |
 | `LLM_REQUEST_TIMEOUT_S` | no | `120.0` | Raise if you hit timeouts on large corpora |

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -59,9 +59,37 @@ class FakeBackend:
         self.generation_jobs: dict[str, dict] = {}
         self.last_generation_job_request: dict | None = None
         self.last_create_codebook_request: dict | None = None
+        # LLM provider setting (Home page dropdown)
+        self.llm_provider_state: dict = {
+            "active": "FAU",
+            "default": "FAU",
+            "available": [
+                {"id": "FAU", "label": "FAU NHR",
+                 "description": "The university's NHR@FAU gateway (default).",
+                 "has_api_key": True},
+                {"id": "ACADEMIC", "label": "Academic Cloud",
+                 "description": "The GWDG Academic Cloud chat-ai endpoint.",
+                 "has_api_key": True},
+            ],
+        }
+        self.last_set_provider: str | None = None
         # Either a method-name string (generic BackendError) or a
         # (method-name, ExceptionClass) tuple (specific typed subclass).
         self.raise_on: str | tuple[str, type] | None = None
+
+    # ---- Settings -----------------------------------------------------------
+
+    def get_llm_provider(self) -> dict:
+        self._maybe_raise("get_llm_provider")
+        return self.llm_provider_state
+
+    def set_llm_provider(self, provider: str) -> dict:
+        self._maybe_raise("set_llm_provider")
+        self.last_set_provider = provider
+        new_state = dict(self.llm_provider_state)
+        new_state["active"] = provider.upper()
+        self.llm_provider_state = new_state
+        return new_state
 
     # ---- Corpora / documents ------------------------------------------------
 
@@ -312,6 +340,7 @@ def fake_backend(monkeypatch) -> FakeBackend:
     monkeypatch.setattr("web.controllers.codebooks._backend", lambda: fake)
     monkeypatch.setattr("web.controllers.demographic._backend", lambda: fake)
     monkeypatch.setattr("web.controllers.analysis._backend", lambda: fake)
+    monkeypatch.setattr("web.controllers.main._backend", lambda: fake)
     return fake
 
 

--- a/Frontend/tests/test_backend_client_validation.py
+++ b/Frontend/tests/test_backend_client_validation.py
@@ -1,0 +1,47 @@
+"""Unit tests for _parse_validation_detail in the backend client.
+
+Focus: the message a 4xx error surfaces to the user. Our backend wraps handled
+errors in an envelope where the human-readable message can live in `detail`,
+`meta.detail`, or the top-level `error` field — the parser must find it in all
+of these so service-raised messages aren't lost to the generic fallback.
+"""
+from __future__ import annotations
+
+import httpx
+
+from web.services.backend_client import _parse_validation_detail
+
+
+def _resp(payload: dict) -> httpx.Response:
+    return httpx.Response(status_code=422, json=payload)
+
+
+def test_parses_fastapi_list_detail() -> None:
+    payload = {"detail": [{"loc": ["body", "provider"], "msg": "field required"}]}
+    assert _parse_validation_detail(_resp(payload)) == "provider: field required"
+
+
+def test_parses_string_detail() -> None:
+    assert _parse_validation_detail(_resp({"detail": "bad thing"})) == "bad thing"
+
+
+def test_parses_meta_detail() -> None:
+    payload = {"success": False, "error": "Validation failed", "meta": {"detail": "field x is wrong"}}
+    assert _parse_validation_detail(_resp(payload)) == "field x is wrong"
+
+
+def test_falls_back_to_top_level_error() -> None:
+    # Service-raised UnprocessableError envelope: message is in `error`, meta null.
+    payload = {
+        "success": False,
+        "error": "Academic Cloud has no API key configured on the server.",
+        "meta": None,
+    }
+    assert (
+        _parse_validation_detail(_resp(payload))
+        == "Academic Cloud has no API key configured on the server."
+    )
+
+
+def test_returns_none_when_no_message() -> None:
+    assert _parse_validation_detail(_resp({"success": False, "meta": None})) is None

--- a/Frontend/tests/test_main_controller.py
+++ b/Frontend/tests/test_main_controller.py
@@ -1,0 +1,59 @@
+"""Tests for the Home page LLM provider dropdown (web.controllers.main)."""
+from __future__ import annotations
+
+
+def test_home_renders_provider_dropdown(client, fake_backend) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "LLM Provider" in body
+    # Both providers from the backend appear as options.
+    assert "FAU NHR" in body
+    assert "Academic Cloud" in body
+    # The active provider is preselected.
+    assert 'value="FAU"' in body and "selected" in body
+
+
+def test_home_degrades_when_backend_down(client, fake_backend) -> None:
+    fake_backend.raise_on = "get_llm_provider"
+    resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    # Card still renders (fallback state) and the control is disabled.
+    assert "LLM Provider" in body
+    assert "unreachable" in body.lower()
+
+
+def test_set_provider_persists_and_flashes(client, fake_backend) -> None:
+    resp = client.post(
+        "/settings/llm-provider",
+        data={"provider": "ACADEMIC"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert fake_backend.last_set_provider == "ACADEMIC"
+    assert "Academic Cloud" in resp.data.decode()
+
+
+def test_set_provider_blank_is_rejected(client, fake_backend) -> None:
+    resp = client.post(
+        "/settings/llm-provider",
+        data={"provider": ""},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    # No backend call was made for a blank selection.
+    assert fake_backend.last_set_provider is None
+    assert "choose an llm provider" in resp.data.decode().lower()
+
+
+def test_set_provider_surfaces_backend_error(client, fake_backend) -> None:
+    fake_backend.raise_on = "set_llm_provider"
+    resp = client.post(
+        "/settings/llm-provider",
+        data={"provider": "ACADEMIC"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    # The friendly BackendError message is flashed.
+    assert "simulated set_llm_provider failure" in resp.data.decode()

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -27,6 +27,18 @@ def index() -> str:
     codebooks = []
     previous_runs = []
 
+    # Best-effort: show which LLM provider a run will use. Non-fatal if it fails.
+    active_provider_label = None
+    try:
+        provider_state = client.get_llm_provider()
+        active_provider_label = next(
+            (opt["label"] for opt in provider_state.get("available", [])
+             if opt["id"] == provider_state.get("active")),
+            provider_state.get("active"),
+        )
+    except BackendError:
+        active_provider_label = None
+
     if not active_corpus_id:
         disabled_reason = "No active corpus selected."
     else:
@@ -72,6 +84,7 @@ def index() -> str:
         previous_runs=previous_runs,
         active_corpus_id=active_corpus_id,
         corpus_options=corpus_options if active_corpus_id else [],
+        active_provider_label=active_provider_label,
     )
 
 @bp.post("/trigger")

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -564,6 +564,19 @@ def _resolve_mode(value: str) -> str:
     return value if value in ("auto", "semi") else "auto"
 
 
+def _active_provider_label() -> str | None:
+    """Best-effort label of the active LLM provider; None if backend is down."""
+    try:
+        state = _backend().get_llm_provider()
+        return next(
+            (opt["label"] for opt in state.get("available", [])
+             if opt["id"] == state.get("active")),
+            state.get("active"),
+        )
+    except BackendError:
+        return None
+
+
 @bp.get("/new/<corpus_id>/auto")
 def new_codebook_auto_form(corpus_id: str) -> str:
     mode = _resolve_mode(request.args.get("mode", ""))
@@ -574,6 +587,7 @@ def new_codebook_auto_form(corpus_id: str) -> str:
         codebook_name=request.args.get("name", ""),
         research_query=request.args.get("rq", ""),
         researcher_topics=request.args.get("rt", ""),
+        active_provider_label=_active_provider_label(),
     )
 
 
@@ -595,6 +609,7 @@ def new_codebook_auto_submit(corpus_id: str):
             researcher_topics=researcher_topics,
             rq_error=rq_error,
             rt_error=rt_error,
+            active_provider_label=_active_provider_label(),
         )
 
     if not name:

--- a/Frontend/web/controllers/main.py
+++ b/Frontend/web/controllers/main.py
@@ -1,11 +1,62 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from web.services.backend_client import BackendError, get_backend_client as _backend
 
 bp = Blueprint("main", __name__)
+
+# Shown when the backend is unreachable so the Home page still renders a sane,
+# read-only provider card instead of erroring out.
+_FALLBACK_PROVIDER_STATE: dict = {
+    "active": "FAU",
+    "default": "FAU",
+    "available": [
+        {"id": "FAU", "label": "FAU NHR",
+         "description": "The university's NHR@FAU gateway (default).",
+         "has_api_key": True},
+        {"id": "ACADEMIC", "label": "Academic Cloud",
+         "description": "The GWDG Academic Cloud chat-ai endpoint.",
+         "has_api_key": True},
+    ],
+}
 
 
 @bp.get("/")
 def index() -> str:
-    return render_template("index.html")
+    provider_state = _FALLBACK_PROVIDER_STATE
+    provider_available = False
+    try:
+        provider_state = _backend().get_llm_provider()
+        provider_available = True
+    except BackendError as exc:
+        # Non-fatal: render the Home page with a disabled provider card.
+        flash(
+            f"Couldn't load the LLM provider setting: {exc.user_message}",
+            "warning",
+        )
+    return render_template(
+        "index.html",
+        provider_state=provider_state,
+        provider_available=provider_available,
+    )
+
+
+@bp.post("/settings/llm-provider")
+def set_llm_provider():
+    provider = (request.form.get("provider") or "").strip()
+    if not provider:
+        flash("Please choose an LLM provider before saving.", "danger")
+        return redirect(url_for("main.index"))
+
+    try:
+        state = _backend().set_llm_provider(provider)
+        label = next(
+            (opt["label"] for opt in state.get("available", []) if opt["id"] == state["active"]),
+            state["active"],
+        )
+        flash(f"LLM provider set to {label}.", "success")
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+    return redirect(url_for("main.index"))
 
 
 @bp.get("/health")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -406,6 +406,20 @@ class BackendClient:
     def cancel_generation_job(self, job_id: str) -> dict:
         return self._post(f"/codebooks/generate-jobs/{job_id}/cancel")
 
+    # ---- Settings -----------------------------------------------------------
+
+    def get_llm_provider(self) -> dict:
+        """Return the active LLM provider plus available options and default.
+
+        Shape: {"active": str, "default": str, "available": [{id, label,
+        description, has_api_key}]}.
+        """
+        return self._get("/settings/llm-provider")
+
+    def set_llm_provider(self, provider: str) -> dict:
+        """Persist the active LLM provider; returns the updated provider state."""
+        return self._put("/settings/llm-provider", json={"provider": provider})
+
     # ---- Helpers ------------------------------------------------------------
 
     def _unwrap(self, response: httpx.Response, *, sub_key: str | None = None):

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -551,13 +551,21 @@ def _parse_validation_detail(response: httpx.Response) -> str | None:
         return detail
 
     if not isinstance(detail, list):
-        # Our backend envelope for handled 422s is:
-        # {"success": false, "error": "...", "meta": {"detail": "..."}}
+        # Our backend envelope for handled 4xx errors is one of:
+        #   {"success": false, "error": "...", "meta": {"detail": "..."}}
+        #   {"success": false, "error": "...", "meta": null}   (e.g. validation
+        #     errors raised in services, where the message lives in `error`)
+        # Prefer the more specific meta.detail, then fall back to the top-level
+        # `error` so service-raised messages (e.g. "<provider> has no API key
+        # configured") reach the user instead of the generic default.
         meta = body.get("meta")
         if isinstance(meta, dict):
             meta_detail = meta.get("detail")
             if isinstance(meta_detail, str) and meta_detail.strip():
                 return meta_detail
+        error = body.get("error")
+        if isinstance(error, str) and error.strip():
+            return error
         return None
 
     messages: list[str] = []

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -27,6 +27,14 @@
         {% endif %}
       </li>
       <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+        <span>LLM Provider</span>
+        {% if active_provider_label %}
+          <span class="badge bg-secondary rounded-pill" title="Change this on the Home page.">{{ active_provider_label }}</span>
+        {% else %}
+          <span class="badge bg-light text-secondary rounded-pill">Unavailable</span>
+        {% endif %}
+      </li>
+      <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
         <span>Transcripts</span>
         {% if transcripts_count > 0 %}
           <span class="badge bg-success rounded-pill">✓ {{ transcripts_count }} ready</span>

--- a/Frontend/web/templates/codebooks/new/auto_form.html
+++ b/Frontend/web/templates/codebooks/new/auto_form.html
@@ -7,6 +7,10 @@
     <h1 class="h3 mb-1">Name Your Codebook</h1>
     <p class="text-secondary mb-0">
       Mode: <span class="badge text-bg-secondary">{{ mode_label }}</span>
+      {% if active_provider_label %}
+        &middot; LLM Provider:
+        <span class="badge text-bg-light border" title="Change this on the Home page.">{{ active_provider_label }}</span>
+      {% endif %}
     </p>
   </div>
 

--- a/Frontend/web/templates/index.html
+++ b/Frontend/web/templates/index.html
@@ -6,6 +6,64 @@
     <p class="text-secondary mb-0">Researcher workspace for corpus ingestion and thematic coding.</p>
   </div>
 
+  <div class="bg-white border rounded-2 p-3 mb-4">
+    <div class="d-flex align-items-center gap-2 mb-1">
+      <h2 class="h6 mb-0">LLM Provider</h2>
+      <span class="text-secondary"
+            data-bs-toggle="tooltip"
+            title="Choose which third-party LLM service runs your AI tasks (codebook generation and analysis). This applies to every AI task across the app until you change it.">
+        &#9432;
+      </span>
+    </div>
+    <p class="text-secondary small mb-3">
+      Select the provider used whenever you run an AI task. &ldquo;FAU NHR&rdquo; is the default.
+    </p>
+
+    {% set active = provider_state.active %}
+    <form method="post"
+          action="{{ url_for('main.set_llm_provider') }}"
+          class="row g-2 align-items-end"
+          {% if not provider_available %}aria-disabled="true"{% endif %}>
+      <div class="col-12 col-sm-6 col-md-4">
+        <label for="llm-provider-select" class="form-label small mb-1">Provider</label>
+        <select id="llm-provider-select"
+                name="provider"
+                class="form-select form-select-sm"
+                required
+                {% if not provider_available %}disabled{% endif %}>
+          {% for opt in provider_state.available %}
+            <option value="{{ opt.id }}"
+                    {% if opt.id == active %}selected{% endif %}
+                    {% if not opt.has_api_key %}disabled{% endif %}
+                    data-bs-toggle="tooltip"
+                    title="{{ opt.description }}{% if not opt.has_api_key %} (No API key configured on the server.){% endif %}">
+              {{ opt.label }}{% if not opt.has_api_key %} — no key configured{% endif %}{% if opt.id == provider_state.default %} (default){% endif %}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12 col-sm-auto">
+        <button type="submit"
+                class="btn btn-sm btn-primary"
+                {% if not provider_available %}disabled{% endif %}>
+          Save provider
+        </button>
+      </div>
+    </form>
+
+    {% if not provider_available %}
+      <p class="text-warning small mb-0 mt-2">
+        The analysis service is unreachable, so the provider can't be changed right now.
+      </p>
+    {% endif %}
+
+    <ul class="list-unstyled small text-secondary mb-0 mt-2">
+      {% for opt in provider_state.available %}
+        <li><strong>{{ opt.label }}:</strong> {{ opt.description }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+
   <div class="row g-3">
     <div class="col-12 col-md-3">
       <div class="bg-white border rounded-2 p-3 h-100">
@@ -36,4 +94,14 @@
       </div>
     </div>
   </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    // Enable Bootstrap tooltips so non-technical users get hover descriptions
+    // on the provider control. The bundle is loaded in base.html.
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+      bootstrap.Tooltip.getOrCreateInstance(el);
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
Add a global, app-wide setting to switch the LLM provider used by all AI tasks (codebook generation and analysis) between FAU NHR and Academic Cloud.

Backend:
- Add llm/providers.py registry as the single source of truth for the two providers (labels, credential mapping, default resolution).
- Add app_settings key/value table + service to persist the active provider (resolution: stored value -> SELECTED_API env default -> FAU).
- Thread provider through build_chat_model, both pipeline chain builders, and the generation/application services; job runners read the active provider at run start.
- Add GET/PUT /settings/llm-provider with validation (unknown id and missing API key return friendly 422s).
- build_chat_model now falls back to the default provider (FAU) for unknown SELECTED_API values instead of Academic.

Frontend:
- Add an LLM Provider card to the Home page (dropdown, tooltips, no-blank validation) wired to the settings API, with graceful degradation when the backend is unreachable.
- Show a read-only active-provider badge on the analysis and codebook auto-generation pages.

Tests/docs:
- Add backend tests (registry, settings service, settings API, chain provider forwarding) and frontend controller tests; update affected tests.
- Update .env.example and Build-&-Deploy docs.