### PR TITLE
small UI fix: remove Code on the Code-editor page.

### DIFF
--- a/Frontend/web/static/js/codebook_review.js
+++ b/Frontend/web/static/js/codebook_review.js
@@ -58,7 +58,6 @@
                   aria-label="Remove">&times;</button>
           <label class="form-check form-switch mb-0 small">
             <input class="form-check-input code-toggle" type="checkbox" ${isCode ? "checked" : ""}>
-            <span class="form-check-label">Code</span>
           </label>
         </div>
       </div>

--- a/Frontend/web/static/js/codebook_review.js
+++ b/Frontend/web/static/js/codebook_review.js
@@ -56,8 +56,9 @@
         <div class="d-flex flex-column align-items-end gap-1">
           <button type="button" class="btn btn-sm btn-outline-secondary remove-row-btn"
                   aria-label="Remove">&times;</button>
-          <label class="form-check form-switch mb-0 small">
-            <input class="form-check-input code-toggle" type="checkbox" ${isCode ? "checked" : ""}>
+          <label class="form-check form-switch mb-0 small" title="Mark this row as a code (leaf observation)">
+            <input class="form-check-input code-toggle" type="checkbox"
+                   aria-label="Code" ${isCode ? "checked" : ""}>
           </label>
         </div>
       </div>

--- a/Frontend/web/templates/codebooks/review.html
+++ b/Frontend/web/templates/codebooks/review.html
@@ -109,7 +109,6 @@
                 <label class="form-check form-switch mb-0 small" title="Mark this row as a code (leaf observation)">
                   <input class="form-check-input code-toggle" type="checkbox"
                          {% if node.is_code %}checked{% endif %}>
-                  <span class="form-check-label">Code</span>
                 </label>
               </div>
             </div>

--- a/Frontend/web/templates/codebooks/review.html
+++ b/Frontend/web/templates/codebooks/review.html
@@ -108,6 +108,7 @@
                         aria-label="Remove">&times;</button>
                 <label class="form-check form-switch mb-0 small" title="Mark this row as a code (leaf observation)">
                   <input class="form-check-input code-toggle" type="checkbox"
+                         aria-label="Code"
                          {% if node.is_code %}checked{% endif %}>
                 </label>
               </div>


### PR DESCRIPTION
Two lines changed to remove the word "code" in the UI.