### PR TITLE
Delete analysis runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ demo_data/
 
 # Internal frontend planning document
 Documentation/frontend-improvements.md
+Frontend/tmp/
 
 # PyCharm Plugins
 .codebuddy

--- a/Backend/app/routers/codebook_applications.py
+++ b/Backend/app/routers/codebook_applications.py
@@ -333,6 +333,33 @@ async def get_codebook_application_run(
     return JSONResponse(content=ResponseEnvelope.ok(detail).model_dump(mode="json"))
 
 
+@router.delete(
+    "/codebook-application-runs/{run_id}",
+    response_model=ResponseEnvelope[None],
+    summary="Delete a codebook application run",
+)
+async def delete_codebook_application_run(
+    run_id: UUID,
+    session: DbSession,
+) -> JSONResponse:
+    """Hard-delete an analysis run and all its coded results.
+
+    Cascades to the run's document codings and their theme/code assignments via
+    the database ON DELETE CASCADE constraints. A run that is still running is
+    refused so a live job does not keep writing to a deleted run.
+    """
+    run = await session.get(CodebookApplicationRun, run_id)
+    if run is None:
+        raise NotFoundError(f"Codebook application run '{run_id}' not found")
+    if run.status == "running":
+        raise UnprocessableError(
+            f"Run '{run_id}' is still running. Cancel the analysis before deleting it."
+        )
+    await session.delete(run)
+    await session.commit()
+    return JSONResponse(content=ResponseEnvelope.ok(None).model_dump(mode="json"))
+
+
 @router.get(
     "/codebook-application-runs/{run_id}/documents",
     response_model=ResponseEnvelope[list[DocumentCodingSchema]],

--- a/Backend/tests/test_codebook_application_runs_api.py
+++ b/Backend/tests/test_codebook_application_runs_api.py
@@ -1,0 +1,75 @@
+"""API tests for deleting codebook application runs (issue #203)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models import Codebook, CodebookApplicationRun, Corpus
+
+RUNS_API = "/api/v1/codebook-application-runs"
+
+
+def _now_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+async def _seed_run(db_engine, *, status: str = "succeeded") -> str:
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        corpus = Corpus(id=uuid4(), project_id=uuid4(), name="Run Corpus")
+        codebook = Codebook(
+            id=uuid4(),
+            corpus_id=corpus.id,
+            name="Run Codebook",
+            description="Fixture",
+            version=1,
+            created_by="system",
+        )
+        run = CodebookApplicationRun(
+            id=uuid4(),
+            name="Initial Run",
+            custom_id="RUN-001",
+            corpus_id=corpus.id,
+            codebook_id=codebook.id,
+            status=status,
+            documents_total=2,
+            documents_coded=2 if status == "succeeded" else 0,
+            documents_failed=0,
+            started_at=_now_naive(),
+            finished_at=_now_naive() if status != "running" else None,
+        )
+        session.add_all([corpus, codebook, run])
+        await session.commit()
+        return str(run.id)
+
+
+async def test_delete_run_succeeds_and_removes_it(client, db_engine) -> None:
+    run_id = await _seed_run(db_engine)
+
+    response = await client.delete(f"{RUNS_API}/{run_id}")
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    # The run is gone; a follow-up fetch 404s.
+    follow_up = await client.get(f"{RUNS_API}/{run_id}")
+    assert follow_up.status_code == 404
+
+
+async def test_delete_unknown_run_is_404(client) -> None:
+    response = await client.delete(f"{RUNS_API}/{uuid4()}")
+    assert response.status_code == 404
+    assert response.json()["success"] is False
+
+
+async def test_delete_running_run_is_rejected(client, db_engine) -> None:
+    run_id = await _seed_run(db_engine, status="running")
+
+    response = await client.delete(f"{RUNS_API}/{run_id}")
+    assert response.status_code == 422
+    assert response.json()["success"] is False
+
+    # The run is untouched and still retrievable.
+    follow_up = await client.get(f"{RUNS_API}/{run_id}")
+    assert follow_up.status_code == 200

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -43,6 +43,9 @@ class FakeBackend:
         self.codebooks: list[dict] = []
         self.theme_frequencies: list[dict] = []
         self.theme_tree: list[dict] = []
+        # Analysis runs (Previous Analysis Runs box)
+        self.application_runs: list[dict] = []
+        self.deleted_run_ids: list[str] = []
         # Demographic data
         self.demographic_files: list[dict] = []
         self.demographic_rows: list[dict] = []
@@ -314,7 +317,17 @@ class FakeBackend:
 
     def list_codebook_application_runs(self, codebook_id: str) -> list[dict]:
         self._maybe_raise("list_codebook_application_runs")
-        return []
+        return [
+            run for run in self.application_runs
+            if run.get("codebook_id") in (None, codebook_id)
+        ]
+
+    def delete_codebook_application_run(self, run_id: str) -> None:
+        self._maybe_raise("delete_codebook_application_run")
+        self.deleted_run_ids.append(run_id)
+        self.application_runs = [
+            run for run in self.application_runs if run.get("id") != run_id
+        ]
 
     # ---- Internal -----------------------------------------------------------
 

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -96,3 +96,84 @@ def test_analysis_job_status(client, fake_backend):
     data = resp.json
     assert data["id"] == job["id"]
     assert data["status"] == "queued"
+
+
+# Delete Analysis Runs (issue #203) ------------------------------------------
+
+
+def _ready_corpus_with_runs(fake_backend):
+    corpus_id = "test-corpus"
+    fake_backend.corpora = [{"id": corpus_id, "name": "Test Corpus"}]
+    fake_backend.documents = [{"id": "doc1"}]
+    fake_backend.codebooks = [{"id": "cb1", "name": "Test CB", "version": 1}]
+    fake_backend.application_runs = [
+        {"id": "run1", "codebook_id": "cb1", "name": "Initial Run",
+         "custom_id": "RUN-001", "status": "succeeded",
+         "created_at": "2026-01-01T00:00:00", "transcript_document_ids": ["doc1"]},
+        {"id": "run2", "codebook_id": "cb1", "name": "Second Run",
+         "custom_id": "RUN-002", "status": "failed",
+         "created_at": "2026-01-02T00:00:00", "transcript_document_ids": ["doc1"]},
+    ]
+    return corpus_id
+
+
+def test_previous_runs_render_with_delete_toolbar(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.get("/analysis/")
+    assert resp.status_code == 200
+    body = resp.data
+    # Selectable-list delete affordances are present.
+    assert b"Delete selected" in body
+    assert b"data-selectable-list" in body
+    # Each run is a selectable row.
+    assert b'data-item-id="run1"' in body
+    assert b'value="run1"' in body
+    assert b"Initial Run" in body
+
+
+def test_delete_selected_runs_success(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.post(
+        f"/analysis/runs/delete?corpus_id={corpus_id}",
+        data={"item_ids": ["run1", "run2"]},
+    )
+    assert resp.status_code == 302
+    assert "/analysis/" in resp.headers["Location"]
+    assert fake_backend.deleted_run_ids == ["run1", "run2"]
+
+    follow = client.get(resp.headers["Location"])
+    assert b"Deleted 2 analysis runs." in follow.data
+
+
+def test_delete_selected_runs_none_selected(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.post(f"/analysis/runs/delete?corpus_id={corpus_id}", data={})
+    assert resp.status_code == 302
+    assert fake_backend.deleted_run_ids == []
+
+    follow = client.get(resp.headers["Location"])
+    assert b"Select at least one analysis run to delete." in follow.data
+
+
+def test_delete_selected_runs_backend_error_is_flashed(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    fake_backend.raise_on = "delete_codebook_application_run"
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.post(
+        f"/analysis/runs/delete?corpus_id={corpus_id}",
+        data={"item_ids": ["run1"]},
+    )
+    assert resp.status_code == 302
+    follow = client.get(resp.headers["Location"])
+    assert b"simulated delete_codebook_application_run failure" in follow.data

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -125,3 +125,30 @@ def job_status(job_id: str):
         return jsonify(job)
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 500
+
+
+@bp.post("/runs/delete")
+def delete_selected_runs():
+    """Hard-delete the analysis runs selected in the Previous Analysis Runs box."""
+    corpus_id = request.args.get("corpus_id") or request.form.get("corpus_id")
+    run_ids = [item_id for item_id in request.form.getlist("item_ids") if item_id]
+    if not run_ids:
+        flash("Select at least one analysis run to delete.", "warning")
+        return redirect(url_for("analysis.index", corpus_id=corpus_id))
+
+    client = _backend()
+    deleted = 0
+    try:
+        for run_id in run_ids:
+            client.delete_codebook_application_run(run_id)
+            deleted += 1
+        flash(f"Deleted {deleted} analysis run{'s' if deleted != 1 else ''}.", "success")
+    except BackendError as exc:
+        if deleted:
+            flash(
+                f"Deleted {deleted} analysis run{'s' if deleted != 1 else ''} before an error occurred.",
+                "warning",
+            )
+        flash(exc.user_message, "danger")
+
+    return redirect(url_for("analysis.index", corpus_id=corpus_id))

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -130,7 +130,7 @@ def job_status(job_id: str):
 @bp.post("/runs/delete")
 def delete_selected_runs():
     """Hard-delete the analysis runs selected in the Previous Analysis Runs box."""
-    corpus_id = request.args.get("corpus_id") or request.form.get("corpus_id")
+    corpus_id = request.args.get("corpus_id")
     run_ids = [item_id for item_id in request.form.getlist("item_ids") if item_id]
     if not run_ids:
         flash("Select at least one analysis run to delete.", "warning")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -321,6 +321,10 @@ class BackendClient:
             return result
         return result.get("items", result) if isinstance(result, dict) else []
 
+    def delete_codebook_application_run(self, run_id: str) -> None:
+        """Hard-delete an analysis run and its coded results."""
+        self._delete(f"/codebook-application-runs/{run_id}")
+
     # ---- Codebook Upload & Parsing ------------------------------------------
 
     def parse_csv_preview(self, file: FileStorage) -> list[dict]:

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -125,9 +125,9 @@
     <h5 class="card-title fw-bold mb-3">Previous Analysis Runs</h5>
     {% if previous_runs %}
     {# Reuses the shared selectable-list pattern (Codebooks/Transcripts). The
-       list sits inside this card, so it intentionally omits its own
-       bg-white/border to avoid a double frame. #}
-    <div class="ata-selectable-list border rounded-2 overflow-hidden" data-selectable-list>
+       surrounding card is border-0 (shadow only), so the list keeps its own
+       border to frame the table. #}
+    <div class="ata-selectable-list border rounded-2" data-selectable-list>
       {% set selectable_list_label = 'analysis runs' %}
       {% set selectable_list_item_singular = 'run' %}
       {% set selectable_list_item_plural = 'runs' %}

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -124,39 +124,62 @@
   <div class="card-body p-4">
     <h5 class="card-title fw-bold mb-3">Previous Analysis Runs</h5>
     {% if previous_runs %}
-    <div class="table-responsive">
-      <table class="table table-hover align-middle">
-        <thead class="table-light">
-          <tr>
-            <th>Name</th>
-            <th>Run ID</th>
-            <th>Codebook</th>
-            <th>Status</th>
-            <th>Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for run in previous_runs %}
-          <tr>
-            <td>{{ run.name or '-' }}</td>
-            <td>{{ run.custom_id or '-' }}</td>
-            <td>{{ run.codebook_name }}</td>
-            <td>
-              {% if run.status == 'succeeded' %}
-                <span class="badge bg-success">Succeeded</span>
-              {% elif run.status == 'failed' %}
-                <span class="badge bg-danger">Failed</span>
-              {% elif run.status == 'cancelled' %}
-                <span class="badge bg-secondary">Cancelled</span>
-              {% else %}
-                <span class="badge bg-primary">Running</span>
-              {% endif %}
-            </td>
-            <td>{{ run.created_at[:10] }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+    {# Reuses the shared selectable-list pattern (Codebooks/Transcripts). The
+       list sits inside this card, so it intentionally omits its own
+       bg-white/border to avoid a double frame. #}
+    <div class="ata-selectable-list border rounded-2 overflow-hidden" data-selectable-list>
+      {% set selectable_list_label = 'analysis runs' %}
+      {% set selectable_list_item_singular = 'run' %}
+      {% set selectable_list_item_plural = 'runs' %}
+      {% set selectable_list_delete_action = url_for('analysis.delete_selected_runs', corpus_id=active_corpus_id) %}
+      {% set selectable_list_delete_label = 'Delete selected' %}
+      {% set selectable_list_delete_modal_id = 'deleteSelectedRunsModal' %}
+      {% set selectable_list_delete_title = 'Delete Analysis Runs' %}
+      {% set selectable_list_delete_message = 'Are you sure you want to delete the selected analysis runs? This permanently removes the runs and all of their coded results, and cannot be undone.' %}
+      {% set selectable_list_delete_confirm_label = 'Delete' %}
+      {% include "_selectable_list_toolbar.html" %}
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle mb-0">
+          <thead class="table-light">
+            <tr>
+              <th class="ata-selectable-list__checkbox-cell" scope="col">Select</th>
+              <th>Name</th>
+              <th>Run ID</th>
+              <th>Codebook</th>
+              <th>Status</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for run in previous_runs %}
+            <tr class="ata-selectable-list__row" data-selectable-list-row data-item-id="{{ run.id }}">
+              <td class="ata-selectable-list__checkbox-cell">
+                <input class="form-check-input"
+                       type="checkbox"
+                       value="{{ run.id }}"
+                       data-selectable-list-checkbox
+                       aria-label="Select analysis run {{ run.name or run.custom_id or run.id }}">
+              </td>
+              <td>{{ run.name or '-' }}</td>
+              <td>{{ run.custom_id or '-' }}</td>
+              <td>{{ run.codebook_name }}</td>
+              <td>
+                {% if run.status == 'succeeded' %}
+                  <span class="badge bg-success">Succeeded</span>
+                {% elif run.status == 'failed' %}
+                  <span class="badge bg-danger">Failed</span>
+                {% elif run.status == 'cancelled' %}
+                  <span class="badge bg-secondary">Cancelled</span>
+                {% else %}
+                  <span class="badge bg-primary">Running</span>
+                {% endif %}
+              </td>
+              <td>{{ run.created_at[:10] }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
     {% else %}
     <p class="text-muted mb-0">No previous analysis runs found for this corpus.</p>


### PR DESCRIPTION
## What this does

Closes #203.

Adds a way to delete old analysis runs from the **Analysis page**. Until now the "Previous Analysis Runs" box only listed runs with no way to remove them. This PR lets a user pick one or more runs and delete them.

## How it works for the user

- Each row in the "Previous Analysis Runs" box now has a checkbox.
- A "Select all" option and a **Delete selected** button sit at the top of the list (the button stays disabled until at least one run is picked).
- Clicking **Delete selected** opens a confirmation pop-up. After the user confirms, the chosen runs are removed for good (a hard delete in the database, including their coded results).

This uses the same select-and-delete pattern we already use for Codebooks and Transcripts, so it looks and behaves consistently with the rest of the app.

## What changed

**Backend**
- New endpoint `DELETE /api/v1/codebook-application-runs/{run_id}`.
- It hard-deletes the run. The run's document codings and their theme/code assignments are removed automatically through the existing database cascade rules.
- Safety checks: returns `404` if the run does not exist, and `422` if the run is still **running** (you must cancel a running analysis before deleting it, so a live job never writes to a deleted run).

**Frontend**
- New `BackendClient` method that calls the delete endpoint.
- New route `POST /analysis/runs/delete` that deletes the selected runs, shows a short success/error message, and returns to the Analysis page.
- The "Previous Analysis Runs" table now uses the shared selectable-list component (checkboxes, select-all, top delete button, confirm modal). It is placed inside the existing card without an extra border, so the layout stays clean.