### PR TITLE
205 view analsys button and 204 Choose Analysis Runs on Codebook View Page

### DIFF
--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -42,6 +42,8 @@ class FakeBackend:
         self.uploaded_files: list[str] = []
         self.codebooks: list[dict] = []
         self.theme_frequencies: list[dict] = []
+        self.theme_frequencies_by_run: dict[str, list[dict]] = {}
+        self.last_theme_frequencies_application_run_id: str | None = None
         self.theme_tree: list[dict] = []
         # Analysis runs (Previous Analysis Runs box)
         self.application_runs: list[dict] = []
@@ -158,8 +160,13 @@ class FakeBackend:
         from web.services.backend_client import BackendNotFoundError
         raise BackendNotFoundError(user_message="Codebook not found.")
 
-    def get_theme_frequencies(self, codebook_id: str) -> list[dict]:
+    def get_theme_frequencies(
+        self, codebook_id: str, application_run_id: str | None = None
+    ) -> list[dict]:
         self._maybe_raise("get_theme_frequencies")
+        self.last_theme_frequencies_application_run_id = application_run_id
+        if application_run_id and application_run_id in self.theme_frequencies_by_run:
+            return self.theme_frequencies_by_run[application_run_id]
         return self.theme_frequencies
 
     def get_theme_tree(self, codebook_id: str) -> list[dict]:

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -134,6 +134,22 @@ def test_previous_runs_render_with_delete_toolbar(client, fake_backend):
     assert b"Initial Run" in body
 
 
+def test_previous_runs_render_view_analysis_link(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.get("/analysis/")
+    assert resp.status_code == 200
+    body = resp.data
+    assert b"<th>Actions</th>" in body
+    assert b"View Analysis" in body
+    assert (
+        b'href="/codebooks/test-corpus/cb1/themes?application_run_id=run1"'
+        in body
+    )
+
+
 def test_delete_selected_runs_success(client, fake_backend):
     corpus_id = _ready_corpus_with_runs(fake_backend)
     with client.session_transaction() as sess:

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -175,6 +175,151 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
     assert b'id="global-corpus-select"' in resp.data
 
 
+def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.application_runs = [
+        {"id": "run-1", "codebook_id": "cb-1", "name": "Initial Run",
+         "custom_id": "RUN-001", "status": "succeeded",
+         "created_at": "2026-01-01T00:00:00"},
+        {"id": "run-2", "codebook_id": "cb-1", "name": "Follow-up Run",
+         "custom_id": "RUN-002", "status": "succeeded",
+         "created_at": "2026-01-02T00:00:00"},
+    ]
+    fake_backend.theme_frequencies = [
+        {"theme_id": "t-1", "theme_name": "Default Theme",
+         "occurrence_count": 1, "interview_coverage_percentage": 10.0},
+    ]
+    fake_backend.theme_frequencies_by_run = {
+        "run-2": [
+            {"theme_id": "t-1", "theme_name": "Run Two Theme",
+             "occurrence_count": 7, "interview_coverage_percentage": 70.0},
+        ],
+    }
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Run Two Theme", "is_active": True},
+         "children": []},
+    ]
+
+    resp = client.get(
+        "/codebooks/test-corpus-id/cb-1/themes?application_run_id=run-2",
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
+    assert b"Run Two Theme" in resp.data
+    assert b"analysis-run-bar" in resp.data
+    assert b'id="application-run-select"' in resp.data
+    assert b'value="run-2" selected' in resp.data
+    assert b"Latest successful" in resp.data
+    assert b"Follow-up Run - 2026-01-02 00:00" in resp.data
+    assert b"Latest successful run" not in resp.data
+
+
+def test_codebook_themes_defaults_to_latest_successful_run(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.application_runs = [
+        {"id": "run-1", "codebook_id": "cb-1", "name": "Initial Run",
+         "custom_id": "RUN-001", "status": "succeeded",
+         "created_at": "2026-01-01T00:00:00"},
+        {"id": "run-2", "codebook_id": "cb-1", "name": "Latest Run",
+         "custom_id": "RUN-002", "status": "succeeded",
+         "created_at": "2026-01-02T00:00:00", "documents_coded": 4,
+         "documents_total": 5, "documents_failed": 1},
+        {"id": "run-3", "codebook_id": "cb-1", "name": "Running Run",
+         "custom_id": "RUN-003", "status": "running",
+         "created_at": "2026-01-03T00:00:00"},
+    ]
+    fake_backend.theme_frequencies_by_run = {
+        "run-2": [
+            {"theme_id": "t-1", "theme_name": "Latest Theme",
+             "occurrence_count": 7, "interview_coverage_percentage": 70.0},
+        ],
+    }
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Latest Theme", "is_active": True},
+         "children": []},
+    ]
+
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
+    assert b'value="run-2" selected' in resp.data
+    assert b"Latest Theme" in resp.data
+    assert b"4 coded" in resp.data
+    assert b"1 failed" in resp.data
+
+
+def test_codebook_themes_shows_analysis_run_bar_without_runs(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.application_runs = []
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Work-Life Balance", "is_active": True},
+         "children": []},
+    ]
+
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert b"analysis-run-bar" in resp.data
+    assert b"Select an analysis run" in resp.data
+    assert b"No analysis runs for this codebook." in resp.data
+    assert b'id="application-run-select"' in resp.data
+    assert b"disabled" in resp.data
+    assert b"No analysis runs available" in resp.data
+
+
+def test_codebook_themes_defaults_to_latest_failed_run_when_no_success(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.application_runs = [
+        {"id": "run-1", "codebook_id": "cb-1", "name": "Failed Run 1",
+         "custom_id": "RUN-001", "status": "failed",
+         "created_at": "2026-01-01T00:00:00", "documents_coded": 1,
+         "documents_total": 5, "documents_failed": 4},
+        {"id": "run-2", "codebook_id": "cb-1", "name": "Failed Run 2",
+         "custom_id": "RUN-002", "status": "failed",
+         "created_at": "2026-01-02T00:00:00", "documents_coded": 2,
+         "documents_total": 5, "documents_failed": 3},
+    ]
+    fake_backend.theme_frequencies_by_run = {
+        "run-2": [
+            {"theme_id": "t-1", "theme_name": "Partial Theme",
+             "occurrence_count": 2, "interview_coverage_percentage": 20.0},
+        ],
+    }
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Partial Theme", "is_active": True},
+         "children": []},
+    ]
+
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
+    assert b'value="run-2" selected' in resp.data
+    assert b"Failed" in resp.data
+    assert b"This analysis run failed." in resp.data
+    assert b"2 coded" in resp.data
+    assert b"3 failed" in resp.data
+
+
 def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
     fake_backend.codebooks = [
         {"id": "cb-1", "name": "Interview Codebook", "version": 3,

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -30,6 +30,56 @@ _QUERY_MIN = 10
 _QUERY_MAX = 500
 
 
+def _format_run_timestamp(run: dict) -> str:
+    raw = run.get("finished_at") or run.get("created_at") or ""
+    return str(raw).replace("T", " ")[:16]
+
+
+def _prepare_application_runs(
+    application_runs: list[dict],
+    requested_run_id: str,
+) -> tuple[list[dict], dict | None, str]:
+    decorated_runs = []
+    latest_run = max(
+        application_runs,
+        key=lambda run: str(run.get("finished_at") or run.get("created_at") or ""),
+        default=None,
+    )
+    latest_successful_run = max(
+        (run for run in application_runs if run.get("status") == "succeeded"),
+        key=lambda run: str(run.get("finished_at") or run.get("created_at") or ""),
+        default=None,
+    )
+    latest_successful_id = str(latest_successful_run.get("id")) if latest_successful_run else ""
+    fallback_run_id = latest_successful_id or (str(latest_run.get("id")) if latest_run else "")
+
+    valid_run_ids = {str(run.get("id")) for run in application_runs}
+    selected_run_id = requested_run_id if requested_run_id in valid_run_ids else ""
+    if not selected_run_id:
+        selected_run_id = fallback_run_id
+
+    for run in application_runs:
+        run_id = str(run.get("id"))
+        timestamp = _format_run_timestamp(run)
+        run_name = run.get("name") or run.get("custom_id") or run_id
+        label = f"{run_name} - {timestamp}" if timestamp else run_name
+        if run_id == latest_successful_id:
+            label = f"{label} - Latest successful"
+        decorated_runs.append({
+            **run,
+            "id": run_id,
+            "timestamp_label": timestamp,
+            "select_label": label,
+            "is_latest_successful": run_id == latest_successful_id,
+        })
+
+    selected_run = next(
+        (run for run in decorated_runs if str(run.get("id")) == selected_run_id),
+        None,
+    )
+    return decorated_runs, selected_run, selected_run_id
+
+
 def _safe_export_filename(name: str, version: int | str | None) -> str:
     safe_name = "".join(
         ch if ch.isalnum() or ch in ("-", "_") else "_"
@@ -173,6 +223,7 @@ def codebook_themes(codebook_id: str) -> str:
                 codebook_id=codebook_id,
                 name=request.args.get("name", ""),
                 version=request.args.get("version", ""),
+                application_run_id=request.args.get("application_run_id", ""),
             )
         )
 
@@ -190,6 +241,7 @@ def codebook_themes(codebook_id: str) -> str:
                 codebook_id=codebook_id,
                 name=request.args.get("name", ""),
                 version=request.args.get("version", ""),
+                application_run_id=request.args.get("application_run_id", ""),
             )
         )
     return redirect(url_for("codebooks.list_codebooks"))
@@ -200,7 +252,10 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
     set_active_corpus_id(corpus_id)
     name = request.args.get("name", "")
     version = request.args.get("version", "")
+    selected_application_run_id = request.args.get("application_run_id", "")
     active_codebook_id = codebook_id
+    application_runs: list[dict] = []
+    selected_application_run: dict | None = None
     corpus_name = "Selected Corpus"
     corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
     try:
@@ -231,8 +286,15 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             version = str(active_codebook["version"])
         research_query = active_codebook.get("research_query") or ""
         researcher_topics = active_codebook.get("researcher_topics") or ""
+        application_runs = client.list_codebook_application_runs(active_codebook_id)
+        application_runs, selected_application_run, selected_application_run_id = (
+            _prepare_application_runs(application_runs, selected_application_run_id)
+        )
 
-        frequencies = client.get_theme_frequencies(active_codebook_id)
+        frequencies = client.get_theme_frequencies(
+            active_codebook_id,
+            application_run_id=selected_application_run_id or None,
+        )
         tree = client.get_theme_tree(active_codebook_id)
         codebook = client.get_codebook(active_codebook_id)
         codes = codebook.get("codes", [])
@@ -251,6 +313,9 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             codes=[],
             research_query="",
             researcher_topics="",
+            application_runs=application_runs,
+            selected_application_run_id=selected_application_run_id,
+            selected_application_run=selected_application_run,
             error=True,
         )
     except BackendError as exc:
@@ -268,6 +333,9 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             codes=[],
             research_query="",
             researcher_topics="",
+            application_runs=application_runs,
+            selected_application_run_id=selected_application_run_id,
+            selected_application_run=selected_application_run,
             error=True,
         )
     return render_template(
@@ -283,6 +351,9 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         codes=codes,
         research_query=research_query,
         researcher_topics=researcher_topics,
+        application_runs=application_runs,
+        selected_application_run_id=selected_application_run_id,
+        selected_application_run=selected_application_run,
     )
 
 @bp.get("/<corpus_id>/<codebook_id>/themes/<theme_id>/quotes.json")
@@ -293,7 +364,14 @@ def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
     except (TypeError, ValueError):
         page, page_size = 1, 20
     try:
-        result = _backend().get_theme_quotes(codebook_id, theme_id, page, page_size)
+        application_run_id = request.args.get("application_run_id") or None
+        result = _backend().get_theme_quotes(
+            codebook_id,
+            theme_id,
+            page,
+            page_size,
+            application_run_id=application_run_id,
+        )
         return jsonify(result)
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 502

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -186,18 +186,29 @@ class BackendClient:
     # ---- Codebooks ----------------------------------------------------------
 
 
-    def get_theme_frequencies(self, codebook_id: str) -> list[dict]:
-        return self._get(f"/codebooks/{codebook_id}/themes")
+    def get_theme_frequencies(
+        self, codebook_id: str, application_run_id: str | None = None
+    ) -> list[dict]:
+        params = {"application_run_id": application_run_id} if application_run_id else None
+        return self._get(f"/codebooks/{codebook_id}/themes", params=params)
 
     def get_theme_tree(self, codebook_id: str) -> list[dict]:
         return self._get(f"/codebooks/{codebook_id}/themes/tree")
 
     def get_theme_quotes(
-        self, codebook_id: str, theme_id: str, page: int = 1, page_size: int = 20
+        self,
+        codebook_id: str,
+        theme_id: str,
+        page: int = 1,
+        page_size: int = 20,
+        application_run_id: str | None = None,
     ) -> dict:
+        params = {"page": page, "page_size": page_size}
+        if application_run_id:
+            params["application_run_id"] = application_run_id
         return self._get(
             f"/codebooks/{codebook_id}/themes/{theme_id}/quotes",
-            params={"page": page, "page_size": page_size},
+            params=params,
         )
 
     # ---- Demographic --------------------------------------------------------

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -68,6 +68,51 @@
     background: linear-gradient(135deg, #3730a3 0%, #4f46e5 55%, #6366f1 100%);
 }
 
+.analysis-run-bar {
+    background: linear-gradient(135deg, #3730a3 0%, #4f46e5 55%, #6366f1 100%);
+}
+
+.analysis-run-badge {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    white-space: nowrap;
+}
+
+.analysis-run-meta {
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 0.86rem;
+}
+
+.analysis-run-message {
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 0.9rem;
+}
+
+.analysis-run-meta span + span::before {
+    content: "•";
+    margin-right: 0.5rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.analysis-run-control {
+    width: min(100%, 360px);
+}
+
+.analysis-run-control .form-select {
+    border-color: rgba(255, 255, 255, 0.38);
+    box-shadow: none;
+}
+
+.analysis-run-control .form-select:focus {
+    border-color: #fff;
+    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.24);
+}
+
 .theme-version-badge {
     background: rgba(255, 255, 255, 0.18);
     color: #fff;
@@ -77,6 +122,12 @@
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.3);
     letter-spacing: 0.03em;
+}
+
+@media (max-width: 767.98px) {
+    .analysis-run-control {
+        width: 100%;
+    }
 }
 
 /* ── Metric cards ───────────────────────────────────────────────────────────── */

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -8,6 +8,20 @@
     const codes             = JSON.parse(appRoot.dataset.codes       || "[]");
     const quotesUrlTemplate = appRoot.dataset.quotesUrlTemplate || "";
     const readUrlTemplate   = appRoot.dataset.readUrlTemplate   || "";
+    const applicationRunId  = appRoot.dataset.applicationRunId || "";
+    const applicationRunSelect = document.getElementById("application-run-select");
+
+    if (applicationRunSelect) {
+        applicationRunSelect.addEventListener("change", () => {
+            const url = new URL(window.location.href);
+            if (applicationRunSelect.value) {
+                url.searchParams.set("application_run_id", applicationRunSelect.value);
+            } else {
+                url.searchParams.delete("application_run_id");
+            }
+            window.location.href = url.toString();
+        });
+    }
 
     // Topics the researcher asked the AI to focus on.
     const researcherTopics = (() => {
@@ -404,8 +418,13 @@
     const PAGE_SIZE        = 20;
 
     function quotesUrl(themeId, page) {
-        return quotesUrlTemplate.replace("__THEME__", themeId)
-            + "?page=" + page + "&page_size=" + PAGE_SIZE;
+        const url = new URL(quotesUrlTemplate.replace("__THEME__", themeId), window.location.origin);
+        url.searchParams.set("page", page);
+        url.searchParams.set("page_size", PAGE_SIZE);
+        if (applicationRunId) {
+            url.searchParams.set("application_run_id", applicationRunId);
+        }
+        return url.toString();
     }
 
     function interviewUrl(documentId) {

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -148,6 +148,7 @@
               <th>Codebook</th>
               <th>Status</th>
               <th>Date</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -175,6 +176,12 @@
                 {% endif %}
               </td>
               <td>{{ run.created_at[:10] }}</td>
+              <td>
+                <a class="btn btn-sm btn-outline-primary"
+                   href="{{ url_for('codebooks.codebook_themes_for_corpus', corpus_id=active_corpus_id, codebook_id=run.codebook_id, application_run_id=run.id) }}">
+                  View Analysis
+                </a>
+              </td>
             </tr>
             {% endfor %}
           </tbody>

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -9,6 +9,7 @@
      data-researcher-topics='{{ researcher_topics | tojson }}'
      data-codebook-id="{{ codebook_id }}"
      data-corpus-id="{{ corpus_id }}"
+     data-application-run-id="{{ selected_application_run_id or '' }}"
      data-quotes-url-template="{{ url_for('codebooks.theme_quotes_json', corpus_id=corpus_id, codebook_id=codebook_id, theme_id='__THEME__') }}"
      data-read-url-template="{{ url_for('ingestion.read_transcript', corpus_id=corpus_id, document_id='__DOC__') }}">
 
@@ -30,13 +31,12 @@
     </ol>
   </nav>
 
-
   {% if error %}
   <p class="text-secondary">Couldn't load themes for this codebook right now.</p>
   {% elif frequencies or tree or codes %}
 
   {# Gradient page header #}
-  <div class="theme-page-header rounded-3 mb-4 p-4">
+  <div class="theme-page-header rounded-3 mb-3 p-4">
     <div class="d-flex align-items-start justify-content-between flex-wrap gap-2">
       <div>
         <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Theme Browser</p>
@@ -53,6 +53,77 @@
         <a href="{{ url_for('codebooks.export_codebook', corpus_id=corpus_id, codebook_id=codebook_id) }}" class="btn btn-sm btn-outline-light ms-2">
           Export CSV
         </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="analysis-run-bar rounded-3 mb-4 p-4">
+    <div class="d-flex align-items-start justify-content-between flex-wrap gap-3">
+      <div>
+        <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Analysis Run</p>
+        <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
+          <h2 class="h5 text-white mb-0">
+            {% if selected_application_run %}
+              {{ selected_application_run.name or selected_application_run.custom_id or selected_application_run.id }}
+            {% else %}
+              Select an analysis run
+            {% endif %}
+          </h2>
+          {% if selected_application_run and selected_application_run.is_latest_successful %}
+            <span class="analysis-run-badge">Latest successful</span>
+          {% endif %}
+          {% if selected_application_run %}
+            {% if selected_application_run.status == 'succeeded' %}
+              <span class="badge bg-success">Succeeded</span>
+            {% elif selected_application_run.status == 'failed' %}
+              <span class="badge bg-danger">Failed</span>
+            {% elif selected_application_run.status == 'cancelled' %}
+              <span class="badge bg-secondary">Cancelled</span>
+            {% else %}
+              <span class="badge bg-primary">Running</span>
+            {% endif %}
+          {% endif %}
+        </div>
+        {% if selected_application_run %}
+          <div class="analysis-run-meta d-flex align-items-center flex-wrap gap-2">
+            {% if selected_application_run.custom_id %}
+              <span>{{ selected_application_run.custom_id }}</span>
+            {% endif %}
+            {% if selected_application_run.timestamp_label %}
+              <span>{{ selected_application_run.timestamp_label }}</span>
+            {% endif %}
+            {% if selected_application_run.documents_coded is defined %}
+              <span>{{ selected_application_run.documents_coded }} coded</span>
+            {% endif %}
+            {% if selected_application_run.documents_total is defined %}
+              <span>{{ selected_application_run.documents_total }} total</span>
+            {% endif %}
+            {% if selected_application_run.documents_failed is defined and selected_application_run.documents_failed %}
+              <span>{{ selected_application_run.documents_failed }} failed</span>
+            {% endif %}
+          </div>
+          {% if selected_application_run.status == 'failed' %}
+            <p class="analysis-run-message mb-0 mt-2">This analysis run failed. Results may be incomplete or unavailable.</p>
+          {% endif %}
+        {% else %}
+          <p class="analysis-run-message mb-0">No analysis runs for this codebook.</p>
+        {% endif %}
+      </div>
+      <div class="analysis-run-control">
+        <label for="application-run-select" class="form-label text-white-50 small text-uppercase fw-semibold mb-1" style="letter-spacing:.07em">Select Run</label>
+        {% if application_runs %}
+          <select id="application-run-select" class="form-select form-select-sm">
+            {% for run in application_runs %}
+              <option value="{{ run.id }}" {% if selected_application_run_id == run.id|string %}selected{% endif %}>
+                {{ run.select_label }}
+              </option>
+            {% endfor %}
+          </select>
+        {% else %}
+          <select id="application-run-select" class="form-select form-select-sm" disabled>
+            <option selected>No analysis runs available</option>
+          </select>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### The issues were dependent on each other thus, Ole and I implemented it in one branch.

## Summary
- Add a `View Analysis` action to each row in the Previous Analysis Runs table.
- Route analysis-run links to the matching codebook results page with the selected run applied.
- Add analysis-run-aware theme statistics and quote loading on the codebook view.
- Replace the loose run dropdown with a full-width Bootstrap-styled analysis run bar.
- Show clear states for latest successful runs, failed runs, and codebooks with no analysis runs.