### PR TITLE
Export Analysis Results

### DIFF
--- a/Backend/app/routers/codebook_applications.py
+++ b/Backend/app/routers/codebook_applications.py
@@ -4,8 +4,8 @@ import json
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -31,7 +31,9 @@ from app.schemas.codebook_application import (
     ThemeAssignmentSchema,
 )
 from app.schemas.common import ResponseEnvelope
+from app.schemas.export_results import RunExportFormat
 from app.services.codebook_application_jobs import codebook_application_job_runner
+from app.services.export_results import RunExportService
 
 router = APIRouter(tags=["codebook-applications"])
 
@@ -374,6 +376,30 @@ async def list_codebook_application_run_documents(
         raise NotFoundError(f"Codebook application run '{run_id}' not found")
     document_codings = await _load_document_coding_schemas(run_id=run_id, session=session)
     return JSONResponse(content=ResponseEnvelope.ok(document_codings).model_dump(mode="json"))
+
+
+@router.get(
+    "/codebook-application-runs/{run_id}/export",
+    summary="Export a codebook application run as CSV",
+)
+async def export_codebook_application_run(
+    run_id: UUID,
+    session: DbSession,
+    format: RunExportFormat = Query(description="Table shape: theme-based or participant-based"),
+) -> Response:
+    service = RunExportService(session)
+    data = await service.fetch_rows(run_id)
+    csv_text = (
+        service.to_theme_based_csv(data)
+        if format == RunExportFormat.THEME_BASED
+        else service.to_participant_based_csv(data)
+    )
+    filename = f"run-{run_id}-{format.value}.csv"
+    return Response(
+        content=csv_text,
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 async def _load_document_coding_schemas(

--- a/Backend/app/schemas/export_results.py
+++ b/Backend/app/schemas/export_results.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RunExportFormat(str, Enum):
+    THEME_BASED = "theme-based"
+    PARTICIPANT_BASED = "participant-based"
+

--- a/Backend/app/schemas/export_results.py
+++ b/Backend/app/schemas/export_results.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class RunExportFormat(str, Enum):
+class RunExportFormat(StrEnum):
     THEME_BASED = "theme-based"
     PARTICIPANT_BASED = "participant-based"
-

--- a/Backend/app/services/export_results.py
+++ b/Backend/app/services/export_results.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import NotFoundError
+from app.models import (
+    CodebookApplicationRun,
+    CorpusDocument,
+    DemographicFiles,
+    DemographicRow,
+    DocumentCoding,
+    Theme,
+    ThemeAssignment,
+    ThemeHierarchyRelationship,
+)
+
+
+@dataclass
+class _ExportRow:
+    """One coded segment = one CSV line (a theme matched to a quote)."""
+
+    theme_label: str
+    parent_label: str | None
+    theme_description: str | None
+    participant_id: str
+    quote: str
+    # Pre-projected demo values in original_columns order — avoids per-row dict lookup in writer.
+    demographics: tuple[str, ...]
+
+
+@dataclass
+class ExportData:
+
+    rows: list[_ExportRow]
+    demo_columns: list[str]
+
+
+class RunExportService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def fetch_rows(self, run_id: UUID) -> ExportData:
+
+        run = await self._session.get(CodebookApplicationRun, run_id)
+        if run is None:
+            raise NotFoundError(f"Codebook application run '{run_id}' not found")
+
+        corpus_id = run.corpus_id
+
+        # Core join, like ThemeQuotesService.list_theme_quotes
+        rows = (await self._session.execute(
+            select(
+                Theme.id, Theme.label, Theme.description,
+                ThemeAssignment.quote, ThemeAssignment.created_at,
+                DemographicRow.interviewee_id, DemographicRow.data,
+                CorpusDocument.title,
+            )
+            .select_from(ThemeAssignment)
+            .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+            .join(Theme, ThemeAssignment.theme_id == Theme.id)
+            .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
+            .outerjoin(DemographicRow, CorpusDocument.demographic_row_id == DemographicRow.id)
+            .where(
+                DocumentCoding.application_run_id == run_id,
+                ThemeAssignment.is_present.is_(True),
+                ThemeAssignment.quote.is_not(None),
+            )
+            .order_by(Theme.label, ThemeAssignment.created_at)
+        )).all()
+
+        #    the LEFT JOIN to DemographicRow keeps quotes from transcripts that were never linked to a demographic row (interviewee_id == None).
+
+        # Report the behavior: if the transcript was never linked to a demographic row, the id will be None, and the demographics dict will be empty.
+        # If the transcript was linked to a demographic row, but the row has no data, the id will be present, but the demographics dict will still be empty.
+
+        #  A theme with no active parent simply gets parent_label = None.
+        parent_label_by_child = {
+            row.child_theme_id: row.parent_label
+            for row in (
+                await self._session.execute(
+                    select(
+                        ThemeHierarchyRelationship.child_theme_id,
+                        Theme.label.label("parent_label"),
+                    )
+                    .join(Theme, ThemeHierarchyRelationship.parent_theme_id == Theme.id)
+                    .where(
+                        ThemeHierarchyRelationship.codebook_id == run.codebook_id,
+                        ThemeHierarchyRelationship.is_active.is_(True),
+                    )
+                )
+            ).all()
+        }
+
+
+        original_columns = (
+            await self._session.execute(
+                select(DemographicFiles.original_columns)
+                .where(DemographicFiles.corpus_id == corpus_id)
+                .order_by(DemographicFiles.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        demo_columns: list[str] = list(original_columns) if original_columns is not None else []
+
+        export_rows = [
+            _ExportRow(
+                theme_label=row.label,
+                parent_label=parent_label_by_child.get(row.id),
+                theme_description=row.description,
+                # Fall back to the document title when the transcript has no linked demographic row.
+                participant_id=row.interviewee_id or row.title,
+                quote=row.quote,
+                demographics=tuple(str((row.data or {}).get(col, "")) for col in demo_columns),
+            )
+            for row in rows
+        ]
+
+        return ExportData(rows=export_rows, demo_columns=demo_columns)
+
+
+    def to_theme_based_csv(self, data: ExportData) -> str:
+        """File 1: one row per tagged quote, grouped by theme.
+
+        Header: Theme Name, Parent Theme, Theme Description, Participant ID, Quote
+        """
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(["Theme Name", "Parent Theme", "Theme Description", "Participant ID", "Quote"])
+        for row in data.rows:
+            writer.writerow([
+                row.theme_label,
+                row.parent_label or "",
+                row.theme_description or "",
+                row.participant_id,
+                row.quote,
+            ])
+        return buffer.getvalue()
+
+    def to_participant_based_csv(self, data: ExportData) -> str:
+        """File 2: demographics repeated per quote, one row per tagged quote.
+
+        Header: Participant ID, <demo columns…>, Theme Name, Quote
+        """
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(["Participant ID", *data.demo_columns, "Theme Name", "Quote"])
+        for row in data.rows:
+            writer.writerow([row.participant_id, *row.demographics, row.theme_label, row.quote])
+        return buffer.getvalue()

--- a/Backend/app/services/export_results.py
+++ b/Backend/app/services/export_results.py
@@ -20,6 +20,10 @@ from app.models import (
     ThemeHierarchyRelationship,
 )
 
+# Demographic link-key column: surfaced as Participant ID, so it's excluded from
+# the demographic data columns to avoid an empty duplicate column.
+LINK_KEY_COLUMN = "username"
+
 
 @dataclass
 class _ExportRow:
@@ -30,8 +34,7 @@ class _ExportRow:
     theme_description: str | None
     participant_id: str
     quote: str
-    # Pre-projected demo values in original_columns order — avoids per-row dict lookup in writer.
-    demographics: tuple[str, ...]
+    demographics: tuple[str, ...] # to avoid per-row dict lookup in writer
 
 
 @dataclass
@@ -51,35 +54,33 @@ class RunExportService:
         if run is None:
             raise NotFoundError(f"Codebook application run '{run_id}' not found")
 
-        corpus_id = run.corpus_id
-
-        # Core join, like ThemeQuotesService.list_theme_quotes
-        rows = (await self._session.execute(
-            select(
-                Theme.id, Theme.label, Theme.description,
-                ThemeAssignment.quote, ThemeAssignment.created_at,
-                DemographicRow.interviewee_id, DemographicRow.data,
-                CorpusDocument.title,
+        # LEFT JOIN to DemographicRow keeps quotes from unlinked transcripts.
+        rows = (
+            await self._session.execute(
+                select(
+                    Theme.id,
+                    Theme.label,
+                    Theme.description,
+                    ThemeAssignment.quote,
+                    ThemeAssignment.created_at,
+                    DemographicRow.interviewee_id,
+                    DemographicRow.data,
+                    CorpusDocument.title,
+                )
+                .select_from(ThemeAssignment)
+                .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+                .join(Theme, ThemeAssignment.theme_id == Theme.id)
+                .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
+                .outerjoin(DemographicRow, CorpusDocument.demographic_row_id == DemographicRow.id)
+                .where(
+                    DocumentCoding.application_run_id == run_id,
+                    ThemeAssignment.is_present.is_(True),
+                    ThemeAssignment.quote.is_not(None),
+                )
+                .order_by(Theme.label, ThemeAssignment.created_at)
             )
-            .select_from(ThemeAssignment)
-            .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
-            .join(Theme, ThemeAssignment.theme_id == Theme.id)
-            .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
-            .outerjoin(DemographicRow, CorpusDocument.demographic_row_id == DemographicRow.id)
-            .where(
-                DocumentCoding.application_run_id == run_id,
-                ThemeAssignment.is_present.is_(True),
-                ThemeAssignment.quote.is_not(None),
-            )
-            .order_by(Theme.label, ThemeAssignment.created_at)
-        )).all()
+        ).all()
 
-        #    the LEFT JOIN to DemographicRow keeps quotes from transcripts that were never linked to a demographic row (interviewee_id == None).
-
-        # Report the behavior: if the transcript was never linked to a demographic row, the id will be None, and the demographics dict will be empty.
-        # If the transcript was linked to a demographic row, but the row has no data, the id will be present, but the demographics dict will still be empty.
-
-        #  A theme with no active parent simply gets parent_label = None.
         parent_label_by_child = {
             row.child_theme_id: row.parent_label
             for row in (
@@ -101,20 +102,19 @@ class RunExportService:
         original_columns = (
             await self._session.execute(
                 select(DemographicFiles.original_columns)
-                .where(DemographicFiles.corpus_id == corpus_id)
+                .where(DemographicFiles.corpus_id == run.corpus_id)
                 .order_by(DemographicFiles.created_at.desc())
                 .limit(1)
             )
         ).scalar_one_or_none()
-
-        demo_columns: list[str] = list(original_columns) if original_columns is not None else []
+        demo_columns = [col for col in (original_columns or []) if col != LINK_KEY_COLUMN]
 
         export_rows = [
             _ExportRow(
                 theme_label=row.label,
                 parent_label=parent_label_by_child.get(row.id),
                 theme_description=row.description,
-                # Fall back to the document title when the transcript has no linked demographic row.
+                # Document title is the fallback when no demographic row is linked.
                 participant_id=row.interviewee_id or row.title,
                 quote=row.quote,
                 demographics=tuple(str((row.data or {}).get(col, "")) for col in demo_columns),
@@ -144,13 +144,15 @@ class RunExportService:
         return buffer.getvalue()
 
     def to_participant_based_csv(self, data: ExportData) -> str:
-        """File 2: demographics repeated per quote, one row per tagged quote.
+        """File 2: demographics repeated per quote, grouped by participant.
 
-        Header: Participant ID, <demo columns…>, Theme Name, Quote
+        Sorted by (participant, quote, theme) so a quote tagged with several
+        themes stays on consecutive rows.
         """
         buffer = io.StringIO()
         writer = csv.writer(buffer)
         writer.writerow(["Participant ID", *data.demo_columns, "Theme Name", "Quote"])
-        for row in data.rows:
+        rows = sorted(data.rows, key=lambda r: (r.participant_id, r.quote, r.theme_label))
+        for row in rows:
             writer.writerow([row.participant_id, *row.demographics, row.theme_label, row.quote])
         return buffer.getvalue()

--- a/Backend/tests/test_export_results.py
+++ b/Backend/tests/test_export_results.py
@@ -1,0 +1,355 @@
+"""Tests for GET /codebook-application-runs/{run_id}/export.
+
+Demographics/transcripts are seeded via the HTTP API (so real linking runs);
+codebook/themes/runs/assignments are inserted directly (no LLM in tests).
+"""
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models import Codebook, CodebookApplicationRun, Theme, ThemeHierarchyRelationship
+from app.models.analysis import DocumentCoding, ThemeAssignment
+
+INGESTION_API = "/api/v1/ingestion"
+DEMOGRAPHIC_API = "/api/v1/demographic"
+EXPORT_API = "/api/v1/codebook-application-runs"
+
+
+def _parse_csv(text: str) -> tuple[list[str], list[list[str]]]:
+    rows = list(csv.reader(io.StringIO(text)))
+    return (rows[0], rows[1:]) if rows else ([], [])
+
+
+# ── seed helpers ──────────────────────────────────────────────────────────────
+
+@dataclass
+class _Seed:
+    run_id: UUID
+    linked_participant_id: str  # "P-101" title matches a demographic username
+    unlinked_doc_title: str  # "Unlinked-Doc" no match; doc title is the fallback
+
+
+async def _seed_full(client, db_engine) -> _Seed:
+    """Rich dataset built via the real HTTP API so the linking service (not a
+    manual FK patch) sets CorpusDocument.demographic_row_id."""
+    corpus_id = uuid4()
+    resp = await client.post(
+        f"{INGESTION_API}/corpora",
+        json={"corpus_id": str(corpus_id), "name": "Export Test Corpus"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    # "P-101" matches a demographic username → auto-linked; "Unlinked-Doc" stays unlinked.
+    resp = await client.post(
+        f"{INGESTION_API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [
+            {"title": "P-101", "text": "Interview text for participant P-101."},
+            {"title": "Unlinked-Doc", "text": "Interview text for unlinked participant."},
+        ]},
+    )
+    assert resp.status_code == 201
+
+    # username is the link key, excluded from the export's demographic columns.
+    csv_content = "username;age;role\nP-101;30;Engineer\n"
+    upload = await client.post(
+        f"{DEMOGRAPHIC_API}/{corpus_id}/upload",
+        files={"file": ("demo.csv", csv_content, "application/octet-stream")},
+    )
+    assert upload.status_code == 201
+    import_id = upload.json()["data"]["import_id"]
+
+    # Confirm triggers auto-linking by title/username match.
+    confirm = await client.post(
+        f"{DEMOGRAPHIC_API}/{corpus_id}/confirm",
+        params={"import_id": import_id, "confirm": True},
+    )
+    assert confirm.status_code == 201
+
+    summary = (await client.get(f"{DEMOGRAPHIC_API}/{corpus_id}/link-summary")).json()["data"]
+    doc_by_title = {d["document_title"]: UUID(d["document_id"]) for d in summary["details"]}
+    linked_doc_id = doc_by_title["P-101"]
+    unlinked_doc_id = doc_by_title["Unlinked-Doc"]
+
+    # Codebook/themes/run/assignments seeded directly (no LLM in tests).
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        codebook_id = uuid4()
+        run_id = uuid4()
+        parent_id = uuid4()
+        theme1_id = uuid4()
+        theme2_id = uuid4()
+        linked_coding_id = uuid4()
+        unlinked_coding_id = uuid4()
+
+        session.add_all([
+            Codebook(id=codebook_id, corpus_id=corpus_id, name="Export Codebook",
+                     description="", version=1, created_by="system"),
+            Theme(id=parent_id, codebook_id=codebook_id, label="Parent A", is_active=True),
+            Theme(id=theme1_id, codebook_id=codebook_id, label="Theme 1", is_active=True),
+            Theme(id=theme2_id, codebook_id=codebook_id, label="Theme 2", is_active=True),
+            ThemeHierarchyRelationship(id=uuid4(), codebook_id=codebook_id,
+                                       parent_theme_id=parent_id, child_theme_id=theme1_id,
+                                       is_active=True),
+            CodebookApplicationRun(id=run_id, corpus_id=corpus_id, codebook_id=codebook_id,
+                                   status="succeeded"),
+            DocumentCoding(id=linked_coding_id, application_run_id=run_id,
+                           document_id=linked_doc_id, codebook_id=codebook_id),
+            DocumentCoding(id=unlinked_coding_id, application_run_id=run_id,
+                           document_id=unlinked_doc_id, codebook_id=codebook_id),
+        ])
+        await session.flush()
+
+        session.add_all([
+            # P-101 gets two quotes on Theme 1 and one on Theme 2.
+            ThemeAssignment(id=uuid4(), document_coding_id=linked_coding_id,
+                            theme_id=theme1_id, is_present=True, quote="Quote 1a"),
+            ThemeAssignment(id=uuid4(), document_coding_id=linked_coding_id,
+                            theme_id=theme1_id, is_present=True, quote="Quote 1b"),
+            ThemeAssignment(id=uuid4(), document_coding_id=linked_coding_id,
+                            theme_id=theme2_id, is_present=True, quote="Quote 2"),
+            # Unlinked transcript gets one quote on Theme 1.
+            ThemeAssignment(id=uuid4(), document_coding_id=unlinked_coding_id,
+                            theme_id=theme1_id, is_present=True, quote="Unlinked quote"),
+            # Excluded: null quote and absent assignment.
+            ThemeAssignment(id=uuid4(), document_coding_id=linked_coding_id,
+                            theme_id=theme1_id, is_present=True, quote=None),
+            ThemeAssignment(id=uuid4(), document_coding_id=linked_coding_id,
+                            theme_id=theme1_id, is_present=False, quote="Absent"),
+        ])
+        await session.commit()
+
+    return _Seed(run_id=run_id, linked_participant_id="P-101", unlinked_doc_title="Unlinked-Doc")
+
+
+async def _seed_empty(client, db_engine) -> UUID:
+    """Run with no assignments and no demographic file."""
+    corpus_id = uuid4()
+    resp = await client.post(
+        f"{INGESTION_API}/corpora",
+        json={"corpus_id": str(corpus_id), "name": "Empty Export Corpus"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        codebook_id = uuid4()
+        run_id = uuid4()
+        session.add_all([
+            Codebook(id=codebook_id, corpus_id=corpus_id, name="Empty Codebook",
+                     description="", version=1, created_by="system"),
+            CodebookApplicationRun(id=run_id, corpus_id=corpus_id, codebook_id=codebook_id,
+                                   status="succeeded"),
+        ])
+        await session.commit()
+    return run_id
+
+
+async def _seed_multi_theme_quote(client, db_engine) -> UUID:
+    """One participant has a single quote tagged with two themes, plus another
+    quote on one of those themes. A second participant has one quote. No
+    demographic file, so demo_columns is empty for this run.
+    """
+    corpus_id = uuid4()
+    resp = await client.post(
+        f"{INGESTION_API}/corpora",
+        json={"corpus_id": str(corpus_id), "name": "Multi Theme Quote Corpus"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    resp = await client.post(
+        f"{INGESTION_API}/corpora/{corpus_id}/documents/bulk",
+        json={"documents": [
+            {"title": "P-Multi", "text": "Transcript for P-Multi."},
+            {"title": "P-Other", "text": "Transcript for P-Other."},
+        ]},
+    )
+    assert resp.status_code == 201
+
+    docs = (await client.get(f"{INGESTION_API}/corpora/{corpus_id}/documents")).json()["data"]["items"]
+    doc_by_title = {d["title"]: UUID(d["id"]) for d in docs}
+
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        codebook_id = uuid4()
+        run_id = uuid4()
+        alpha_id = uuid4()
+        beta_id = uuid4()
+        multi_coding_id = uuid4()
+        other_coding_id = uuid4()
+
+        session.add_all([
+            Codebook(id=codebook_id, corpus_id=corpus_id, name="Multi Theme Codebook",
+                     description="", version=1, created_by="system"),
+            Theme(id=alpha_id, codebook_id=codebook_id, label="Alpha", is_active=True),
+            Theme(id=beta_id, codebook_id=codebook_id, label="Beta", is_active=True),
+            CodebookApplicationRun(id=run_id, corpus_id=corpus_id, codebook_id=codebook_id,
+                                   status="succeeded"),
+            DocumentCoding(id=multi_coding_id, application_run_id=run_id,
+                           document_id=doc_by_title["P-Multi"], codebook_id=codebook_id),
+            DocumentCoding(id=other_coding_id, application_run_id=run_id,
+                           document_id=doc_by_title["P-Other"], codebook_id=codebook_id),
+        ])
+        await session.flush()
+
+        session.add_all([
+            # "Zebra insight" is tagged on both themes these two rows must
+            # stay adjacent in the export, not be split apart by theme grouping.
+            ThemeAssignment(id=uuid4(), document_coding_id=multi_coding_id,
+                            theme_id=beta_id, is_present=True, quote="Zebra insight"),
+            ThemeAssignment(id=uuid4(), document_coding_id=multi_coding_id,
+                            theme_id=alpha_id, is_present=True, quote="Zebra insight"),
+            ThemeAssignment(id=uuid4(), document_coding_id=multi_coding_id,
+                            theme_id=alpha_id, is_present=True, quote="Apple insight"),
+            ThemeAssignment(id=uuid4(), document_coding_id=other_coding_id,
+                            theme_id=alpha_id, is_present=True, quote="Other insight"),
+        ])
+        await session.commit()
+    return run_id
+
+
+# ── 404 ──────────────────────────────────────────────────────────────────────
+
+async def test_unknown_run_returns_404(client) -> None:
+    resp = await client.get(f"{EXPORT_API}/{uuid4()}/export", params={"format": "theme-based"})
+    assert resp.status_code == 404
+
+
+# ── response shape ────────────────────────────────────────────────────────────
+
+async def test_response_is_csv_with_content_disposition(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert str(seed.run_id) in resp.headers["content-disposition"]
+    assert "theme-based" in resp.headers["content-disposition"]
+
+
+# ── theme-based ───────────────────────────────────────────────────────────────
+
+async def test_theme_based_headers(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    headers, _ = _parse_csv(resp.text)
+    assert headers == ["Theme Name", "Parent Theme", "Theme Description", "Participant ID", "Quote"]
+
+
+async def test_theme_based_row_count_excludes_null_and_absent(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    _, rows = _parse_csv(resp.text)
+    # 2×Theme1(P-101) + 1×Theme2(P-101) + 1×Theme1(unlinked) = 4
+    assert len(rows) == 4
+
+
+async def test_theme_based_parent_theme_populated_for_child(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    _, rows = _parse_csv(resp.text)
+    theme1_rows = [r for r in rows if r[0] == "Theme 1"]
+    assert all(r[1] == "Parent A" for r in theme1_rows)
+
+
+async def test_theme_based_root_theme_has_empty_parent(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    _, rows = _parse_csv(resp.text)
+    theme2_rows = [r for r in rows if r[0] == "Theme 2"]
+    assert all(r[1] == "" for r in theme2_rows)
+
+
+async def test_theme_based_multi_quote_same_participant_and_theme(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    _, rows = _parse_csv(resp.text)
+    p101_theme1_quotes = {r[4] for r in rows
+                          if r[0] == "Theme 1" and r[3] == seed.linked_participant_id}
+    assert p101_theme1_quotes == {"Quote 1a", "Quote 1b"}
+
+
+async def test_theme_based_unlinked_transcript_uses_document_title(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export", params={"format": "theme-based"})
+    _, rows = _parse_csv(resp.text)
+    assert seed.unlinked_doc_title in {r[3] for r in rows}
+
+
+# ── participant-based ─────────────────────────────────────────────────────────
+
+async def test_participant_based_headers_include_demo_columns(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export",
+                            params={"format": "participant-based"})
+    headers, _ = _parse_csv(resp.text)
+    assert headers == ["Participant ID", "age", "role", "Theme Name", "Quote"]
+
+
+async def test_participant_based_row_count(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export",
+                            params={"format": "participant-based"})
+    _, rows = _parse_csv(resp.text)
+    assert len(rows) == 4
+
+
+async def test_participant_based_demographics_repeated_per_quote(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export",
+                            params={"format": "participant-based"})
+    _, rows = _parse_csv(resp.text)
+    p101_rows = [r for r in rows if r[0] == seed.linked_participant_id]
+    assert len(p101_rows) == 3  # Quote 1a, Quote 1b, Quote 2
+    assert all(r[1] == "30" and r[2] == "Engineer" for r in p101_rows)
+
+
+async def test_participant_based_unlinked_transcript_has_blank_demo_cells(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export",
+                            params={"format": "participant-based"})
+    _, rows = _parse_csv(resp.text)
+    unlinked = [r for r in rows if r[0] == seed.unlinked_doc_title]
+    assert len(unlinked) == 1
+    assert unlinked[0][1] == "" and unlinked[0][2] == ""  # blank age, blank role
+
+
+async def test_participant_based_rows_grouped_by_participant(client, db_engine) -> None:
+    seed = await _seed_full(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{seed.run_id}/export",
+                            params={"format": "participant-based"})
+    _, rows = _parse_csv(resp.text)
+    # to_participant_based_csv() sorts by participant, so a participant's
+    # rows arrive contiguously.
+    participant_col = [r[0] for r in rows]
+    assert participant_col == sorted(participant_col)
+
+
+async def test_participant_based_full_sort_order(client, db_engine) -> None:
+    """Sorted by participant, then quote, then theme so the two rows of a
+    quote tagged with multiple themes stay adjacent."""
+    run_id = await _seed_multi_theme_quote(client, db_engine)
+    resp = await client.get(f"{EXPORT_API}/{run_id}/export", params={"format": "participant-based"})
+    _, rows = _parse_csv(resp.text)
+
+    # [Participant ID, Theme Name, Quote] no demographic columns for this corpus.
+    assert rows == [
+        ["P-Multi", "Alpha", "Apple insight"],
+        ["P-Multi", "Alpha", "Zebra insight"],
+        ["P-Multi", "Beta", "Zebra insight"],
+        ["P-Other", "Alpha", "Other insight"],
+    ]
+
+
+# ── edge cases ────────────────────────────────────────────────────────────────
+
+async def test_empty_run_returns_header_only_csv(client, db_engine) -> None:
+    run_id = await _seed_empty(client, db_engine)
+    for fmt in ("theme-based", "participant-based"):
+        resp = await client.get(f"{EXPORT_API}/{run_id}/export", params={"format": fmt})
+        assert resp.status_code == 200
+        _, rows = _parse_csv(resp.text)
+        assert rows == [], f"expected no data rows for format={fmt}"

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -1,9 +1,18 @@
-from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+import io
+import zipfile
+
+from flask import Blueprint, Response, flash, jsonify, redirect, render_template, request, url_for
 
 from web.services.corpus_context import resolve_active_corpus
-from web.services.backend_client import BackendError, get_backend_client as _backend
+from web.services.backend_client import (
+    BackendError,
+    BackendNotFoundError,
+    get_backend_client as _backend,
+)
 
 bp = Blueprint("analysis", __name__)
+
+EXPORT_FORMATS = ("theme-based", "participant-based")
 
 
 @bp.get("/")
@@ -125,6 +134,41 @@ def job_status(job_id: str):
         return jsonify(job)
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 500
+
+
+@bp.post("/runs/export")
+def export_selected_runs() -> Response | str:
+    """Export the selected runs as one ZIP with a CSV per run, per chosen format."""
+    corpus_id = request.args.get("corpus_id")
+    run_ids = [item_id for item_id in request.form.getlist("item_ids") if item_id]
+    formats = [fmt for fmt in request.form.getlist("formats") if fmt in EXPORT_FORMATS]
+    if not run_ids:
+        flash("Select at least one analysis run to export.", "warning")
+        return redirect(url_for("analysis.index", corpus_id=corpus_id))
+    if not formats:
+        flash("Select at least one export format.", "warning")
+        return redirect(url_for("analysis.index", corpus_id=corpus_id))
+
+    client = _backend()
+    try:
+        archive_buffer = io.BytesIO()
+        with zipfile.ZipFile(archive_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for run_id in run_ids:
+                for export_format in formats:
+                    csv_bytes = client.fetch_run_export_csv(run_id, export_format)
+                    archive.writestr(f"run-{run_id}-{export_format}.csv", csv_bytes)
+        archive_buffer.seek(0)
+        return Response(
+            archive_buffer.getvalue(),
+            mimetype="application/zip",
+            headers={"Content-Disposition": 'attachment; filename="analysis-runs-export.zip"'},
+        )
+    except BackendNotFoundError:
+        flash("One of the selected runs couldn't be found. It may have been deleted.", "danger")
+        return redirect(url_for("analysis.index", corpus_id=corpus_id))
+    except BackendError as exc:
+        flash(exc.user_message, "danger")
+        return redirect(url_for("analysis.index", corpus_id=corpus_id))
 
 
 @bp.post("/runs/delete")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -325,6 +325,21 @@ class BackendClient:
         """Hard-delete an analysis run and its coded results."""
         self._delete(f"/codebook-application-runs/{run_id}")
 
+    def fetch_run_export_csv(self, run_id: str, export_format: str) -> bytes:
+        """Fetch a run's CSV export as raw bytes.
+
+        The export endpoint returns raw CSV, not the JSON envelope, so this
+        bypasses _get / _unwrap.
+        """
+        path = f"/codebook-application-runs/{run_id}/export"
+        started_at = time.monotonic()
+        try:
+            r = self._client.get(path, params={"format": export_format})
+            r.raise_for_status()
+            return r.content
+        except httpx.HTTPError as exc:
+            self._handle_exc(exc, path, "GET", started_at)
+
     # ---- Codebook Upload & Parsing ------------------------------------------
 
     def parse_csv_preview(self, file: FileStorage) -> list[dict]:

--- a/Frontend/web/templates/_selectable_list_toolbar.html
+++ b/Frontend/web/templates/_selectable_list_toolbar.html
@@ -15,9 +15,20 @@
     </span>
   </div>
 
-  {% if selectable_list_delete_action or selectable_list_export_url_template or selectable_list_export_action %}
+  {% if selectable_list_delete_action or selectable_list_export_url_template or selectable_list_export_action or selectable_list_export_modal_id %}
     <div class="ata-selectable-list__actions" aria-label="{{ selectable_list_label }} selection actions">
-      {% if selectable_list_export_action %}
+      {% if selectable_list_export_modal_id %}
+        <button type="button"
+                class="btn btn-sm btn-outline-secondary"
+                data-bs-toggle="modal"
+                data-bs-target="#{{ selectable_list_export_modal_id }}"
+                data-selectable-list-action
+                data-min-selected="1"
+                data-disabled-title="Select at least one {{ selectable_list_item_singular }} to export."
+                disabled>
+          {{ selectable_list_export_label | default('Export selected') }}
+        </button>
+      {% elif selectable_list_export_action %}
         <form method="POST"
               action="{{ selectable_list_export_action }}"
               class="d-inline"

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -127,10 +127,12 @@
     {# Reuses the shared selectable-list pattern (Codebooks/Transcripts). The
        surrounding card is border-0 (shadow only), so the list keeps its own
        border to frame the table. #}
-    <div class="ata-selectable-list border rounded-2" data-selectable-list>
+    <div id="previousRunsList" class="ata-selectable-list border rounded-2" data-selectable-list>
       {% set selectable_list_label = 'analysis runs' %}
       {% set selectable_list_item_singular = 'run' %}
       {% set selectable_list_item_plural = 'runs' %}
+      {% set selectable_list_export_modal_id = 'exportRunsModal' %}
+      {% set selectable_list_export_label = 'Export selected' %}
       {% set selectable_list_delete_action = url_for('analysis.delete_selected_runs', corpus_id=active_corpus_id) %}
       {% set selectable_list_delete_label = 'Delete selected' %}
       {% set selectable_list_delete_modal_id = 'deleteSelectedRunsModal' %}
@@ -179,6 +181,80 @@
             {% endfor %}
           </tbody>
         </table>
+      </div>
+
+      {# Kept inside the selectable list so its form receives the selected run
+         ids that selectable_list.js injects as item_ids (same as the delete modal). #}
+      <div class="modal fade text-start" id="exportRunsModal" tabindex="-1"
+           aria-labelledby="exportRunsModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <form method="POST"
+                  action="{{ url_for('analysis.export_selected_runs', corpus_id=active_corpus_id) }}"
+                  data-selectable-list-selected-form>
+              <div class="modal-header">
+                <h5 class="modal-title" id="exportRunsModalLabel">Export Analysis Runs</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                <p class="text-secondary">
+                  Pick one or both formats. The selected runs download as a single ZIP
+                  with <strong>one CSV per format, per run</strong>.
+                </p>
+
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" id="exportThemeBased"
+                         name="formats" value="theme-based" checked>
+                  <label class="form-check-label fw-semibold" for="exportThemeBased">Theme-based</label>
+                </div>
+                <p class="small text-secondary ms-4 mb-2">One row per tagged quote, grouped by theme.</p>
+                <div class="table-responsive ms-4 mb-4">
+                  <table class="table table-sm table-bordered small mb-0">
+                    <thead class="table-light">
+                      <tr>
+                        <th>Theme Name</th><th>Parent Theme</th><th>Theme Description</th>
+                        <th>Participant ID</th><th>Quote</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="text-secondary">
+                        <td>Team Communication</td><td>Communication</td><td>In-person team comms.</td>
+                        <td>P-001</td><td>"Our daily standups help…"</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <div class="form-check mb-2">
+                  <input class="form-check-input" type="checkbox" id="exportParticipantBased"
+                         name="formats" value="participant-based">
+                  <label class="form-check-label fw-semibold" for="exportParticipantBased">Participant-based</label>
+                </div>
+                <p class="small text-secondary ms-4 mb-2">Demographics repeated per quote, grouped by participant.</p>
+                <div class="table-responsive ms-4 mb-0">
+                  <table class="table table-sm table-bordered small mb-0">
+                    <thead class="table-light">
+                      <tr>
+                        <th>Participant ID</th><th>&lt;demographic columns…&gt;</th>
+                        <th>Theme Name</th><th>Quote</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="text-secondary">
+                        <td>P-001</td><td>29, Software Engineer, …</td>
+                        <td>Team Communication</td><td>"Our daily standups help…"</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-primary">Download ZIP</button>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
     </div>
     {% else %}


### PR DESCRIPTION
Adds the ability to export a codebook application run's coded results as CSV, in two shapes, and to bulk-export multiple runs from the Analysis page as a single ZIP.

- **Theme-based**, one row per tagged quote: `Theme Name, Parent Theme, Theme Description, Participant ID, Quote`
- **Participant-based**, demographics repeated per quote: `Participant ID, <demographic columns…>, Theme Name, Quote`

### Backend
- New `GET /codebook-application-runs/{run_id}/export?format=theme-based|participant-based` returning raw `text/csv` as an attachment.
- `RunExportService` builds rows from a single join (`ThemeAssignment → DocumentCoding → Theme → CorpusDocument`, LEFT JOIN `DemographicRow`), resolving parent themes via `ThemeHierarchyRelationship` and projecting demographics over `DemographicFiles.original_columns`.
- `RunExportFormat` as a `StrEnum`
- `tests/test_export_results.py`

### Frontend
- **Analysis page**: an "Export selected" toolbar button (next to "Delete selected") opens a modal to choose one or both formats, with a preview of each CSV's structure. Submitting downloads one ZIP containing `run-<id>-<format>.csv` per selected run × format.
- Follows the existing `export_selected_codebooks` pattern: a POST form inside the selectable list (run ids injected by `selectable_list.js`), server-side zipping in the controller, single download.