### PR TITLE
feat: per-theme demographic breakdown for themes (UC 3.6)

### DIFF
--- a/Backend/app/config.py
+++ b/Backend/app/config.py
@@ -29,6 +29,10 @@ class Settings(BaseSettings):
     DEMOGRAPHIC_UPLOAD_TTL_SECONDS: int = 60 * 60
     UPLOAD_CLEANUP_INTERVAL_SECONDS: int = 5 * 60
 
+    # Demographic groups smaller than this are flagged as small samples in the
+    # per-theme demographic breakdown so percentages are read with caution.
+    DEMOGRAPHIC_SMALL_SAMPLE_THRESHOLD: int = 5
+
     @property
     def is_production(self) -> bool:
         return self.APP_ENV == "production" # Helper property to check if the app is running in production mode

--- a/Backend/app/routers/demographic.py
+++ b/Backend/app/routers/demographic.py
@@ -15,8 +15,10 @@ from app.schemas.demographic import (
     LinkRequest,
     UploadDemographicConfirmResponse,
 )
+from app.schemas.theme_views import DemographicDimensionsResponse
 from app.services.demographic import DemographicService
 from app.services.linking import set_document_link
+from app.services.theme_demographic_breakdown import ThemeDemographicBreakdownService
 
 router = APIRouter(prefix="/demographic/{corpus_id}", tags=["demographic"])
 
@@ -140,6 +142,28 @@ async def list_demographic_files(
             items=items,
             meta=PageMeta(total=total, page=page, page_size=page_size, pages=_pages(total, page_size)),
         )
+    )
+
+
+@router.get(
+    "/dimensions",
+    response_model=ResponseEnvelope[DemographicDimensionsResponse],
+    summary="List demographic dimensions available for breakdowns",
+    description=(
+        "Return the demographic variables present in the uploaded data for one "
+        "corpus (the username identifier column is excluded). Returns an empty "
+        "list when no demographic data has been uploaded."
+    ),
+)
+async def list_demographic_dimensions(
+    corpus_id: uuid.UUID,
+    session: DbSession,
+) -> ResponseEnvelope[DemographicDimensionsResponse]:
+    """Return the demographic variables that can be used to break down a theme."""
+    service = ThemeDemographicBreakdownService(session)
+    dimensions = await service.list_available_dimensions(corpus_id=corpus_id)
+    return ResponseEnvelope[DemographicDimensionsResponse].ok(
+        data=DemographicDimensionsResponse(dimensions=dimensions)
     )
 
 

--- a/Backend/app/routers/themes.py
+++ b/Backend/app/routers/themes.py
@@ -5,11 +5,16 @@ from uuid import UUID
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from app.dependencies import DbSession
+from app.dependencies import AppSettings, DbSession
 from app.exceptions import NotFoundError, UnprocessableError
 from app.schemas.common import Page, ResponseEnvelope
 from app.schemas.theme_graph import ThemeTreeNode
-from app.schemas.theme_views import ThemeFrequencyItem, ThemeQuoteItem
+from app.schemas.theme_views import (
+    ThemeDemographicBreakdownResponse,
+    ThemeFrequencyItem,
+    ThemeQuoteItem,
+)
+from app.services.theme_demographic_breakdown import ThemeDemographicBreakdownService
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import ThemeGraphService, ThemeNotFoundError, ThemeValidationError
 from app.services.theme_quotes import ThemeQuotesService
@@ -65,6 +70,46 @@ async def get_theme_tree(
         raise UnprocessableError(str(exc)) from exc
 
     # Wrap successful payloads in response envelope
+    return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
+
+
+@router.get(
+    "/{theme_id}/demographic-breakdown",
+    response_model=ResponseEnvelope[ThemeDemographicBreakdownResponse],
+    summary="Break a theme's frequency down by demographic groups",
+    description=(
+        "For each requested demographic dimension, return the theme's frequency "
+        "split by group (absolute count and percentage within the group). "
+        "Unknown dimensions are ignored; an empty/zero result is returned when the "
+        "codebook has no analysis run."
+    ),
+)
+async def get_theme_demographic_breakdown(
+    codebook_id: UUID,
+    theme_id: UUID,
+    session: DbSession,
+    settings: AppSettings,
+    dimensions: str = Query(
+        default="",
+        description="Comma-separated demographic dimension names to break down by.",
+    ),
+    application_run_id: UUID | None = Query(default=None),
+) -> JSONResponse:
+    requested = [part.strip() for part in dimensions.split(",") if part.strip()]
+    service = ThemeDemographicBreakdownService(
+        session,
+        small_sample_threshold=settings.DEMOGRAPHIC_SMALL_SAMPLE_THRESHOLD,
+    )
+    try:
+        payload = await service.get_theme_breakdown(
+            codebook_id=codebook_id,
+            theme_id=theme_id,
+            dimensions=requested,
+            application_run_id=application_run_id,
+        )
+    except ThemeNotFoundError as exc:
+        raise NotFoundError(str(exc)) from exc
+
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
 
 

--- a/Backend/app/schemas/theme_views.py
+++ b/Backend/app/schemas/theme_views.py
@@ -33,3 +33,34 @@ class ThemeQuoteItem(BaseSchema):
     document_id: UUID
     document_title: str
     interviewee_id: str | None
+
+
+class DemographicDimensionsResponse(BaseSchema):
+    """Demographic variables available for breaking down a theme in one corpus."""
+
+    dimensions: list[str]
+
+
+class DemographicGroupStat(BaseSchema):
+    """Theme frequency within one group of a demographic dimension."""
+
+    group_value: str
+    present_count: int = Field(ge=0)
+    group_total: int = Field(ge=0)
+    percentage: float = Field(ge=0.0, le=100.0)
+    small_sample: bool = False
+
+
+class ThemeDimensionBreakdown(BaseSchema):
+    """Theme frequency broken down by the groups of one demographic dimension."""
+
+    dimension: str
+    groups: list[DemographicGroupStat]
+
+
+class ThemeDemographicBreakdownResponse(BaseSchema):
+    """Per-theme demographic breakdown across one or more selected dimensions."""
+
+    theme_id: UUID
+    application_run_id: UUID | None = None
+    dimensions: list[ThemeDimensionBreakdown]

--- a/Backend/app/services/theme_demographic_breakdown.py
+++ b/Backend/app/services/theme_demographic_breakdown.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    Codebook,
+    CodebookApplicationRun,
+    CorpusDocument,
+    DemographicFiles,
+    DemographicRow,
+    DocumentCoding,
+    Theme,
+    ThemeAssignment,
+)
+from app.schemas.theme_views import (
+    DemographicGroupStat,
+    ThemeDemographicBreakdownResponse,
+    ThemeDimensionBreakdown,
+)
+from app.services.theme_graph import ThemeNotFoundError
+
+# The username column links a demographic row to a transcript; it is an
+# identifier, not a demographic variable, so it is never offered as a dimension.
+USERNAME_COLUMN = "username"
+
+# Bucket used for coded interviews that have no demographic link, or whose
+# linked row has no value for the selected dimension. Surfaced (count 0+),
+# never silently dropped.
+NOT_SPECIFIED_LABEL = "Not specified"
+
+DEFAULT_SMALL_SAMPLE_THRESHOLD = 5
+
+
+class ThemeDemographicBreakdownService:
+    """Break a single theme's frequency down by demographic dimensions.
+
+    The population for a breakdown is the set of interviews coded in the
+    selected application run. For each dimension, those interviews are grouped by
+    their linked demographic value; within each group we report how many had the
+    theme present (absolute count) and the share of the group (percentage).
+    Aggregation happens in Python so it stays portable across PostgreSQL (prod)
+    and SQLite (tests) without relying on JSON SQL operators.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        small_sample_threshold: int = DEFAULT_SMALL_SAMPLE_THRESHOLD,
+    ) -> None:
+        self._session = session
+        self._small_sample_threshold = small_sample_threshold
+
+    async def list_available_dimensions(self, *, corpus_id: UUID) -> list[str]:
+        """Demographic variables present in the uploaded data for one corpus.
+
+        Derived from every demographic file's columns, with the username
+        identifier removed. Order of first appearance is preserved and
+        duplicates across files are collapsed.
+        """
+        rows = (
+            await self._session.execute(
+                select(DemographicFiles.original_columns).where(
+                    DemographicFiles.corpus_id == corpus_id
+                )
+            )
+        ).scalars().all()
+
+        dimensions: list[str] = []
+        for columns in rows:
+            for column in columns or []:
+                if column != USERNAME_COLUMN and column not in dimensions:
+                    dimensions.append(column)
+        return dimensions
+
+    async def get_theme_breakdown(
+        self,
+        *,
+        codebook_id: UUID,
+        theme_id: UUID,
+        dimensions: list[str],
+        application_run_id: UUID | None = None,
+    ) -> ThemeDemographicBreakdownResponse:
+        corpus_id = await self._resolve_codebook_corpus(codebook_id=codebook_id)
+        await self._ensure_theme_in_codebook(codebook_id=codebook_id, theme_id=theme_id)
+        run_id = await self._resolve_run_id(
+            codebook_id=codebook_id, application_run_id=application_run_id
+        )
+
+        available = await self.list_available_dimensions(corpus_id=corpus_id)
+        # Only honor dimensions that actually exist in the data; keep the
+        # caller's order and drop unknown/duplicate names.
+        selected: list[str] = []
+        for dimension in dimensions:
+            if dimension in available and dimension not in selected:
+                selected.append(dimension)
+
+        if run_id is None or not selected:
+            return ThemeDemographicBreakdownResponse(
+                theme_id=theme_id,
+                application_run_id=run_id,
+                dimensions=[
+                    ThemeDimensionBreakdown(dimension=dimension, groups=[])
+                    for dimension in selected
+                ],
+            )
+
+        population = await self._load_population(run_id=run_id)
+        present_document_ids = await self._load_present_document_ids(
+            run_id=run_id, theme_id=theme_id
+        )
+
+        return ThemeDemographicBreakdownResponse(
+            theme_id=theme_id,
+            application_run_id=run_id,
+            dimensions=[
+                self._build_dimension_breakdown(
+                    dimension=dimension,
+                    population=population,
+                    present_document_ids=present_document_ids,
+                )
+                for dimension in selected
+            ],
+        )
+
+    async def _resolve_codebook_corpus(self, *, codebook_id: UUID) -> UUID:
+        corpus_id = (
+            await self._session.execute(
+                select(Codebook.corpus_id).where(Codebook.id == codebook_id)
+            )
+        ).scalar_one_or_none()
+        if corpus_id is None:
+            raise ThemeNotFoundError(f"Codebook '{codebook_id}' not found.")
+        return corpus_id
+
+    async def _ensure_theme_in_codebook(self, *, codebook_id: UUID, theme_id: UUID) -> None:
+        theme_row = (
+            await self._session.execute(
+                select(Theme.id).where(
+                    Theme.id == theme_id,
+                    Theme.codebook_id == codebook_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if theme_row is None:
+            raise ThemeNotFoundError(
+                f"Theme '{theme_id}' not found in codebook '{codebook_id}'."
+            )
+
+    async def _resolve_run_id(
+        self,
+        *,
+        codebook_id: UUID,
+        application_run_id: UUID | None,
+    ) -> UUID | None:
+        if application_run_id is not None:
+            run = await self._session.get(CodebookApplicationRun, application_run_id)
+            if run is None or run.codebook_id != codebook_id:
+                raise ThemeNotFoundError(
+                    f"Codebook application run '{application_run_id}' not found "
+                    f"for codebook '{codebook_id}'."
+                )
+            return run.id
+
+        stmt = (
+            select(CodebookApplicationRun.id)
+            .where(
+                CodebookApplicationRun.codebook_id == codebook_id,
+                CodebookApplicationRun.status == "succeeded",
+            )
+            .order_by(
+                desc(CodebookApplicationRun.finished_at),
+                desc(CodebookApplicationRun.created_at),
+            )
+            .limit(1)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def _load_population(
+        self, *, run_id: UUID
+    ) -> list[tuple[UUID, dict[str, Any] | None]]:
+        """Every interview coded in the run, paired with its demographic data.
+
+        One coding row exists per (run, document), so each interview appears once.
+        Interviews with no demographic link yield ``None`` data.
+        """
+        rows = (
+            await self._session.execute(
+                select(DocumentCoding.document_id, DemographicRow.data)
+                .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
+                .outerjoin(
+                    DemographicRow,
+                    CorpusDocument.demographic_row_id == DemographicRow.id,
+                )
+                .where(DocumentCoding.application_run_id == run_id)
+            )
+        ).all()
+        return [(row.document_id, row.data) for row in rows]
+
+    async def _load_present_document_ids(
+        self, *, run_id: UUID, theme_id: UUID
+    ) -> set[UUID]:
+        rows = (
+            await self._session.execute(
+                select(DocumentCoding.document_id)
+                .join(
+                    ThemeAssignment,
+                    ThemeAssignment.document_coding_id == DocumentCoding.id,
+                )
+                .where(
+                    DocumentCoding.application_run_id == run_id,
+                    ThemeAssignment.theme_id == theme_id,
+                    ThemeAssignment.is_present.is_(True),
+                )
+            )
+        ).scalars().all()
+        return set(rows)
+
+    def _build_dimension_breakdown(
+        self,
+        *,
+        dimension: str,
+        population: list[tuple[UUID, dict[str, Any] | None]],
+        present_document_ids: set[UUID],
+    ) -> ThemeDimensionBreakdown:
+        group_total: dict[str, int] = defaultdict(int)
+        group_present: dict[str, int] = defaultdict(int)
+
+        for document_id, data in population:
+            value = self._group_value(data, dimension)
+            group_total[value] += 1
+            if document_id in present_document_ids:
+                group_present[value] += 1
+
+        groups = [
+            DemographicGroupStat(
+                group_value=value,
+                present_count=group_present.get(value, 0),
+                group_total=group_total[value],
+                percentage=self._to_percentage(
+                    present=group_present.get(value, 0),
+                    total=group_total[value],
+                ),
+                small_sample=0 < group_total[value] < self._small_sample_threshold,
+            )
+            for value in sorted(group_total, key=self._group_sort_key)
+        ]
+        return ThemeDimensionBreakdown(dimension=dimension, groups=groups)
+
+    @staticmethod
+    def _group_value(data: dict[str, Any] | None, dimension: str) -> str:
+        if not data:
+            return NOT_SPECIFIED_LABEL
+        raw = data.get(dimension)
+        if raw is None:
+            return NOT_SPECIFIED_LABEL
+        text = str(raw).strip()
+        return text or NOT_SPECIFIED_LABEL
+
+    @staticmethod
+    def _group_sort_key(value: str) -> tuple[bool, str]:
+        # Keep the catch-all bucket last; order real groups alphabetically.
+        return (value == NOT_SPECIFIED_LABEL, value.lower())
+
+    @staticmethod
+    def _to_percentage(*, present: int, total: int) -> float:
+        if total <= 0:
+            return 0.0
+        return (present / total) * 100.0

--- a/Backend/tests/test_theme_demographic_breakdown_api.py
+++ b/Backend/tests/test_theme_demographic_breakdown_api.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import uuid
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models import (
+    Codebook,
+    CodebookApplicationRun,
+    CodebookThemeRelationship,
+    CorpusDocument,
+    DemographicFiles,
+    DemographicRow,
+    DocumentCoding,
+    Theme,
+    ThemeAssignment,
+)
+
+
+async def _seed(db_engine):
+    """Seed one corpus with a gender dimension and a theme present for some men."""
+    session_factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        corpus_id = uuid4()
+        codebook_id = uuid4()
+        theme_id = uuid4()
+        run_id = uuid4()
+        file_id = uuid4()
+
+        session.add(
+            Codebook(
+                id=codebook_id,
+                corpus_id=corpus_id,
+                name="Breakdown API",
+                description="Fixture",
+                version=1,
+                created_by="system",
+            )
+        )
+        session.add(Theme(id=theme_id, codebook_id=codebook_id, label="Theme A", is_active=True))
+        await session.flush()
+        session.add(
+            CodebookThemeRelationship(
+                id=uuid4(), codebook_id=codebook_id, theme_id=theme_id, is_active=True
+            )
+        )
+        session.add(
+            DemographicFiles(
+                id=file_id,
+                name="people.csv",
+                corpus_id=corpus_id,
+                original_columns=["username", "gender"],
+            )
+        )
+
+        people = {
+            "m1": "male",
+            "m2": "male",
+            "f1": "female",
+            "f2": "female",
+        }
+        present = {"m1", "f1", "f2"}
+        doc_ids = {}
+        for i, (person, gender) in enumerate(people.items(), start=1):
+            row_id = uuid4()
+            doc_id = uuid4()
+            doc_ids[person] = doc_id
+            session.add(
+                DemographicRow(
+                    id=row_id,
+                    demographic_file_id=file_id,
+                    corpus_id=corpus_id,
+                    row_number=i,
+                    interviewee_id=person,
+                    data={"gender": gender},
+                )
+            )
+            session.add(
+                CorpusDocument(
+                    id=doc_id,
+                    corpus_id=corpus_id,
+                    demographic_row_id=row_id,
+                    title=person,
+                    content="body",
+                )
+            )
+        await session.flush()
+
+        session.add(
+            CodebookApplicationRun(
+                id=run_id,
+                corpus_id=corpus_id,
+                codebook_id=codebook_id,
+                status="succeeded",
+                documents_total=len(people),
+                documents_coded=len(people),
+            )
+        )
+        await session.flush()
+        for person, doc_id in doc_ids.items():
+            coding_id = uuid4()
+            session.add(
+                DocumentCoding(
+                    id=coding_id,
+                    application_run_id=run_id,
+                    document_id=doc_id,
+                    codebook_id=codebook_id,
+                    status="coded",
+                )
+            )
+            await session.flush()
+            session.add(
+                ThemeAssignment(
+                    id=uuid4(),
+                    document_coding_id=coding_id,
+                    theme_id=theme_id,
+                    is_present=person in present,
+                    confidence=0.9,
+                )
+            )
+        await session.commit()
+        return corpus_id, codebook_id, theme_id
+
+
+async def test_dimensions_endpoint_lists_variables(client, db_engine):
+    corpus_id, _, _ = await _seed(db_engine)
+    response = await client.get(f"/api/v1/demographic/{corpus_id}/dimensions")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["data"]["dimensions"] == ["gender"]
+
+
+async def test_dimensions_endpoint_empty_when_no_data(client):
+    response = await client.get(f"/api/v1/demographic/{uuid.uuid4()}/dimensions")
+    assert response.status_code == 200
+    assert response.json()["data"]["dimensions"] == []
+
+
+async def test_breakdown_endpoint_returns_groups(client, db_engine):
+    _, codebook_id, theme_id = await _seed(db_engine)
+    response = await client.get(
+        f"/api/v1/codebooks/{codebook_id}/themes/{theme_id}/demographic-breakdown",
+        params={"dimensions": "gender"},
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data["dimensions"]) == 1
+    groups = {g["group_value"]: g for g in data["dimensions"][0]["groups"]}
+    assert groups["male"]["present_count"] == 1
+    assert groups["male"]["group_total"] == 2
+    assert groups["male"]["percentage"] == 50.0
+    assert groups["female"]["present_count"] == 2
+    assert groups["female"]["percentage"] == 100.0
+
+
+async def test_breakdown_endpoint_unknown_codebook_404(client):
+    response = await client.get(
+        f"/api/v1/codebooks/{uuid.uuid4()}/themes/{uuid.uuid4()}/demographic-breakdown",
+        params={"dimensions": "gender"},
+    )
+    assert response.status_code == 404
+
+
+async def test_breakdown_endpoint_no_dimensions_returns_empty(client, db_engine):
+    _, codebook_id, theme_id = await _seed(db_engine)
+    response = await client.get(
+        f"/api/v1/codebooks/{codebook_id}/themes/{theme_id}/demographic-breakdown",
+    )
+    assert response.status_code == 200
+    assert response.json()["data"]["dimensions"] == []

--- a/Backend/tests/test_theme_demographic_breakdown_service.py
+++ b/Backend/tests/test_theme_demographic_breakdown_service.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import (
+    Base,
+    Codebook,
+    CodebookApplicationRun,
+    CodebookThemeRelationship,
+    CorpusDocument,
+    DemographicFiles,
+    DemographicRow,
+    DocumentCoding,
+    Theme,
+    ThemeAssignment,
+)
+from app.services.theme_demographic_breakdown import (
+    NOT_SPECIFIED_LABEL,
+    ThemeDemographicBreakdownService,
+)
+from app.services.theme_graph import ThemeNotFoundError
+
+AIOSQLITE_AVAILABLE = importlib.util.find_spec("aiosqlite") is not None
+
+
+@dataclass
+class BreakdownSeed:
+    corpus_id: UUID
+    codebook_id: UUID
+    run_id: UUID
+    theme_ids: dict[str, UUID] = field(default_factory=dict)
+
+
+async def _seed_breakdown(
+    session: AsyncSession,
+    *,
+    columns: list[str],
+    # interviewee -> demographic data dict (or None to leave the transcript unlinked)
+    people: dict[str, dict | None],
+    theme_labels: list[str],
+    # theme label -> set of interviewees for whom the theme is present
+    present_by_theme: dict[str, set[str]],
+    run_status: str = "succeeded",
+) -> BreakdownSeed:
+    corpus_id = uuid4()
+    codebook_id = uuid4()
+    run_id = uuid4()
+
+    session.add(
+        Codebook(
+            id=codebook_id,
+            corpus_id=corpus_id,
+            name="Breakdown Codebook",
+            description="Fixture",
+            version=1,
+            created_by="system",
+        )
+    )
+    theme_ids = {label: uuid4() for label in theme_labels}
+    for label, theme_id in theme_ids.items():
+        session.add(Theme(id=theme_id, codebook_id=codebook_id, label=label, is_active=True))
+    await session.flush()
+    for theme_id in theme_ids.values():
+        session.add(
+            CodebookThemeRelationship(
+                id=uuid4(), codebook_id=codebook_id, theme_id=theme_id, is_active=True
+            )
+        )
+
+    demographic_file_id = uuid4()
+    session.add(
+        DemographicFiles(
+            id=demographic_file_id,
+            name="people.csv",
+            corpus_id=corpus_id,
+            original_columns=columns,
+        )
+    )
+
+    document_ids: dict[str, UUID] = {}
+    for row_number, (interviewee, data) in enumerate(people.items(), start=1):
+        document_id = uuid4()
+        document_ids[interviewee] = document_id
+        demographic_row_id: UUID | None = None
+        if data is not None:
+            demographic_row_id = uuid4()
+            session.add(
+                DemographicRow(
+                    id=demographic_row_id,
+                    demographic_file_id=demographic_file_id,
+                    corpus_id=corpus_id,
+                    row_number=row_number,
+                    interviewee_id=interviewee,
+                    data=data,
+                )
+            )
+        session.add(
+            CorpusDocument(
+                id=document_id,
+                corpus_id=corpus_id,
+                demographic_row_id=demographic_row_id,
+                title=interviewee,
+                content="transcript body",
+            )
+        )
+    await session.flush()
+
+    session.add(
+        CodebookApplicationRun(
+            id=run_id,
+            corpus_id=corpus_id,
+            codebook_id=codebook_id,
+            status=run_status,
+            documents_total=len(people),
+            documents_coded=len(people),
+        )
+    )
+    await session.flush()
+
+    for interviewee, document_id in document_ids.items():
+        coding_id = uuid4()
+        session.add(
+            DocumentCoding(
+                id=coding_id,
+                application_run_id=run_id,
+                document_id=document_id,
+                codebook_id=codebook_id,
+                status="coded",
+            )
+        )
+        await session.flush()
+        for label, theme_id in theme_ids.items():
+            session.add(
+                ThemeAssignment(
+                    id=uuid4(),
+                    document_coding_id=coding_id,
+                    theme_id=theme_id,
+                    is_present=interviewee in present_by_theme.get(label, set()),
+                    confidence=0.9,
+                )
+            )
+
+    await session.commit()
+    return BreakdownSeed(
+        corpus_id=corpus_id,
+        codebook_id=codebook_id,
+        run_id=run_id,
+        theme_ids=theme_ids,
+    )
+
+
+@unittest.skipUnless(AIOSQLITE_AVAILABLE, "These tests require aiosqlite.")
+class ThemeDemographicBreakdownServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.engine.dispose()
+
+    # --- available dimensions ------------------------------------------------
+
+    async def test_lists_available_dimensions_excluding_username(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender", "age_group", "party"],
+                people={"p1": {"gender": "male", "age_group": "18-29", "party": "A"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            dims = await ThemeDemographicBreakdownService(session).list_available_dimensions(
+                corpus_id=seed.corpus_id
+            )
+            self.assertEqual(dims, ["gender", "age_group", "party"])
+
+    async def test_no_demographic_data_yields_no_dimensions(self) -> None:
+        async with self.session_factory() as session:
+            # A corpus with no demographic files at all.
+            codebook_id = uuid4()
+            corpus_id = uuid4()
+            session.add(
+                Codebook(
+                    id=codebook_id,
+                    corpus_id=corpus_id,
+                    name="No Demo",
+                    description="Fixture",
+                    version=1,
+                    created_by="system",
+                )
+            )
+            await session.commit()
+            dims = await ThemeDemographicBreakdownService(session).list_available_dimensions(
+                corpus_id=corpus_id
+            )
+            self.assertEqual(dims, [])
+
+    # --- binary dimension (DoD: gender male/female) --------------------------
+
+    async def test_binary_dimension_counts_and_percentages(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={
+                    "m1": {"gender": "male"},
+                    "m2": {"gender": "male"},
+                    "f1": {"gender": "female"},
+                    "f2": {"gender": "female"},
+                },
+                theme_labels=["Theme A"],
+                # 50% of males, 100% of females
+                present_by_theme={"Theme A": {"m1", "f1", "f2"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+            )
+            self.assertEqual(len(result.dimensions), 1)
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(groups["male"].present_count, 1)
+            self.assertEqual(groups["male"].group_total, 2)
+            self.assertEqual(groups["male"].percentage, 50.0)
+            self.assertEqual(groups["female"].present_count, 2)
+            self.assertEqual(groups["female"].group_total, 2)
+            self.assertEqual(groups["female"].percentage, 100.0)
+
+    async def test_zero_occurrence_group_shown_with_count_zero(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={"m1": {"gender": "male"}, "f1": {"gender": "female"}},
+                # Theme present for nobody female
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"m1"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertIn("female", groups)
+            self.assertEqual(groups["female"].present_count, 0)
+            self.assertEqual(groups["female"].percentage, 0.0)
+
+    # --- multi-value dimension (DoD: political affiliation 4+ values) --------
+
+    async def test_multi_value_dimension(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "party"],
+                people={
+                    "a": {"party": "Green"},
+                    "b": {"party": "Liberal"},
+                    "c": {"party": "Conservative"},
+                    "d": {"party": "Socialist"},
+                    "e": {"party": "Green"},
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"a", "c"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["party"],
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(set(groups), {"Green", "Liberal", "Conservative", "Socialist"})
+            self.assertEqual(groups["Green"].group_total, 2)
+            self.assertEqual(groups["Green"].present_count, 1)
+            self.assertEqual(groups["Green"].percentage, 50.0)
+            self.assertEqual(groups["Liberal"].present_count, 0)
+
+    # --- multiple dimensions at once (DoD: 1, 3, 5+ dimensions) --------------
+
+    async def test_multiple_dimensions_returned_in_request_order(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender", "age_group", "party", "region", "education"],
+                people={
+                    "p1": {
+                        "gender": "male",
+                        "age_group": "18-29",
+                        "party": "Green",
+                        "region": "North",
+                        "education": "BSc",
+                    },
+                    "p2": {
+                        "gender": "female",
+                        "age_group": "30-44",
+                        "party": "Liberal",
+                        "region": "South",
+                        "education": "MSc",
+                    },
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            requested = ["party", "gender", "education", "region", "age_group"]
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=requested,
+            )
+            self.assertEqual([d.dimension for d in result.dimensions], requested)
+
+    async def test_unknown_dimension_is_ignored(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={"p1": {"gender": "male"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender", "not_a_real_column"],
+            )
+            self.assertEqual([d.dimension for d in result.dimensions], ["gender"])
+
+    # --- missing / unlinked data --------------------------------------------
+
+    async def test_unlinked_and_blank_values_bucket_into_not_specified(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={
+                    "linked": {"gender": "male"},
+                    "blank": {"gender": "  "},
+                    "missing_key": {"age": "40"},
+                    "unlinked": None,
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"linked", "unlinked"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(groups[NOT_SPECIFIED_LABEL].group_total, 3)
+            self.assertEqual(groups[NOT_SPECIFIED_LABEL].present_count, 1)
+            # Not specified is sorted last.
+            self.assertEqual(result.dimensions[0].groups[-1].group_value, NOT_SPECIFIED_LABEL)
+
+    # --- small sample --------------------------------------------------------
+
+    async def test_small_sample_flagged_below_threshold(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={
+                    "m1": {"gender": "male"},
+                    "m2": {"gender": "male"},
+                    "m3": {"gender": "male"},
+                    "m4": {"gender": "male"},
+                    "m5": {"gender": "male"},
+                    "f1": {"gender": "female"},
+                    "f2": {"gender": "female"},
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"m1"}},
+            )
+            result = await ThemeDemographicBreakdownService(
+                session, small_sample_threshold=5
+            ).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertFalse(groups["male"].small_sample)  # total 5, not < 5
+            self.assertTrue(groups["female"].small_sample)  # total 2 < 5
+
+    # --- run handling / errors ----------------------------------------------
+
+    async def test_no_run_returns_empty_groups_for_selected_dimensions(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={"m1": {"gender": "male"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"m1"}},
+                run_status="failed",  # no succeeded run to default to
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+            )
+            self.assertIsNone(result.application_run_id)
+            self.assertEqual(len(result.dimensions), 1)
+            self.assertEqual(result.dimensions[0].groups, [])
+
+    async def test_unknown_codebook_raises(self) -> None:
+        async with self.session_factory() as session:
+            with self.assertRaises(ThemeNotFoundError):
+                await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                    codebook_id=uuid4(),
+                    theme_id=uuid4(),
+                    dimensions=["gender"],
+                )
+
+    async def test_unknown_theme_raises(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={"m1": {"gender": "male"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"m1"}},
+            )
+            with self.assertRaises(ThemeNotFoundError):
+                await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                    codebook_id=seed.codebook_id,
+                    theme_id=uuid4(),
+                    dimensions=["gender"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -51,6 +51,9 @@ class FakeBackend:
         # Demographic data
         self.demographic_files: list[dict] = []
         self.demographic_rows: list[dict] = []
+        self.demographic_dimensions: list[str] = []
+        self.theme_demographic_breakdown: dict = {"theme_id": None, "dimensions": []}
+        self.last_breakdown_request: dict | None = None
         self.demographic_link_summary: dict = {
             "total_transcripts": 0,
             "matched": 0,
@@ -172,6 +175,26 @@ class FakeBackend:
     def get_theme_tree(self, codebook_id: str) -> list[dict]:
         self._maybe_raise("get_theme_tree")
         return self.theme_tree
+
+    def get_demographic_dimensions(self, corpus_id: str) -> list[str]:
+        self._maybe_raise("get_demographic_dimensions")
+        return self.demographic_dimensions
+
+    def get_theme_demographic_breakdown(
+        self,
+        codebook_id: str,
+        theme_id: str,
+        dimensions: list[str],
+        application_run_id: str | None = None,
+    ) -> dict:
+        self._maybe_raise("get_theme_demographic_breakdown")
+        self.last_breakdown_request = {
+            "codebook_id": codebook_id,
+            "theme_id": theme_id,
+            "dimensions": dimensions,
+            "application_run_id": application_run_id,
+        }
+        return self.theme_demographic_breakdown
 
     def create_codebook(self, *, corpus_id: str, name: str, themes: list[dict]) -> dict:
         self._maybe_raise("create_codebook")

--- a/Frontend/tests/test_codebook_breakdown.py
+++ b/Frontend/tests/test_codebook_breakdown.py
@@ -1,0 +1,125 @@
+"""Tests for the per-theme demographic breakdown wiring in the codebook
+controller: the themes page (dimension picker / disabled state) and the
+JSON proxy route used by theme_breakdown.js.
+"""
+from __future__ import annotations
+
+import json
+
+THEMES_PATH = "/codebooks/test-corpus-id/cb-1/themes"
+BREAKDOWN_JSON_PATH = (
+    "/codebooks/test-corpus-id/cb-1/themes/theme-1/demographic-breakdown.json"
+)
+
+
+def _seed_themes_page(fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "My Codebook", "version": 1, "corpus_id": "test-corpus-id"}
+    ]
+    fake_backend.theme_frequencies = [
+        {
+            "theme_id": "theme-1",
+            "theme_name": "Theme One",
+            "occurrence_count": 3,
+            "interview_coverage_percentage": 60.0,
+        }
+    ]
+    fake_backend.theme_tree = []
+
+
+# ---------------------------------------------------------------------------
+# Themes page: dimension picker vs disabled state
+# ---------------------------------------------------------------------------
+
+
+def test_themes_page_shows_dimension_picker_when_data_present(client, fake_backend):
+    _seed_themes_page(fake_backend)
+    fake_backend.demographic_dimensions = ["gender", "age_group"]
+
+    resp = client.get(THEMES_PATH)
+    assert resp.status_code == 200
+    assert b"Demographic Breakdown" in resp.data
+    assert b"data-breakdown-dimension" in resp.data
+    assert b"gender" in resp.data
+    assert b"age_group" in resp.data
+    assert b"No demographic data available" not in resp.data
+    # The dimensions are also embedded for the JS to read.
+    assert b"data-demographic-dimensions" in resp.data
+
+
+def test_themes_page_shows_disabled_state_when_no_data(client, fake_backend):
+    _seed_themes_page(fake_backend)
+    fake_backend.demographic_dimensions = []
+
+    resp = client.get(THEMES_PATH)
+    assert resp.status_code == 200
+    assert b"Demographic Breakdown" in resp.data
+    assert b"No demographic data available" in resp.data
+    assert b"data-breakdown-dimension" not in resp.data
+
+
+def test_themes_page_survives_dimensions_backend_error(client, fake_backend):
+    # A failure fetching dimensions must not break the themes page; it degrades
+    # to the disabled state.
+    _seed_themes_page(fake_backend)
+    fake_backend.raise_on = "get_demographic_dimensions"
+
+    resp = client.get(THEMES_PATH)
+    assert resp.status_code == 200
+    assert b"No demographic data available" in resp.data
+
+
+# ---------------------------------------------------------------------------
+# JSON proxy route
+# ---------------------------------------------------------------------------
+
+
+def test_breakdown_json_returns_payload(client, fake_backend):
+    fake_backend.theme_demographic_breakdown = {
+        "theme_id": "theme-1",
+        "application_run_id": "run-1",
+        "dimensions": [
+            {
+                "dimension": "gender",
+                "groups": [
+                    {
+                        "group_value": "male",
+                        "present_count": 1,
+                        "group_total": 2,
+                        "percentage": 50.0,
+                        "small_sample": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+    resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=gender&application_run_id=run-1")
+    assert resp.status_code == 200
+    payload = json.loads(resp.data)
+    assert payload["dimensions"][0]["dimension"] == "gender"
+    assert payload["dimensions"][0]["groups"][0]["percentage"] == 50.0
+    # The controller parses and forwards the comma-separated dimensions.
+    assert fake_backend.last_breakdown_request["dimensions"] == ["gender"]
+    assert fake_backend.last_breakdown_request["application_run_id"] == "run-1"
+
+
+def test_breakdown_json_parses_multiple_dimensions(client, fake_backend):
+    fake_backend.theme_demographic_breakdown = {"theme_id": "theme-1", "dimensions": []}
+    resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=gender,age_group,party")
+    assert resp.status_code == 200
+    assert fake_backend.last_breakdown_request["dimensions"] == ["gender", "age_group", "party"]
+
+
+def test_breakdown_json_handles_empty_dimensions(client, fake_backend):
+    fake_backend.theme_demographic_breakdown = {"theme_id": "theme-1", "dimensions": []}
+    resp = client.get(BREAKDOWN_JSON_PATH)
+    assert resp.status_code == 200
+    assert fake_backend.last_breakdown_request["dimensions"] == []
+
+
+def test_breakdown_json_surfaces_backend_error(client, fake_backend):
+    fake_backend.raise_on = "get_theme_demographic_breakdown"
+    resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=gender")
+    assert resp.status_code == 502
+    assert "error" in json.loads(resp.data)

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -298,6 +298,13 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         tree = client.get_theme_tree(active_codebook_id)
         codebook = client.get_codebook(active_codebook_id)
         codes = codebook.get("codes", [])
+
+        # Best-effort: demographic variables available for per-theme breakdowns.
+        # A failure here must not block the themes page, so default to none.
+        try:
+            demographic_dimensions = client.get_demographic_dimensions(active_corpus_id)
+        except BackendError:
+            demographic_dimensions = []
     except BackendNotFoundError as exc:
         flash(exc.user_message, "danger")
         return render_template(
@@ -316,6 +323,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             application_runs=application_runs,
             selected_application_run_id=selected_application_run_id,
             selected_application_run=selected_application_run,
+            demographic_dimensions=[],
             error=True,
         )
     except BackendError as exc:
@@ -336,6 +344,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             application_runs=application_runs,
             selected_application_run_id=selected_application_run_id,
             selected_application_run=selected_application_run,
+            demographic_dimensions=[],
             error=True,
         )
     return render_template(
@@ -354,7 +363,26 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         application_runs=application_runs,
         selected_application_run_id=selected_application_run_id,
         selected_application_run=selected_application_run,
+        demographic_dimensions=demographic_dimensions,
     )
+
+@bp.get("/<corpus_id>/<codebook_id>/themes/<theme_id>/demographic-breakdown.json")
+def theme_demographic_breakdown_json(corpus_id: str, codebook_id: str, theme_id: str):
+    dimensions = [d for d in request.args.get("dimensions", "").split(",") if d]
+    application_run_id = request.args.get("application_run_id") or None
+    try:
+        result = _backend().get_theme_demographic_breakdown(
+            codebook_id,
+            theme_id,
+            dimensions,
+            application_run_id=application_run_id,
+        )
+        return jsonify(result)
+    except BackendError as exc:
+        return jsonify({"error": exc.user_message}), 502
+    except Exception:
+        return jsonify({"error": "An unexpected error occurred."}), 500
+
 
 @bp.get("/<corpus_id>/<codebook_id>/themes/<theme_id>/quotes.json")
 def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -211,7 +211,30 @@ class BackendClient:
             params=params,
         )
 
+    def get_theme_demographic_breakdown(
+        self,
+        codebook_id: str,
+        theme_id: str,
+        dimensions: list[str],
+        application_run_id: str | None = None,
+    ) -> dict:
+        """Break a theme's frequency down by the given demographic dimensions."""
+        params: dict = {"dimensions": ",".join(dimensions)}
+        if application_run_id:
+            params["application_run_id"] = application_run_id
+        return self._get(
+            f"/codebooks/{codebook_id}/themes/{theme_id}/demographic-breakdown",
+            params=params,
+        )
+
     # ---- Demographic --------------------------------------------------------
+
+    def get_demographic_dimensions(self, corpus_id: str) -> list[str]:
+        """List demographic variables available for breaking down a theme."""
+        return self._get(
+            f"/demographic/{corpus_id}/dimensions",
+            sub_key="dimensions",
+        )
 
     def upload_demographic(
         self, corpus_id: str, file: FileStorage, name: str | None = None,

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -245,6 +245,89 @@
 /* 67–100 %: prevalent — emerald */
 .theme-progress-bar--high { background: linear-gradient(90deg, #059669, #34d399); }
 
+/* ── Demographic breakdown (UC 3.6) ─────────────────────────────────────────── */
+.breakdown-dimension { margin-bottom: 1.5rem; }
+.breakdown-dimension:last-of-type { margin-bottom: 0; }
+
+.breakdown-dim-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #4f46e5;
+    margin-bottom: 0.6rem;
+}
+
+.breakdown-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.breakdown-row {
+    display: grid;
+    grid-template-columns: minmax(90px, 160px) 1fr;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.breakdown-row-label {
+    font-size: 0.82rem;
+    color: #374151;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.breakdown-track {
+    position: relative;
+    height: 20px;
+    background: #eef2ff;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.breakdown-bar {
+    height: 100%;
+    border-radius: 6px;
+    background: linear-gradient(90deg, #4338ca, #6366f1);
+    transition: width 0.4s ease;
+    min-width: 2px;
+}
+
+.breakdown-bar-value {
+    font-size: 0.75rem;
+    color: #1e1b4b;
+    margin-left: 0.5rem;
+    white-space: nowrap;
+}
+
+.breakdown-table th {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
+}
+
+.breakdown-small-sample {
+    display: inline-block;
+    font-size: 0.66rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #92400e;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-radius: 10px;
+    padding: 1px 7px;
+    margin-left: 6px;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
 /* ── Tree with connector lines (file-explorer style) ────────────────────────── */
 .tree-container {
     flex: 1 1 auto;

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -193,6 +193,14 @@
     // Detail panel
     // ------------------------------------------------------------------
 
+    // Broadcast theme selection so sibling modules (e.g. the demographic
+    // breakdown panel) can react. A global mirror covers the boot race where a
+    // listener attaches after the initial auto-selection has already fired.
+    function announceSelectedTheme(detail) {
+        window.__ataCurrentTheme = detail.themeId ? detail : null;
+        document.dispatchEvent(new CustomEvent("theme:selected", { detail }));
+    }
+
     function clearThemeDetails() {
         selectedThemeId = null;
         themeDetailsEmpty.classList.remove("d-none");
@@ -202,6 +210,7 @@
         themeDetailsId.textContent          = "";
         themeDetailsOccur.textContent       = "";
         themeDetailsCoverage.textContent    = "";
+        announceSelectedTheme({ themeId: null, themeName: "" });
     }
 
     // Sync the visual selection highlight across both the table and tree.
@@ -232,6 +241,7 @@
         themeDetailsOccur.textContent    = String(info.occurrence_count ?? 0);
         themeDetailsCoverage.textContent = formatCoverage(info.interview_coverage_percentage ?? 0);
         highlightSelectedRow();
+        announceSelectedTheme({ themeId, themeName: info.theme_name ?? "" });
     }
 
     // ------------------------------------------------------------------

--- a/Frontend/web/static/js/theme_breakdown.js
+++ b/Frontend/web/static/js/theme_breakdown.js
@@ -1,0 +1,317 @@
+(function () {
+    // Per-theme demographic breakdown panel (UC 3.6).
+    //
+    // Listens for the `theme:selected` event from codebook_themes.js, lets the
+    // researcher pick demographic dimensions (selection persisted per theme via
+    // localStorage), fetches the breakdown, and renders a table + horizontal bar
+    // chart per dimension. All user-supplied values are written with textContent
+    // / dataset, never innerHTML, so theme/group labels cannot inject markup.
+
+    const appRoot = document.getElementById("theme-app");
+    if (!appRoot) return;
+
+    let dimensions = [];
+    try {
+        dimensions = JSON.parse(appRoot.dataset.demographicDimensions || "[]");
+    } catch (_) {
+        dimensions = [];
+    }
+    // No demographic data → the panel renders a disabled explanation server-side
+    // and there is nothing to wire up here.
+    if (!Array.isArray(dimensions) || dimensions.length === 0) return;
+
+    const breakdownUrlTemplate = appRoot.dataset.breakdownUrlTemplate || "";
+    const applicationRunId     = appRoot.dataset.applicationRunId || "";
+    const codebookId           = appRoot.dataset.codebookId || "";
+
+    const picker     = document.getElementById("breakdown-dimension-picker");
+    const emptyEl    = document.getElementById("breakdown-empty");
+    const loadingEl  = document.getElementById("breakdown-loading");
+    const errorEl    = document.getElementById("breakdown-error");
+    const resultsEl  = document.getElementById("breakdown-results");
+    const themeNameEl = document.getElementById("breakdown-theme-name");
+    const checkboxes = Array.from(document.querySelectorAll("[data-breakdown-dimension]"));
+
+    if (!picker || !resultsEl || checkboxes.length === 0) return;
+
+    let currentThemeId   = null;
+    let currentThemeName = "";
+    let requestToken     = 0;
+
+    // ------------------------------------------------------------------
+    // Per-theme selection persistence
+    // ------------------------------------------------------------------
+
+    function storageKey(themeId) {
+        return `ata-breakdown:${codebookId}:${applicationRunId}:${themeId}`;
+    }
+
+    function loadSelection(themeId) {
+        if (!themeId) return [];
+        try {
+            const raw = window.localStorage.getItem(storageKey(themeId));
+            const parsed = raw ? JSON.parse(raw) : [];
+            return Array.isArray(parsed) ? parsed.filter((d) => dimensions.includes(d)) : [];
+        } catch (_) {
+            return [];
+        }
+    }
+
+    function saveSelection(themeId, selected) {
+        if (!themeId) return;
+        try {
+            window.localStorage.setItem(storageKey(themeId), JSON.stringify(selected));
+        } catch (_) {
+            // Storage may be unavailable (private mode); selection stays in-memory.
+        }
+    }
+
+    function selectedDimensions() {
+        return checkboxes.filter((cb) => cb.checked).map((cb) => cb.value);
+    }
+
+    function applySelectionToCheckboxes(selected) {
+        const set = new Set(selected);
+        checkboxes.forEach((cb) => { cb.checked = set.has(cb.value); });
+    }
+
+    // ------------------------------------------------------------------
+    // State / rendering helpers
+    // ------------------------------------------------------------------
+
+    function setState(opts) {
+        const { empty = false, loading = false, error = null } = opts || {};
+        emptyEl.classList.toggle("d-none", !empty);
+        loadingEl.classList.toggle("d-none", !loading);
+        if (error) {
+            errorEl.textContent = error;
+            errorEl.classList.remove("d-none");
+        } else {
+            errorEl.classList.add("d-none");
+        }
+        if (empty || loading || error) resultsEl.replaceChildren();
+    }
+
+    function breakdownUrl(themeId, dims) {
+        const url = new URL(
+            breakdownUrlTemplate.replace("__THEME__", themeId),
+            window.location.origin
+        );
+        url.searchParams.set("dimensions", dims.join(","));
+        if (applicationRunId) url.searchParams.set("application_run_id", applicationRunId);
+        return url.toString();
+    }
+
+    function clampPct(value) {
+        const num = typeof value === "number" ? value : 0;
+        return Math.min(Math.max(num, 0), 100);
+    }
+
+    function formatPct(value) {
+        return (typeof value === "number" ? value : 0).toFixed(1) + "%";
+    }
+
+    function smallSampleBadge() {
+        const badge = document.createElement("span");
+        badge.className = "breakdown-small-sample";
+        badge.textContent = "small sample";
+        badge.title = "Few interviews in this group; percentage may be unreliable.";
+        return badge;
+    }
+
+    function renderChart(groups) {
+        const chart = document.createElement("div");
+        chart.className = "breakdown-chart";
+
+        for (const group of groups) {
+            const row = document.createElement("div");
+            row.className = "breakdown-row";
+
+            const label = document.createElement("div");
+            label.className = "breakdown-row-label";
+            label.textContent = group.group_value;
+            label.title = group.group_value;
+            row.appendChild(label);
+
+            const right = document.createElement("div");
+            right.className = "d-flex align-items-center";
+
+            const track = document.createElement("div");
+            track.className = "breakdown-track flex-grow-1";
+            const bar = document.createElement("div");
+            bar.className = "breakdown-bar";
+            bar.style.width = clampPct(group.percentage) + "%";
+            track.appendChild(bar);
+            right.appendChild(track);
+
+            const value = document.createElement("span");
+            value.className = "breakdown-bar-value";
+            value.textContent =
+                `${formatPct(group.percentage)} (${group.present_count}/${group.group_total})`;
+            right.appendChild(value);
+
+            row.appendChild(right);
+            chart.appendChild(row);
+        }
+        return chart;
+    }
+
+    function renderTable(groups) {
+        const wrap = document.createElement("div");
+        wrap.className = "table-responsive";
+
+        const table = document.createElement("table");
+        table.className = "table table-sm align-middle mb-0 breakdown-table";
+
+        const thead = document.createElement("thead");
+        const headRow = document.createElement("tr");
+        ["Group", "Count", "Group total", "% within group"].forEach((text, idx) => {
+            const th = document.createElement("th");
+            th.textContent = text;
+            if (idx > 0) th.className = "text-end";
+            headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        for (const group of groups) {
+            const tr = document.createElement("tr");
+
+            const groupCell = document.createElement("td");
+            groupCell.textContent = group.group_value;
+            if (group.small_sample) groupCell.appendChild(smallSampleBadge());
+            tr.appendChild(groupCell);
+
+            const countCell = document.createElement("td");
+            countCell.className = "text-end";
+            countCell.textContent = String(group.present_count);
+            if (group.present_count === 0) countCell.classList.add("theme-zero");
+            tr.appendChild(countCell);
+
+            const totalCell = document.createElement("td");
+            totalCell.className = "text-end";
+            totalCell.textContent = String(group.group_total);
+            tr.appendChild(totalCell);
+
+            const pctCell = document.createElement("td");
+            pctCell.className = "text-end";
+            pctCell.textContent = formatPct(group.percentage);
+            tr.appendChild(pctCell);
+
+            tbody.appendChild(tr);
+        }
+        table.appendChild(tbody);
+        wrap.appendChild(table);
+        return wrap;
+    }
+
+    function renderDimension(dim) {
+        const wrap = document.createElement("div");
+        wrap.className = "breakdown-dimension";
+
+        const title = document.createElement("p");
+        title.className = "breakdown-dim-title";
+        title.textContent = dim.dimension;
+        wrap.appendChild(title);
+
+        const groups = dim.groups || [];
+        if (groups.length === 0) {
+            const none = document.createElement("p");
+            none.className = "text-secondary small mb-0";
+            none.textContent = "No coded interviews for this variable in the selected run.";
+            wrap.appendChild(none);
+            return wrap;
+        }
+
+        wrap.appendChild(renderChart(groups));
+        wrap.appendChild(renderTable(groups));
+        return wrap;
+    }
+
+    function renderResults(data) {
+        setState({});
+        resultsEl.replaceChildren();
+
+        const dims = data.dimensions || [];
+        if (dims.length === 0) {
+            setState({ empty: true });
+            return;
+        }
+
+        let anySmallSample = false;
+        for (const dim of dims) {
+            resultsEl.appendChild(renderDimension(dim));
+            if ((dim.groups || []).some((g) => g.small_sample)) anySmallSample = true;
+        }
+
+        if (anySmallSample) {
+            const note = document.createElement("p");
+            note.className = "text-secondary small mt-2 mb-0";
+            note.textContent =
+                "⚠ Groups marked “small sample” have very few interviews; " +
+                "read their percentages with caution.";
+            resultsEl.appendChild(note);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Fetch
+    // ------------------------------------------------------------------
+
+    async function refresh() {
+        const dims = selectedDimensions();
+        if (currentThemeId) saveSelection(currentThemeId, dims);
+
+        if (!currentThemeId || dims.length === 0) {
+            setState({ empty: true });
+            return;
+        }
+
+        const token = ++requestToken;
+        setState({ loading: true });
+
+        try {
+            const response = await fetch(breakdownUrl(currentThemeId, dims));
+            const data = await response.json();
+            if (token !== requestToken) return; // a newer request superseded this one
+            if (!response.ok || data.error) {
+                throw new Error(data.error || "HTTP " + response.status);
+            }
+            renderResults(data);
+        } catch (err) {
+            if (token !== requestToken) return;
+            setState({ error: "Could not load breakdown: " + err.message });
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Wiring
+    // ------------------------------------------------------------------
+
+    function onThemeChange(themeId, themeName) {
+        currentThemeId = themeId || null;
+        currentThemeName = themeName || "";
+        if (themeNameEl) {
+            themeNameEl.textContent = currentThemeName || "the selected theme";
+        }
+        applySelectionToCheckboxes(loadSelection(currentThemeId));
+        refresh();
+    }
+
+    checkboxes.forEach((cb) => cb.addEventListener("change", refresh));
+
+    document.addEventListener("theme:selected", (event) => {
+        const detail = event.detail || {};
+        onThemeChange(detail.themeId, detail.themeName);
+    });
+
+    // Cover the boot race: codebook_themes.js auto-selects the top theme during
+    // its own IIFE, which may run before this listener is attached.
+    const initial = window.__ataCurrentTheme;
+    if (initial && initial.themeId) {
+        onThemeChange(initial.themeId, initial.themeName);
+    } else {
+        setState({ empty: true });
+    }
+})();

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -10,7 +10,9 @@
      data-codebook-id="{{ codebook_id }}"
      data-corpus-id="{{ corpus_id }}"
      data-application-run-id="{{ selected_application_run_id or '' }}"
+     data-demographic-dimensions='{{ (demographic_dimensions or []) | tojson }}'
      data-quotes-url-template="{{ url_for('codebooks.theme_quotes_json', corpus_id=corpus_id, codebook_id=codebook_id, theme_id='__THEME__') }}"
+     data-breakdown-url-template="{{ url_for('codebooks.theme_demographic_breakdown_json', corpus_id=corpus_id, codebook_id=codebook_id, theme_id='__THEME__') }}"
      data-read-url-template="{{ url_for('ingestion.read_transcript', corpus_id=corpus_id, document_id='__DOC__') }}">
 
   {% if corpus_id and corpus_options %}
@@ -220,6 +222,51 @@
 
     </div>
 
+    {# Demographic breakdown (UC 3.6) — per-theme, driven by the selected theme #}
+    <div class="row g-3 mt-1">
+      <div class="col-12">
+        <div class="bg-white border rounded-3 p-3">
+          <h2 class="h6 panel-title">Demographic Breakdown</h2>
+
+          {% if demographic_dimensions %}
+            <p class="text-secondary small mb-2">
+              Choose one or more demographic variables to see how
+              <span id="breakdown-theme-name" class="fw-semibold">the selected theme</span>'s
+              frequency differs across groups. Your selection applies to this theme only.
+            </p>
+
+            <div id="breakdown-dimension-picker" class="d-flex flex-wrap gap-3 mb-3">
+              {% for dim in demographic_dimensions %}
+                <div class="form-check form-check-inline m-0">
+                  <input class="form-check-input" type="checkbox"
+                         id="breakdown-dim-{{ loop.index }}"
+                         value="{{ dim }}" data-breakdown-dimension>
+                  <label class="form-check-label" for="breakdown-dim-{{ loop.index }}">{{ dim }}</label>
+                </div>
+              {% endfor %}
+            </div>
+
+            <p id="breakdown-empty" class="text-secondary mb-0 text-center py-3">
+              Select a theme and at least one demographic variable to see the breakdown.
+            </p>
+            <div id="breakdown-loading" class="d-none text-center py-4">
+              <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading breakdown…</span>
+              </div>
+            </div>
+            <div id="breakdown-error" class="d-none alert alert-danger" role="alert"></div>
+            <div id="breakdown-results"></div>
+          {% else %}
+            <div class="alert alert-secondary mb-0" role="status">
+              <strong>No demographic data available.</strong>
+              Upload a demographic CSV for this corpus and link it to your transcripts to
+              break themes down by variables such as age, gender, or political affiliation.
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
   {% else %}
     <p class="text-secondary">No themes found for this codebook.</p>
   {% endif %}
@@ -260,4 +307,5 @@
 {% block scripts %}
 
 <script src="{{ url_for('static', filename='js/codebook_themes.js') }}"></script>
+<script src="{{ url_for('static', filename='js/theme_breakdown.js') }}"></script>
 {% endblock %}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ The **Automated Thematic Analysis** project is designed to automate the extracti
 
 By mapping documents and extracted text chunks to a hierarchical thematic tree (Codebook), the system enables structured qualitative analysis, thematic frequency tracking, and deeper insights into your data corpora.
 
+### Demographic Breakdown
+
+When demographic data (a CSV linked to your transcripts) is uploaded for a corpus, the Theme Browser lets researchers break a theme's frequency down by demographic group:
+
+- **Choose variables per theme** — pick one or more demographic dimensions (e.g. gender, age group, political affiliation) from the variables present in the uploaded data. Only variables that exist in the data are offered, and the selection applies to the selected theme only (changeable at any time). If no demographic data is uploaded, the panel is shown in a disabled state with an explanation.
+- **See frequency across groups** — for each selected dimension, the theme's frequency is shown per group as both an absolute count and a percentage within that group, rendered as a table and bar chart. Groups with no occurrences are shown with a count of 0, very small groups are flagged with a small-sample warning, and interviews without a linked demographic value are bucketed as "Not specified". The breakdown updates immediately as dimensions are toggled.
+
 ## Built With
 
 - **Backend Framework:** FastAPI (Python 3.11+)


### PR DESCRIPTION
Let researchers break a theme's frequency down by demographic group on the Theme Browser page.

Backend
- New ThemeDemographicBreakdownService: derives available dimensions from a corpus's demographic files (excluding the username identifier) and computes, per dimension, group present/total counts and percentage within group.
- Population is the run's coded interviews; unlinked/blank values bucket into 'Not specified', zero-occurrence groups are kept, and groups below DEMOGRAPHIC_SMALL_SAMPLE_THRESHOLD are flagged. Aggregation is done in Python for Postgres/SQLite portability.
- New endpoints: GET /codebooks/{id}/themes/{theme_id}/demographic-breakdown and GET /demographic/{corpus_id}/dimensions.

Frontend
- Theme Browser gains a Demographic Breakdown panel: per-theme dimension picker (selection persisted per theme in localStorage), or a disabled state with explanation when no demographic data exists.
- theme_breakdown.js renders a table + CSS bar charts (XSS-safe DOM), shows a small-sample warning, and updates immediately on selection change via a theme:selected event from codebook_themes.js.

Tests: 12 service + 5 API (backend), 7 controller/proxy (frontend).