### PR TITLE
Protect destructive deletes during active analyses

### DIFF
--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -319,8 +319,9 @@ async def get_codebook_detail(
 async def delete_codebook(
     codebook_id: UUID,
     session: DbSession,
+    force: bool = False,
 ) -> JSONResponse:
     """Delete a codebook and all its themes/codes."""
     service = CodebookService(session)
-    await service.delete_codebook(codebook_id)
+    await service.delete_codebook(codebook_id, force=force)
     return JSONResponse(content=ResponseEnvelope.ok(None).model_dump(mode="json"))

--- a/Backend/app/routers/ingestion.py
+++ b/Backend/app/routers/ingestion.py
@@ -91,9 +91,10 @@ async def delete_corpus(
     corpus_id: uuid.UUID,
     session: DbSession,
     settings: AppSettings,
+    force: bool = False,
 ) -> ResponseEnvelope[bool]:
     service = IngestionService(session)
-    await service.delete_corpus(corpus_id)
+    await service.delete_corpus(corpus_id, force=force)
     return ResponseEnvelope.ok(True)
 
 

--- a/Backend/app/routers/ingestion.py
+++ b/Backend/app/routers/ingestion.py
@@ -250,8 +250,9 @@ async def delete_document(
     corpus_id: uuid.UUID,
     document_id: uuid.UUID,
     session: DbSession,
+    force: bool = False,
 ) -> ResponseEnvelope[None]:
     """Delete a single document and its relationships."""
     service = IngestionService(session)
-    await service.delete_document(corpus_id=corpus_id, document_id=document_id)
+    await service.delete_document(corpus_id=corpus_id, document_id=document_id, force=force)
     return ResponseEnvelope.ok(None)

--- a/Backend/app/services/analysis_dependency_guard.py
+++ b/Backend/app/services/analysis_dependency_guard.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import ConflictError
+from app.models import CodebookApplicationJob
+
+_ACTIVE_STATUSES = {"queued", "running"}
+
+
+def _utc_now_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _document_ids_for_job(job: CodebookApplicationJob) -> set[UUID]:
+    try:
+        raw_ids = json.loads(job.transcript_document_ids_json or "[]")
+    except json.JSONDecodeError:
+        return set()
+    return {UUID(raw_id) for raw_id in raw_ids}
+
+
+def _job_label(job: CodebookApplicationJob) -> str:
+    return job.name or job.custom_id or str(job.id)
+
+
+def _conflict_message(*, resource_label: str, jobs: list[CodebookApplicationJob]) -> str:
+    names = ", ".join(_job_label(job) for job in jobs[:3])
+    suffix = f": {names}." if names else "."
+    more = f" and {len(jobs) - 3} more" if len(jobs) > 3 else ""
+    if more and suffix.endswith("."):
+        suffix = suffix[:-1] + more + "."
+    return f"Deleting {resource_label} will cancel the running analysis run(s){suffix}"
+
+
+async def _cancel_jobs(jobs: Iterable[CodebookApplicationJob]) -> None:
+    now = _utc_now_naive()
+    for job in jobs:
+        job.cancel_requested = True
+        if job.status == "queued":
+            job.status = "cancelled"
+            job.phase = "cancelled"
+            job.finished_at = now
+
+
+async def active_jobs_for_documents(
+    session: AsyncSession,
+    *,
+    corpus_id: UUID,
+    document_ids: Iterable[UUID],
+) -> list[CodebookApplicationJob]:
+    requested_ids = set(document_ids)
+    if not requested_ids:
+        return []
+
+    jobs = list(
+        (
+            await session.scalars(
+                select(CodebookApplicationJob).where(
+                    CodebookApplicationJob.corpus_id == corpus_id,
+                    CodebookApplicationJob.status.in_(_ACTIVE_STATUSES),
+                )
+            )
+        ).all()
+    )
+
+    impacted: list[CodebookApplicationJob] = []
+    for job in jobs:
+        job_document_ids = _document_ids_for_job(job)
+        if not job_document_ids or requested_ids.intersection(job_document_ids):
+            impacted.append(job)
+    return impacted
+
+
+async def guard_document_deletion(
+    session: AsyncSession,
+    *,
+    corpus_id: UUID,
+    document_ids: Iterable[UUID],
+    force: bool,
+) -> None:
+    impacted_jobs = await active_jobs_for_documents(
+        session,
+        corpus_id=corpus_id,
+        document_ids=document_ids,
+    )
+    if not impacted_jobs:
+        return
+    if not force:
+        raise ConflictError(_conflict_message(resource_label="the selected transcript(s)", jobs=impacted_jobs))
+    await _cancel_jobs(impacted_jobs)
+
+
+async def active_jobs_for_codebooks(
+    session: AsyncSession,
+    *,
+    codebook_ids: Iterable[UUID],
+) -> list[CodebookApplicationJob]:
+    requested_ids = set(codebook_ids)
+    if not requested_ids:
+        return []
+    return list(
+        (
+            await session.scalars(
+                select(CodebookApplicationJob).where(
+                    CodebookApplicationJob.codebook_id.in_(requested_ids),
+                    CodebookApplicationJob.status.in_(_ACTIVE_STATUSES),
+                )
+            )
+        ).all()
+    )
+
+
+async def guard_codebook_deletion(
+    session: AsyncSession,
+    *,
+    codebook_ids: Iterable[UUID],
+    force: bool,
+) -> None:
+    impacted_jobs = await active_jobs_for_codebooks(session, codebook_ids=codebook_ids)
+    if not impacted_jobs:
+        return
+    if not force:
+        raise ConflictError(_conflict_message(resource_label="the selected codebook(s)", jobs=impacted_jobs))
+    await _cancel_jobs(impacted_jobs)

--- a/Backend/app/services/analysis_dependency_guard.py
+++ b/Backend/app/services/analysis_dependency_guard.py
@@ -129,3 +129,36 @@ async def guard_codebook_deletion(
     if not force:
         raise ConflictError(_conflict_message(resource_label="the selected codebook(s)", jobs=impacted_jobs))
     await _cancel_jobs(impacted_jobs)
+
+
+async def active_jobs_for_corpus(
+    session: AsyncSession,
+    *,
+    corpus_id: UUID,
+) -> list[CodebookApplicationJob]:
+    return list(
+        (
+            await session.scalars(
+                select(CodebookApplicationJob).where(
+                    CodebookApplicationJob.corpus_id == corpus_id,
+                    CodebookApplicationJob.status.in_(_ACTIVE_STATUSES),
+                )
+            )
+        ).all()
+    )
+
+
+async def guard_corpus_deletion(
+    session: AsyncSession,
+    *,
+    corpus_id: UUID,
+    force: bool,
+) -> None:
+    # Deleting a corpus cascades to every document it owns, so any active job
+    # in the corpus is impacted regardless of which documents it targets.
+    impacted_jobs = await active_jobs_for_corpus(session, corpus_id=corpus_id)
+    if not impacted_jobs:
+        return
+    if not force:
+        raise ConflictError(_conflict_message(resource_label="this corpus", jobs=impacted_jobs))
+    await _cancel_jobs(impacted_jobs)

--- a/Backend/app/services/codebook.py
+++ b/Backend/app/services/codebook.py
@@ -20,6 +20,7 @@ from app.schemas.codebook import (
     NodeType,
     ThemeInCodebookSchema,
 )
+from app.services.analysis_dependency_guard import guard_codebook_deletion
 
 if TYPE_CHECKING:
     from app.schemas.codebook import CodebookDetailSchema
@@ -255,7 +256,7 @@ class CodebookService:
     # Delete
     # ------------------------------------------------------------------
 
-    async def delete_codebook(self, codebook_id: uuid.UUID) -> None:
+    async def delete_codebook(self, codebook_id: uuid.UUID, *, force: bool = False) -> None:
         """Delete a codebook and all associated themes/codes via cascade.
 
         Raises:
@@ -268,6 +269,11 @@ class CodebookService:
         if codebook is None:
             raise NotFoundError(f"Codebook '{codebook_id}' not found.")
 
+        await guard_codebook_deletion(
+            self._session,
+            codebook_ids=[codebook_id],
+            force=force,
+        )
         await self._session.delete(codebook)
         await self._session.commit()
 

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -126,7 +126,7 @@ class CodebookApplicationJobRunner:
             async def _should_cancel() -> bool:
                 async with session_factory() as cancel_session:
                     cancel_job = await cancel_session.get(CodebookApplicationJob, job_id)
-                    return bool(cancel_job and cancel_job.cancel_requested)
+                    return cancel_job is None or cancel_job.cancel_requested
 
             try:
                 summary = await service.apply_codebook(
@@ -141,15 +141,24 @@ class CodebookApplicationJobRunner:
                     on_run_created=_on_run_created,
                     should_cancel=_should_cancel,
                 )
-                await session.refresh(job)
-                job.status = "succeeded"
-                job.phase = "succeeded"
-                job.application_run_id = summary.application_run.id
-                job.documents_total = summary.documents_total
-                job.documents_done = summary.documents_total
-                job.documents_coded = summary.documents_coded
-                job.documents_failed = summary.documents_failed
-                job.error_message = (
+                current_job = await session.get(CodebookApplicationJob, job_id)
+                if current_job is None:
+                    return
+                if current_job.cancel_requested:
+                    current_job.status = "cancelled"
+                    current_job.phase = "cancelled"
+                    current_job.finished_at = _utc_now_naive()
+                    await self._mark_run_terminal(session, current_job.application_run_id, status="cancelled")
+                    await session.commit()
+                    return
+                current_job.status = "succeeded"
+                current_job.phase = "succeeded"
+                current_job.application_run_id = summary.application_run.id
+                current_job.documents_total = summary.documents_total
+                current_job.documents_done = summary.documents_total
+                current_job.documents_coded = summary.documents_coded
+                current_job.documents_failed = summary.documents_failed
+                current_job.error_message = (
                     json.dumps(
                         {
                             "type": "document_application_partial_failures",
@@ -161,24 +170,35 @@ class CodebookApplicationJobRunner:
                     if summary.documents_failed
                     else None
                 )
-                job.finished_at = _utc_now_naive()
+                current_job.finished_at = _utc_now_naive()
                 await session.commit()
             except CodebookApplicationCancelledError:
                 await session.rollback()
-                await session.refresh(job)
-                job.status = "cancelled"
-                job.phase = "cancelled"
-                job.finished_at = _utc_now_naive()
-                await self._mark_run_terminal(session, job.application_run_id, status="cancelled")
+                current_job = await session.get(CodebookApplicationJob, job_id)
+                if current_job is None:
+                    return
+                current_job.status = "cancelled"
+                current_job.phase = "cancelled"
+                current_job.finished_at = _utc_now_naive()
+                await self._mark_run_terminal(session, current_job.application_run_id, status="cancelled")
                 await session.commit()
             except Exception as exc:
                 await session.rollback()
-                await session.refresh(job)
-                job.status = "failed"
-                job.phase = "failed"
-                job.error_message = str(exc)
-                job.finished_at = _utc_now_naive()
-                await self._mark_run_terminal(session, job.application_run_id, status="failed")
+                current_job = await session.get(CodebookApplicationJob, job_id)
+                if current_job is None:
+                    return
+                if current_job.cancel_requested:
+                    current_job.status = "cancelled"
+                    current_job.phase = "cancelled"
+                    current_job.finished_at = _utc_now_naive()
+                    await self._mark_run_terminal(session, current_job.application_run_id, status="cancelled")
+                    await session.commit()
+                    return
+                current_job.status = "failed"
+                current_job.phase = "failed"
+                current_job.error_message = str(exc)
+                current_job.finished_at = _utc_now_naive()
+                await self._mark_run_terminal(session, current_job.application_run_id, status="failed")
                 await session.commit()
 
     @staticmethod

--- a/Backend/app/services/ingestion.py
+++ b/Backend/app/services/ingestion.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload
 from app.exceptions import NotFoundError, UnprocessableError
 from app.models.ingestion import Corpus, CorpusDocument
 from app.schemas.ingestion import CorpusCreate, DocumentInput
+from app.services.analysis_dependency_guard import guard_document_deletion
 from app.services.linking import auto_link_demographics
 
 
@@ -162,9 +163,21 @@ class IngestionService:
             raise NotFoundError(f"Document '{document_id}' not found in corpus '{corpus_id}'")
         return doc
 
-    async def delete_document(self, corpus_id: uuid.UUID, document_id: uuid.UUID) -> None:
+    async def delete_document(
+        self,
+        corpus_id: uuid.UUID,
+        document_id: uuid.UUID,
+        *,
+        force: bool = False,
+    ) -> None:
         """Delete a single document by ID. Raises NotFoundError if absent."""
         doc = await self.get_document(corpus_id, document_id)
+        await guard_document_deletion(
+            self._session,
+            corpus_id=corpus_id,
+            document_ids=[document_id],
+            force=force,
+        )
         await self._session.delete(doc)
         await self._session.commit()
 

--- a/Backend/app/services/ingestion.py
+++ b/Backend/app/services/ingestion.py
@@ -8,7 +8,10 @@ from sqlalchemy.orm import joinedload
 from app.exceptions import NotFoundError, UnprocessableError
 from app.models.ingestion import Corpus, CorpusDocument
 from app.schemas.ingestion import CorpusCreate, DocumentInput
-from app.services.analysis_dependency_guard import guard_document_deletion
+from app.services.analysis_dependency_guard import (
+    guard_corpus_deletion,
+    guard_document_deletion,
+)
 from app.services.linking import auto_link_demographics
 
 
@@ -73,11 +76,16 @@ class IngestionService:
         )
         return list(rows.scalars().all()), total
 
-    async def delete_corpus(self, corpus_id: uuid.UUID) -> None:
+    async def delete_corpus(self, corpus_id: uuid.UUID, *, force: bool = False) -> None:
         """Delete a corpus and all its associated data.
         Relies on database CASCADE ON DELETE constraints.
         """
         corpus = await self.get_corpus(corpus_id)
+        await guard_corpus_deletion(
+            self._session,
+            corpus_id=corpus_id,
+            force=force,
+        )
         await self._session.delete(corpus)
         await self._session.commit()
 

--- a/Backend/tests/test_codebook_router.py
+++ b/Backend/tests/test_codebook_router.py
@@ -5,7 +5,10 @@ tested endpoints over HTTP/REST on an in-memory SQLite database.
 """
 from __future__ import annotations
 
+import json
 import uuid
+
+from app.models import CodebookApplicationJob
 
 API = "/api/v1/codebooks"
 CORPUS_ID = "00000000-0000-0000-0000-000000000099"
@@ -260,4 +263,71 @@ async def test_delete_codebook_not_found(client):
     body = resp.json()
     assert body["success"] is False
     assert "not found" in body["error"].lower()
+
+
+async def test_delete_codebook_warns_when_running_analysis_depends_on_it(client, db_session):
+    await _ensure_corpus(client)
+    payload = {
+        "name": "Active Analysis Codebook",
+        "corpus_id": CORPUS_ID,
+        "nodes": [
+            {"name": f"Theme {index}", "description": "Desc", "node_type": "THEME"}
+            for index in range(1, 6)
+        ],
+    }
+    create_resp = await client.post(f"{API}/", json=payload)
+    codebook_id = create_resp.json()["data"]["id"]
+
+    job = CodebookApplicationJob(
+        id=uuid.uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(CORPUS_ID),
+        codebook_id=uuid.UUID(codebook_id),
+        transcript_document_ids_json=json.dumps([]),
+        cancel_requested=False,
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.delete(f"{API}/{codebook_id}")
+
+    assert resp.status_code == 409
+    assert "running analysis" in resp.json()["error"].lower()
+
+
+async def test_delete_codebook_force_cancels_impacted_analysis(client, db_session):
+    await _ensure_corpus(client)
+    payload = {
+        "name": "Forced Delete Codebook",
+        "corpus_id": CORPUS_ID,
+        "nodes": [
+            {"name": f"Theme {index}", "description": "Desc", "node_type": "THEME"}
+            for index in range(1, 6)
+        ],
+    }
+    create_resp = await client.post(f"{API}/", json=payload)
+    codebook_id = create_resp.json()["data"]["id"]
+
+    job = CodebookApplicationJob(
+        id=uuid.uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(CORPUS_ID),
+        codebook_id=uuid.UUID(codebook_id),
+        transcript_document_ids_json=json.dumps([]),
+        cancel_requested=False,
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    resp = await client.delete(f"{API}/{codebook_id}", params={"force": "true"})
+
+    assert resp.status_code == 200
+    refreshed_job = await db_session.get(CodebookApplicationJob, job.id)
+    if refreshed_job is not None:
+        await db_session.refresh(refreshed_job)
+        assert refreshed_job.cancel_requested is True
 

--- a/Backend/tests/test_ingestion_api.py
+++ b/Backend/tests/test_ingestion_api.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 from uuid import uuid4
 
-from app.models import Codebook, CodebookApplicationJob, CorpusDocument
+from app.models import Codebook, CodebookApplicationJob, Corpus, CorpusDocument
 
 API = "/api/v1/ingestion"
 
@@ -672,3 +672,89 @@ async def test_delete_document_force_cancels_impacted_analysis(client, db_sessio
     assert refreshed_job is not None
     await db_session.refresh(refreshed_job)
     assert refreshed_job.cancel_requested is True
+
+
+async def test_delete_corpus_warns_when_running_analysis_depends_on_it(client, db_session):
+    create = await client.post(f"{API}/corpora", json={"corpus_id": P1_STR, "name": "C"})
+    corpus_id = create.json()["data"]["id"]
+
+    await client.post(
+        f"{API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [{"title": "Running doc", "text": "content"}]},
+    )
+    docs_resp = await client.get(f"{API}/corpora/{corpus_id}/documents")
+    document_id = docs_resp.json()["data"]["items"][0]["id"]
+
+    codebook = Codebook(
+        id=uuid4(),
+        corpus_id=uuid.UUID(P1_STR),
+        name="Active Codebook",
+        version=1,
+        created_by="test",
+    )
+    job = CodebookApplicationJob(
+        id=uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(P1_STR),
+        codebook_id=codebook.id,
+        transcript_document_ids_json=json.dumps([document_id]),
+        cancel_requested=False,
+    )
+    db_session.add_all([codebook, job])
+    await db_session.commit()
+
+    del_resp = await client.delete(f"{API}/corpora/{corpus_id}")
+
+    assert del_resp.status_code == 409
+    assert "running analysis" in del_resp.json()["error"].lower()
+    still_exists = await db_session.get(Corpus, uuid.UUID(corpus_id))
+    assert still_exists is not None
+
+
+async def test_delete_corpus_force_cancels_impacted_analysis(client, db_session):
+    create = await client.post(f"{API}/corpora", json={"corpus_id": P1_STR, "name": "C"})
+    corpus_id = create.json()["data"]["id"]
+
+    await client.post(
+        f"{API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [{"title": "Force delete doc", "text": "content"}]},
+    )
+    docs_resp = await client.get(f"{API}/corpora/{corpus_id}/documents")
+    document_id = docs_resp.json()["data"]["items"][0]["id"]
+
+    codebook = Codebook(
+        id=uuid4(),
+        corpus_id=uuid.UUID(P1_STR),
+        name="Active Codebook",
+        version=1,
+        created_by="test",
+    )
+    job = CodebookApplicationJob(
+        id=uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(P1_STR),
+        codebook_id=codebook.id,
+        transcript_document_ids_json=json.dumps([document_id]),
+        cancel_requested=False,
+    )
+    db_session.add_all([codebook, job])
+    await db_session.commit()
+
+    del_resp = await client.delete(
+        f"{API}/corpora/{corpus_id}",
+        params={"force": "true"},
+    )
+
+    assert del_resp.status_code == 200
+    # The corpus (and its cascading data) is gone once force-deletion proceeds.
+    assert await db_session.get(Corpus, uuid.UUID(corpus_id)) is None
+    # The impacted job is either cascade-removed with the corpus or, if the row
+    # survives, flagged for cancellation so the live runner stops.
+    refreshed_job = await db_session.get(CodebookApplicationJob, job.id)
+    if refreshed_job is not None:
+        await db_session.refresh(refreshed_job)
+        assert refreshed_job.cancel_requested is True

--- a/Backend/tests/test_ingestion_api.py
+++ b/Backend/tests/test_ingestion_api.py
@@ -1,4 +1,9 @@
+import json
+import uuid
 from pathlib import Path
+from uuid import uuid4
+
+from app.models import Codebook, CodebookApplicationJob, CorpusDocument
 
 API = "/api/v1/ingestion"
 
@@ -585,3 +590,85 @@ async def test_delete_document_not_found(client):
 
     del_resp = await client.delete(f"{API}/corpora/{corpus_id}/documents/{MISSING_STR}")
     assert del_resp.status_code == 404
+
+
+async def test_delete_document_warns_when_running_analysis_depends_on_it(client, db_session):
+    create = await client.post(f"{API}/corpora", json={"corpus_id": P1_STR, "name": "C"})
+    corpus_id = create.json()["data"]["id"]
+
+    await client.post(
+        f"{API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [{"title": "Running doc", "text": "content"}]},
+    )
+    docs_resp = await client.get(f"{API}/corpora/{corpus_id}/documents")
+    document_id = docs_resp.json()["data"]["items"][0]["id"]
+
+    codebook = Codebook(
+        id=uuid4(),
+        corpus_id=uuid.UUID(P1_STR),
+        name="Active Codebook",
+        version=1,
+        created_by="test",
+    )
+    job = CodebookApplicationJob(
+        id=uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(P1_STR),
+        codebook_id=codebook.id,
+        transcript_document_ids_json=json.dumps([document_id]),
+        cancel_requested=False,
+    )
+    db_session.add_all([codebook, job])
+    await db_session.commit()
+
+    del_resp = await client.delete(f"{API}/corpora/{corpus_id}/documents/{document_id}")
+
+    assert del_resp.status_code == 409
+    assert "running analysis" in del_resp.json()["error"].lower()
+    still_exists = await db_session.get(CorpusDocument, uuid.UUID(document_id))
+    assert still_exists is not None
+
+
+async def test_delete_document_force_cancels_impacted_analysis(client, db_session):
+    create = await client.post(f"{API}/corpora", json={"corpus_id": P1_STR, "name": "C"})
+    corpus_id = create.json()["data"]["id"]
+
+    await client.post(
+        f"{API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [{"title": "Force delete doc", "text": "content"}]},
+    )
+    docs_resp = await client.get(f"{API}/corpora/{corpus_id}/documents")
+    document_id = docs_resp.json()["data"]["items"][0]["id"]
+
+    codebook = Codebook(
+        id=uuid4(),
+        corpus_id=uuid.UUID(P1_STR),
+        name="Active Codebook",
+        version=1,
+        created_by="test",
+    )
+    job = CodebookApplicationJob(
+        id=uuid4(),
+        name="Running Analysis",
+        status="running",
+        phase="coding_documents",
+        corpus_id=uuid.UUID(P1_STR),
+        codebook_id=codebook.id,
+        transcript_document_ids_json=json.dumps([document_id]),
+        cancel_requested=False,
+    )
+    db_session.add_all([codebook, job])
+    await db_session.commit()
+
+    del_resp = await client.delete(
+        f"{API}/corpora/{corpus_id}/documents/{document_id}",
+        params={"force": "true"},
+    )
+
+    assert del_resp.status_code == 200
+    refreshed_job = await db_session.get(CodebookApplicationJob, job.id)
+    assert refreshed_job is not None
+    await db_session.refresh(refreshed_job)
+    assert refreshed_job.cancel_requested is True

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -49,6 +49,7 @@ class FakeBackend:
         self.cancelled_analysis_job_ids: list[str] = []
         self.force_deleted_documents: list[tuple[str, str]] = []
         self.force_deleted_codebooks: list[str] = []
+        self.force_deleted_corpora: list[str] = []
         # Demographic data
         self.demographic_files: list[dict] = []
         self.demographic_rows: list[dict] = []
@@ -118,8 +119,10 @@ class FakeBackend:
         self.last_created_corpus = created
         return created
 
-    def delete_corpus(self, corpus_id: str) -> None:
+    def delete_corpus(self, corpus_id: str, *, force: bool = False) -> None:
         self._maybe_raise("delete_corpus")
+        if force:
+            self.force_deleted_corpora.append(corpus_id)
         self.corpora = [c for c in self.corpora if c.get("id") != corpus_id]
 
     def upload_files(self, corpus_id, files) -> list[dict]:

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -46,6 +46,9 @@ class FakeBackend:
         # Analysis runs (Previous Analysis Runs box)
         self.application_runs: list[dict] = []
         self.deleted_run_ids: list[str] = []
+        self.cancelled_analysis_job_ids: list[str] = []
+        self.force_deleted_documents: list[tuple[str, str]] = []
+        self.force_deleted_codebooks: list[str] = []
         # Demographic data
         self.demographic_files: list[dict] = []
         self.demographic_rows: list[dict] = []
@@ -129,14 +132,18 @@ class FakeBackend:
         self._maybe_raise("list_documents")
         return self.documents
 
-    def delete_document(self, corpus_id, document_id) -> None:
+    def delete_document(self, corpus_id, document_id, *, force: bool = False) -> None:
         self._maybe_raise("delete_document")
+        if force:
+            self.force_deleted_documents.append((corpus_id, document_id))
         self.documents = [d for d in self.documents if d["id"] != document_id]
 
     # ---- Codebooks / themes -------------------------------------------------
 
-    def delete_codebook(self, codebook_id: str) -> None:
+    def delete_codebook(self, codebook_id: str, *, force: bool = False) -> None:
         self._maybe_raise("delete_codebook")
+        if force:
+            self.force_deleted_codebooks.append(codebook_id)
         self.codebooks = [cb for cb in self.codebooks if cb.get("id") != codebook_id]
 
     def list_codebooks(self, corpus_id: str | None = None) -> list[dict]:
@@ -315,6 +322,15 @@ class FakeBackend:
             return {"id": job_id, "status": "succeeded", "documents_total": 5, "documents_done": 5}
         return self.analysis_jobs[job_id]
 
+    def cancel_analysis_job(self, job_id: str) -> dict:
+        self._maybe_raise("cancel_analysis_job")
+        self.cancelled_analysis_job_ids.append(job_id)
+        if not hasattr(self, "analysis_jobs"):
+            self.analysis_jobs = {}
+        job = self.analysis_jobs.setdefault(job_id, {"id": job_id, "status": "running"})
+        job["cancel_requested"] = True
+        return job
+
     def list_codebook_application_runs(self, codebook_id: str) -> list[dict]:
         self._maybe_raise("list_codebook_application_runs")
         return [
@@ -342,6 +358,8 @@ class FakeBackend:
             and self.raise_on[0] == method
         ):
             exc_class = self.raise_on[1]
+            if exc_class.__name__ == "BackendConflictError":
+                raise exc_class("Deleting this item would interrupt a running analysis.")
             raise exc_class()
 
 

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -88,6 +88,8 @@ def test_analysis_wait_page(client):
     resp = client.get("/analysis/job/test-job")
     assert resp.status_code == 200
     assert b"Applying Codebook" in resp.data
+    assert b'data-cancel-url="/analysis/job/test-job/cancel"' in resp.data
+    assert b"/api/v1/codebooks/apply-jobs/" not in resp.data
 
 def test_analysis_job_status(client, fake_backend):
     job = fake_backend.trigger_analysis("test", "cb1")
@@ -96,6 +98,13 @@ def test_analysis_job_status(client, fake_backend):
     data = resp.json
     assert data["id"] == job["id"]
     assert data["status"] == "queued"
+
+
+def test_analysis_job_cancel(client, fake_backend):
+    resp = client.post("/analysis/job/job-123/cancel")
+    assert resp.status_code == 200
+    assert fake_backend.cancelled_analysis_job_ids == ["job-123"]
+    assert resp.json["cancel_requested"] is True
 
 
 # Delete Analysis Runs (issue #203) ------------------------------------------

--- a/Frontend/tests/test_backend_client.py
+++ b/Frontend/tests/test_backend_client.py
@@ -13,6 +13,7 @@ import pytest
 from web.services.backend_client import (
     BackendClient,
     BackendError,
+    BackendConflictError,
     BackendNotFoundError,
     BackendServerError,
     BackendUnavailableError,
@@ -100,6 +101,23 @@ def test_status_422_parses_response_envelope_meta_detail():
     with pytest.raises(BackendValidationError) as exc_info:
         client.list_codebooks()
     assert "username already exists" in exc_info.value.user_message
+
+
+def test_status_409_parses_response_envelope_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            409,
+            json={
+                "success": False,
+                "error": "Deleting this transcript would interrupt a running analysis.",
+                "meta": None,
+            },
+        )
+
+    client = _client_with_handler(handler)
+    with pytest.raises(BackendConflictError) as exc_info:
+        client.delete_document("corpus-1", "doc-1")
+    assert "interrupt a running analysis" in exc_info.value.user_message
 
 
 def test_status_500_maps_to_server_error():
@@ -231,6 +249,29 @@ def test_cancel_generation_job_posts_and_unwraps():
     assert captured["method"] == "POST"
     assert captured["path"].endswith("/codebooks/generate-jobs/job-7/cancel")
     assert job["status"] == "cancelled"
+
+
+def test_cancel_analysis_job_posts_and_unwraps():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        return httpx.Response(
+            202,
+            json={
+                "success": True,
+                "data": {"id": "job-8", "status": "running", "cancel_requested": True},
+                "error": None,
+                "meta": None,
+            },
+        )
+
+    client = _client_with_handler(handler)
+    job = client.cancel_analysis_job("job-8")
+    assert captured["method"] == "POST"
+    assert captured["path"].endswith("/codebooks/apply-jobs/job-8/cancel")
+    assert job["cancel_requested"] is True
 
 
 # User messages never leak raw exception text

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -719,6 +719,57 @@ def test_delete_selected_codebooks_success(client, fake_backend):
     assert fake_backend.codebooks == []
 
 
+def test_delete_selected_codebooks_running_analysis_warning(client, fake_backend):
+    from web.services.backend_client import BackendConflictError
+
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+        {"id": "cb-2", "name": "Focus Group Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "bob", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.raise_on = ("delete_codebook", BackendConflictError)
+
+    resp = client.post(
+        f"/codebooks/{fake_backend.corpus_id}/delete",
+        data={"item_ids": ["cb-1", "cb-2"]},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"running analysis" in resp.data
+    assert b'id="confirmAnalysisDeleteModal"' in resp.data
+    assert b"modal fade text-start" in resp.data
+    assert b"Delete Codebooks" in resp.data
+    assert b'name="force_delete" value="1"' in resp.data
+    assert b'value="cb-1"' in resp.data
+    assert b'value="cb-2"' in resp.data
+    assert b'data-flash-category="warning"' not in resp.data
+
+
+def test_delete_selected_codebooks_force_after_warning(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+        {"id": "cb-2", "name": "Focus Group Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "bob", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+
+    resp = client.post(
+        f"/codebooks/{fake_backend.corpus_id}/delete",
+        data={"item_ids": ["cb-1", "cb-2"], "force_delete": "1"},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"Deleted 2 codebooks" in resp.data
+    assert fake_backend.force_deleted_codebooks == ["cb-1", "cb-2"]
+
+
 def test_delete_selected_codebooks_requires_selection(client, fake_backend):
     resp = client.post(
         f"/codebooks/{fake_backend.corpus_id}/delete",

--- a/Frontend/tests/test_ingestion.py
+++ b/Frontend/tests/test_ingestion.py
@@ -432,3 +432,37 @@ def test_delete_selected_transcripts_requires_selection(client, fake_backend):
     resp = client.post(f"/transcripts/{CORPUS}/delete_transcripts", data={}, follow_redirects=True)
     assert resp.status_code == 200
     assert b"Select at least one transcript to delete" in resp.data
+
+
+def test_delete_corpus_running_analysis_warning(client, fake_backend):
+    from web.services.backend_client import BackendConflictError
+
+    fake_backend.corpora = [{"id": CORPUS, "name": "Test Corpus"}]
+    fake_backend.raise_on = ("delete_corpus", BackendConflictError)
+
+    resp = client.post(f"/transcripts/{CORPUS}/delete", follow_redirects=True)
+
+    assert resp.status_code == 200
+    assert b"running analysis" in resp.data
+    assert b'id="confirmAnalysisDeleteModal"' in resp.data
+    assert b"Delete Corpus" in resp.data
+    assert b'name="force_delete" value="1"' in resp.data
+    # Without force the corpus is left intact.
+    assert fake_backend.force_deleted_corpora == []
+
+
+def test_delete_corpus_force_after_warning(client, fake_backend):
+    fake_backend.corpora = [
+        {"id": CORPUS, "name": "Test Corpus"},
+        {"id": "other-corpus", "name": "Other Corpus"},
+    ]
+
+    resp = client.post(
+        f"/transcripts/{CORPUS}/delete",
+        data={"force_delete": "1"},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"Corpus deleted successfully" in resp.data
+    assert fake_backend.force_deleted_corpora == [CORPUS]

--- a/Frontend/tests/test_ingestion.py
+++ b/Frontend/tests/test_ingestion.py
@@ -385,6 +385,49 @@ def test_delete_selected_transcripts_success(client, fake_backend):
     assert [d["id"] for d in fake_backend.documents] == ["doc-3"]
 
 
+def test_delete_selected_transcripts_running_analysis_warning(client, fake_backend):
+    from web.services.backend_client import BackendConflictError
+
+    fake_backend.documents = [
+        {"id": "doc-1", "title": "Interview 1", "filename": "1.txt", "created_at": "2026-05-12"},
+        {"id": "doc-2", "title": "Interview 2", "filename": "2.txt", "created_at": "2026-05-13"},
+    ]
+    fake_backend.raise_on = ("delete_document", BackendConflictError)
+
+    resp = client.post(
+        f"/transcripts/{CORPUS}/delete_transcripts",
+        data={"item_ids": ["doc-1", "doc-2"]},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"running analysis" in resp.data
+    assert b'id="confirmAnalysisDeleteModal"' in resp.data
+    assert b"modal fade text-start" in resp.data
+    assert b"Delete Transcripts" in resp.data
+    assert b'name="force_delete" value="1"' in resp.data
+    assert b'value="doc-1"' in resp.data
+    assert b'value="doc-2"' in resp.data
+    assert b'data-flash-category="warning"' not in resp.data
+
+
+def test_delete_selected_transcripts_force_after_warning(client, fake_backend):
+    fake_backend.documents = [
+        {"id": "doc-1", "title": "Interview 1", "filename": "1.txt", "created_at": "2026-05-12"},
+        {"id": "doc-2", "title": "Interview 2", "filename": "2.txt", "created_at": "2026-05-13"},
+    ]
+
+    resp = client.post(
+        f"/transcripts/{CORPUS}/delete_transcripts",
+        data={"item_ids": ["doc-1", "doc-2"], "force_delete": "1"},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"Deleted 2 transcripts" in resp.data
+    assert fake_backend.force_deleted_documents == [(CORPUS, "doc-1"), (CORPUS, "doc-2")]
+
+
 def test_delete_selected_transcripts_requires_selection(client, fake_backend):
     resp = client.post(f"/transcripts/{CORPUS}/delete_transcripts", data={}, follow_redirects=True)
     assert resp.status_code == 200

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -141,7 +141,7 @@ def cancel_job(job_id: str):
     try:
         job = _backend().cancel_analysis_job(job_id)
     except BackendError as exc:
-        return jsonify({"error": exc.user_message}), 200
+        return jsonify({"error": exc.user_message}), 400
     return jsonify(job)
 
 @bp.post("/runs/export")

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -127,6 +127,15 @@ def job_status(job_id: str):
         return jsonify({"error": exc.user_message}), 500
 
 
+@bp.post("/job/<job_id>/cancel")
+def cancel_job(job_id: str):
+    try:
+        job = _backend().cancel_analysis_job(job_id)
+    except BackendError as exc:
+        return jsonify({"error": exc.user_message}), 200
+    return jsonify(job)
+
+
 @bp.post("/runs/delete")
 def delete_selected_runs():
     """Hard-delete the analysis runs selected in the Previous Analysis Runs box."""

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -12,10 +12,12 @@ from flask import (
     redirect,
     render_template,
     request,
+    session,
     url_for,
 )
 
 from web.services.backend_client import (
+    BackendConflictError,
     BackendError,
     BackendNotFoundError,
     get_backend_client as _backend,
@@ -28,6 +30,7 @@ CODING_MODES = ("auto", "semi", "manual")
 
 _QUERY_MIN = 10
 _QUERY_MAX = 500
+_PENDING_CODEBOOK_DELETE_KEY = "pending_codebook_delete"
 
 
 def _safe_export_filename(name: str, version: int | str | None) -> str:
@@ -75,6 +78,22 @@ def _codebook_to_csv(codebook: dict) -> str:
     writer.writeheader()
     writer.writerows(flat_rows)
     return output.getvalue()
+
+
+def _pending_codebook_delete(corpus_id: str) -> dict | None:
+    pending = session.pop(_PENDING_CODEBOOK_DELETE_KEY, None)
+    if not isinstance(pending, dict) or pending.get("corpus_id") != corpus_id:
+        return None
+    item_ids = [item_id for item_id in pending.get("item_ids", []) if item_id]
+    if not item_ids:
+        return None
+    return {
+        "message": pending.get("message") or "Deleting these codebooks would interrupt a running analysis.",
+        "item_ids": item_ids,
+        "action": url_for("codebooks.delete_selected_codebooks", corpus_id=corpus_id),
+        "title": "Delete Codebooks",
+        "confirm_label": "Delete",
+    }
 
 
 @bp.get("/")
@@ -139,6 +158,7 @@ def list_codebooks_for_corpus(corpus_id: str) -> str:
             corpus_options=corpus_options,
             active_corpus_name=corpus_name,
             running_jobs=[],
+            pending_analysis_delete=None,
             error=True,
         )
 
@@ -159,6 +179,7 @@ def list_codebooks_for_corpus(corpus_id: str) -> str:
         corpus_options=corpus_options,
         active_corpus_name=corpus_name,
         running_jobs=running_jobs,
+        pending_analysis_delete=_pending_codebook_delete(active_corpus_id),
     )
 
 
@@ -968,9 +989,16 @@ def codebook_review_submit(codebook_id: str) -> str:
 @bp.post("/<corpus_id>/<codebook_id>/delete")
 def delete_codebook(corpus_id: str, codebook_id: str):
     """Delete a codebook and its themes."""
+    force = request.form.get("force_delete") == "1"
     try:
-        _backend().delete_codebook(codebook_id)
+        _backend().delete_codebook(codebook_id, force=force)
         flash("Codebook successfully deleted.", "success")
+    except BackendConflictError as exc:
+        session[_PENDING_CODEBOOK_DELETE_KEY] = {
+            "corpus_id": corpus_id,
+            "item_ids": [codebook_id],
+            "message": exc.user_message,
+        }
     except BackendError as exc:
         flash(exc.user_message, "danger")
     return redirect(url_for("codebooks.list_codebooks_for_corpus", corpus_id=corpus_id))
@@ -984,13 +1012,25 @@ def delete_selected_codebooks(corpus_id: str):
         flash("Select at least one codebook to delete.", "warning")
         return redirect(url_for("codebooks.list_codebooks_for_corpus", corpus_id=corpus_id))
 
+    force = request.form.get("force_delete") == "1"
     deleted = 0
     try:
         client = _backend()
         for codebook_id in codebook_ids:
-            client.delete_codebook(codebook_id)
+            client.delete_codebook(codebook_id, force=force)
             deleted += 1
         flash(f"Deleted {deleted} codebook{'s' if deleted != 1 else ''}.", "success")
+    except BackendConflictError as exc:
+        if deleted:
+            flash(f"Deleted {deleted} codebook{'s' if deleted != 1 else ''} before an error occurred.", "warning")
+        if not force:
+            session[_PENDING_CODEBOOK_DELETE_KEY] = {
+                "corpus_id": corpus_id,
+                "item_ids": codebook_ids[deleted:],
+                "message": exc.user_message,
+            }
+        else:
+            flash(exc.user_message, "danger")
     except BackendError as exc:
         if deleted:
             flash(f"Deleted {deleted} codebook{'s' if deleted != 1 else ''} before an error occurred.", "warning")

--- a/Frontend/web/controllers/ingestion.py
+++ b/Frontend/web/controllers/ingestion.py
@@ -1,7 +1,8 @@
 import uuid
-from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask import Blueprint, current_app, flash, redirect, render_template, request, session, url_for
 
 from web.services.backend_client import (
+    BackendConflictError,
     BackendError,
     BackendValidationError,
     get_backend_client as _backend,
@@ -12,6 +13,8 @@ from web.services.corpus_context import (
 )
 
 bp = Blueprint("ingestion", __name__)
+
+_PENDING_TRANSCRIPT_DELETE_KEY = "pending_transcript_delete"
 
 
 
@@ -224,6 +227,22 @@ def _build_link_status(client, corpus_id: str) -> dict:
     return status
 
 
+def _pending_transcript_delete(corpus_id: str) -> dict | None:
+    pending = session.pop(_PENDING_TRANSCRIPT_DELETE_KEY, None)
+    if not isinstance(pending, dict) or pending.get("corpus_id") != corpus_id:
+        return None
+    item_ids = [item_id for item_id in pending.get("item_ids", []) if item_id]
+    if not item_ids:
+        return None
+    return {
+        "message": pending.get("message") or "Deleting these transcripts would interrupt a running analysis.",
+        "item_ids": item_ids,
+        "action": url_for("ingestion.delete_selected_transcripts", corpus_id=corpus_id),
+        "title": "Delete Transcripts",
+        "confirm_label": "Yes, Delete Transcripts",
+    }
+
+
 @bp.get("/<corpus_id>/")
 def list_transcripts(corpus_id: str) -> str:
     set_active_corpus_id(corpus_id)
@@ -245,6 +264,7 @@ def list_transcripts(corpus_id: str) -> str:
             corpus_id=corpus_id,
             corpus_options=corpus_options,
             active_corpus_name=active_corpus_name,
+            pending_analysis_delete=None,
             error=True,
         )
     link_status = _build_link_status(client, active_corpus_id)
@@ -255,6 +275,7 @@ def list_transcripts(corpus_id: str) -> str:
         corpus_options=corpus_options,
         active_corpus_name=active_corpus_name,
         link_status=link_status,
+        pending_analysis_delete=_pending_transcript_delete(active_corpus_id),
     )
 
 
@@ -262,9 +283,16 @@ def list_transcripts(corpus_id: str) -> str:
 def delete_transcript(corpus_id: str, document_id: str):
     """Delete a single transcript from the active corpus."""
     set_active_corpus_id(corpus_id)
+    force = request.form.get("force_delete") == "1"
     try:
-        _backend().delete_document(corpus_id, document_id)
+        _backend().delete_document(corpus_id, document_id, force=force)
         flash("Transcript deleted successfully.", "success")
+    except BackendConflictError as exc:
+        session[_PENDING_TRANSCRIPT_DELETE_KEY] = {
+            "corpus_id": corpus_id,
+            "item_ids": [document_id],
+            "message": exc.user_message,
+        }
     except BackendError as exc:
         flash(exc.user_message, "danger")
     return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
@@ -279,13 +307,25 @@ def delete_selected_transcripts(corpus_id: str):
         flash("Select at least one transcript to delete.", "warning")
         return redirect(url_for("ingestion.list_transcripts", corpus_id=corpus_id))
 
+    force = request.form.get("force_delete") == "1"
     deleted = 0
     try:
         client = _backend()
         for document_id in document_ids:
-            client.delete_document(corpus_id, document_id)
+            client.delete_document(corpus_id, document_id, force=force)
             deleted += 1
         flash(f"Deleted {deleted} transcript{'s' if deleted != 1 else ''}.", "success")
+    except BackendConflictError as exc:
+        if deleted:
+            flash(f"Deleted {deleted} transcript{'s' if deleted != 1 else ''} before an error occurred.", "warning")
+        if not force:
+            session[_PENDING_TRANSCRIPT_DELETE_KEY] = {
+                "corpus_id": corpus_id,
+                "item_ids": document_ids[deleted:],
+                "message": exc.user_message,
+            }
+        else:
+            flash(exc.user_message, "danger")
     except BackendError as exc:
         if deleted:
             flash(f"Deleted {deleted} transcript{'s' if deleted != 1 else ''} before an error occurred.", "warning")

--- a/Frontend/web/controllers/ingestion.py
+++ b/Frontend/web/controllers/ingestion.py
@@ -15,6 +15,7 @@ from web.services.corpus_context import (
 bp = Blueprint("ingestion", __name__)
 
 _PENDING_TRANSCRIPT_DELETE_KEY = "pending_transcript_delete"
+_PENDING_CORPUS_DELETE_KEY = "pending_corpus_delete"
 
 
 
@@ -49,6 +50,19 @@ def upload_landing():
 
 
 
+def _pending_corpus_delete(corpus_id: str) -> dict | None:
+    pending = session.pop(_PENDING_CORPUS_DELETE_KEY, None)
+    if not isinstance(pending, dict) or pending.get("corpus_id") != corpus_id:
+        return None
+    return {
+        "message": pending.get("message") or "Deleting this corpus would interrupt a running analysis.",
+        "item_ids": [],
+        "action": url_for("ingestion.delete_corpus_submit", corpus_id=corpus_id),
+        "title": "Delete Corpus",
+        "confirm_label": "Yes, Delete Corpus",
+    }
+
+
 def _render_upload_form(corpus_id: str) -> str:
     cfg = current_app.config
     try:
@@ -70,6 +84,7 @@ def _render_upload_form(corpus_id: str) -> str:
         corpus_options=corpus_options,
         max_size_mb=cfg["MAX_UPLOAD_SIZE_MB"],
         accepted_extensions=sorted(cfg["ACCEPTED_EXTENSIONS"]),
+        pending_analysis_delete=_pending_corpus_delete(active_corpus_id),
     )
 
 
@@ -131,15 +146,22 @@ def create_corpus_submit():
 @bp.post("/<corpus_id>/delete")
 def delete_corpus_submit(corpus_id: str):
     """Delete a corpus and redirect to landing page."""
+    force = request.form.get("force_delete") == "1"
     try:
-        _backend().delete_corpus(corpus_id)
+        _backend().delete_corpus(corpus_id, force=force)
         flash("Corpus deleted successfully.", "success")
         # Clear the active corpus ID from the session as it no longer exists
         set_active_corpus_id(None)
+    except BackendConflictError as exc:
+        session[_PENDING_CORPUS_DELETE_KEY] = {
+            "corpus_id": corpus_id,
+            "message": exc.user_message,
+        }
+        return redirect(url_for("ingestion.upload_form", corpus_id=corpus_id))
     except BackendError as exc:
         flash(exc.user_message, "danger")
         return redirect(url_for("ingestion.upload_form", corpus_id=corpus_id))
-    
+
     return redirect(url_for("ingestion.transcripts_landing"))
 
 

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -134,12 +134,13 @@ class BackendClient:
             return existing[0]["id"]
         return self.create_corpus(corpus_id, name)["id"]
 
-    def delete_corpus(self, corpus_id: str) -> None:
+    def delete_corpus(self, corpus_id: str, *, force: bool = False) -> None:
         """Delete a corpus and all its associated data."""
         path = f"/ingestion/corpora/{corpus_id}"
+        params = {"force": "true"} if force else None
         started_at = time.monotonic()
         try:
-            r = self._client.delete(path)
+            r = self._client.delete(path, params=params)
             r.raise_for_status()
             return self._unwrap(r)
         except httpx.HTTPError as exc:

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -75,6 +75,15 @@ class BackendNotFoundError(BackendError):
     log_level = "info"
 
 
+class BackendConflictError(BackendError):
+    """The backend returned 409 — the request conflicts with live state."""
+
+    default_user_message = (
+        "This action conflicts with the current analysis state. Please review and try again."
+    )
+    log_level = "info"
+
+
 class BackendValidationError(BackendError):
     """The backend returned 422 — payload failed Pydantic validation.
 
@@ -170,12 +179,13 @@ class BackendClient:
         """Fetch a single document including its full text content."""
         return self._get(f"/ingestion/corpora/{corpus_id}/documents/{document_id}")
 
-    def delete_document(self, corpus_id: str, document_id: str) -> None:
+    def delete_document(self, corpus_id: str, document_id: str, *, force: bool = False) -> None:
         """Delete a document from a corpus."""
         path = f"/ingestion/corpora/{corpus_id}/documents/{document_id}"
+        params = {"force": "true"} if force else None
         started_at = time.monotonic()
         try:
-            r = self._client.delete(path)
+            r = self._client.delete(path, params=params)
             r.raise_for_status()
             return self._unwrap(r)
         except httpx.HTTPError as exc:
@@ -315,6 +325,9 @@ class BackendClient:
     def get_analysis_job(self, job_id: str) -> dict:
         return self._get(f"/codebooks/apply-jobs/{job_id}")
 
+    def cancel_analysis_job(self, job_id: str) -> dict:
+        return self._post(f"/codebooks/apply-jobs/{job_id}/cancel")
+
     def list_codebook_application_runs(self, codebook_id: str) -> list[dict]:
         result = self._get(f"/codebooks/{codebook_id}/application-runs")
         if isinstance(result, list):
@@ -362,9 +375,10 @@ class BackendClient:
             return result
         return result.get("items", result) if isinstance(result, dict) else []
 
-    def delete_codebook(self, codebook_id: str) -> None:
+    def delete_codebook(self, codebook_id: str, *, force: bool = False) -> None:
         """Delete a codebook and all its associated themes/codes via cascade."""
-        self._delete(f"/codebooks/{codebook_id}")
+        params = {"force": "true"} if force else None
+        self._delete(f"/codebooks/{codebook_id}", params=params)
 
     # ---- Codebook generation jobs -------------------------------------------
 
@@ -503,6 +517,13 @@ class BackendClient:
             if status_code == 404:
                 error = BackendNotFoundError(
                     source_exc=exc, status_code=status_code, path=path
+                )
+            elif status_code == 409:
+                error = BackendConflictError(
+                    user_message=_parse_validation_detail(exc.response),
+                    source_exc=exc,
+                    status_code=status_code,
+                    path=path,
                 )
             elif status_code == 422:
                 if has_app_context():

--- a/Frontend/web/templates/_analysis_delete_confirm_modal.html
+++ b/Frontend/web/templates/_analysis_delete_confirm_modal.html
@@ -1,0 +1,37 @@
+{% if pending_analysis_delete %}
+  <div class="modal fade text-start"
+       id="confirmAnalysisDeleteModal"
+       tabindex="-1"
+       aria-labelledby="confirmAnalysisDeleteModalLabel"
+       aria-hidden="true"
+       data-pending-delete-modal>
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="POST" action="{{ pending_analysis_delete.action }}">
+          <div class="modal-header {{ pending_analysis_delete.header_class | default('text-danger') }}">
+            <h5 class="modal-title" id="confirmAnalysisDeleteModalLabel">
+              {{ pending_analysis_delete.title }}
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>{{ pending_analysis_delete.message }}</p>
+            <p class="text-muted small mb-0">
+              Confirming will cancel the affected analysis run and continue with deletion.
+            </p>
+            <input type="hidden" name="force_delete" value="1">
+            {% for item_id in pending_analysis_delete.item_ids %}
+              <input type="hidden" name="item_ids" value="{{ item_id }}">
+            {% endfor %}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-danger">
+              {{ pending_analysis_delete.confirm_label }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -15,6 +15,7 @@
   <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
        data-job-id="{{ job_id }}"
        data-status-url="{{ url_for('analysis.job_status', job_id=job_id) }}"
+       data-cancel-url="{{ url_for('analysis.cancel_job', job_id=job_id) }}"
        data-list-url="{{ url_for('analysis.index') }}"
        id="progress-app">
 
@@ -40,6 +41,7 @@
       const app = document.getElementById("progress-app");
       const jobId = app.dataset.jobId;
       const statusUrl = app.dataset.statusUrl;
+      const cancelUrl = app.dataset.cancelUrl;
       const listUrl = app.dataset.listUrl;
 
       const statusLine = document.getElementById("status-line");
@@ -160,9 +162,17 @@
       cancelBtn.addEventListener("click", async () => {
         cancelBtn.disabled = true;
         try {
-          // Send cancel request to the job cancellation endpoint
-          await fetch("/api/v1/codebooks/apply-jobs/" + jobId + "/cancel", { method: "POST" });
+          const r = await fetch(cancelUrl, { method: "POST", headers: { "Accept": "application/json" } });
+          const body = await r.json();
+          if (body.error) {
+            showError(body.error);
+            cancelBtn.disabled = false;
+            return;
+          }
+          statusLine.textContent = "Cancellation requested…";
         } catch (e) {
+          showError("Could not request cancellation. Please try again.");
+          cancelBtn.disabled = false;
         }
       });
 

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -18,6 +18,8 @@
     </a>
   </div>
 
+  {% include "_analysis_delete_confirm_modal.html" %}
+
   {# Server-rendered in-progress runs (visible in any session). job_tracker.js
      polls these rows live and skips creating duplicates for the same job id. #}
   {% if running_jobs %}
@@ -110,5 +112,16 @@
     </div>
   {% else %}
     <p class="text-secondary">No codebooks found.</p>
+  {% endif %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  {% if pending_analysis_delete %}
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const modalEl = document.getElementById("confirmAnalysisDeleteModal");
+        if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
+      });
+    </script>
   {% endif %}
 {% endblock %}

--- a/Frontend/web/templates/ingestion/list.html
+++ b/Frontend/web/templates/ingestion/list.html
@@ -20,6 +20,8 @@
     {% endif %}
   </div>
 
+  {% include "_analysis_delete_confirm_modal.html" %}
+
   {% if error %}
     <p class="text-secondary">Couldn't load transcripts right now.</p>
   {% elif documents %}
@@ -93,4 +95,12 @@
 {% endblock %}
 {% block scripts %}
   {{ super() }}
+  {% if pending_analysis_delete %}
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const modalEl = document.getElementById("confirmAnalysisDeleteModal");
+        if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
+      });
+    </script>
+  {% endif %}
 {% endblock %}

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -15,6 +15,8 @@
   {% set show_delete_corpus = True %}
   {% include "_corpus_select.html" %}
 
+  {% include "_analysis_delete_confirm_modal.html" %}
+
   <div class="row g-4 upload-row">
 
     {# ─── Transcripts card (primary, indigo) ─────────────────────────── #}
@@ -463,4 +465,15 @@
       document.getElementById("codebook-upload-col").scrollIntoView({ behavior: "smooth", block: "nearest" });
     })();
   </script>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  {% if pending_analysis_delete %}
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const modalEl = document.getElementById("confirmAnalysisDeleteModal");
+        if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
+      });
+    </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
- Prevent transcript/codebook deletion from silently disrupting active analysis runs.
- Add force-delete confirmation flow that requests cancellation before continuing.
- Route analysis job cancellation through the frontend and harden job runner cancellation handling.

.