### PR TITLE
230 popup window for transcripts in analysis run

### DIFF
--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -1,3 +1,5 @@
+import re
+
 
 def test_analysis_index_no_corpus(client, fake_backend):
     # Setup state to simulate backend failure which results in no active corpus
@@ -202,3 +204,69 @@ def test_delete_selected_runs_backend_error_is_flashed(client, fake_backend):
     assert resp.status_code == 302
     follow = client.get(resp.headers["Location"])
     assert b"simulated delete_codebook_application_run failure" in follow.data
+
+
+def test_previous_runs_transcript_count_and_popup_trigger(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    fake_backend.documents = [
+        {"id": "doc1", "title": "Interview Alpha"},
+        {"id": "doc2", "title": "Interview Beta"},
+    ]
+    fake_backend.application_runs[0]["transcript_document_ids"] = ["doc1", "doc2"]
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.get("/analysis/")
+    assert resp.status_code == 200
+    body = resp.data
+    # The old hard-to-scroll dropdown is gone entirely.
+    assert b"dropdown" not in body
+    # Transcripts column shows a bare integer count.
+    assert re.search(rb'<td class="text-secondary">\s*2\s*</td>', body)
+    # Succeeded run gets a View Transcripts trigger wired to its run id...
+    assert b"View Transcripts" in body
+    assert b'data-view-transcripts' in body
+    assert b'data-run-id="run1"' in body
+    # ...but the failed run does not.
+    assert b'aria-label="View transcripts used in analysis run Second Run"' not in body
+    # Shared modal skeleton + read-URL template are on the page.
+    assert b'id="runTranscriptsModal"' in body
+    assert b'id="runTranscriptsSearch"' in body
+    assert b"__DOC__" in body and b"__RUN__" in body
+    # Resolved titles are serialized into previousRuns for the modal JS.
+    assert b"transcript_docs" in body
+    assert b"Interview Alpha" in body
+    assert b"Interview Beta" in body
+
+
+def test_previous_runs_transcript_title_fallback_for_unknown_doc(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    fake_backend.documents = [{"id": "other-doc", "title": "Interview Alpha"}]
+    fake_backend.application_runs[0]["transcript_document_ids"] = ["doc-gone-12345"]
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.get("/analysis/")
+    assert resp.status_code == 200
+    body = resp.data
+    # Unknown ids fall back to a shortened id (tojson may escape the ellipsis).
+    assert (b"doc-gone\\u2026" in body) or ("doc-gone…".encode() in body)
+
+
+def test_previous_runs_without_transcripts_show_dash(client, fake_backend):
+    corpus_id = _ready_corpus_with_runs(fake_backend)
+    fake_backend.application_runs = [
+        {"id": "run3", "codebook_id": "cb1", "name": "Running Run",
+         "custom_id": "RUN-003", "status": "running",
+         "created_at": "2026-01-03T00:00:00", "transcript_document_ids": []},
+    ]
+    with client.session_transaction() as sess:
+        sess["active_corpus_id"] = corpus_id
+
+    resp = client.get("/analysis/")
+    assert resp.status_code == 200
+    body = resp.data
+    # No trigger button is rendered (data-run-id is unique to it); the shared
+    # modal skeleton and its JS may still be present on the page.
+    assert b"data-run-id=" not in body
+    assert re.search(rb'<td class="text-secondary">\s*<span class="text-muted small">', body)

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -68,12 +68,24 @@ def index() -> str:
                 else:
                     can_run_analysis = True
                 
+                # Resolve transcript titles once; runs reference documents by id.
+                title_by_id = {d["id"]: d.get("title") for d in transcripts}
+
                 # Fetch runs for all codebooks
                 for cb in codebooks:
                     runs = client.list_codebook_application_runs(cb["id"])
-                    # Attach codebook name to each run for display
+                    # Attach codebook name and resolved transcript titles to
+                    # each run for display (count column + View Transcripts
+                    # modal; also serialized into the page's previousRuns JS).
                     for r in runs:
                         r["codebook_name"] = cb["name"]
+                        r["transcript_docs"] = [
+                            {
+                                "id": doc_id,
+                                "title": title_by_id.get(doc_id) or f"{doc_id[:8]}…",
+                            }
+                            for doc_id in (r.get("transcript_document_ids") or [])
+                        ]
                     previous_runs.extend(runs)
                 
                 # Sort runs by created_at descending

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -934,3 +934,73 @@
   max-height: 70vh;
   overflow-y: auto;
 }
+
+/* ── Analysis run transcripts popup (View Transcripts) ─────────────────────
+   Teal family — matches .btn-teal / .metric-card--teal — so the trigger and
+   modal read as their own feature, distinct from the indigo View Analysis. */
+.btn-outline-teal {
+    color: #0d9488;
+    border: 1px solid #0d9488;
+    background: transparent;
+    font-weight: 500;
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.18s ease;
+}
+.btn-outline-teal:hover,
+.btn-outline-teal:focus {
+    background: #0d9488;
+    color: #fff;
+    box-shadow: 0 6px 14px -6px rgba(13, 148, 136, 0.45);
+}
+.btn-outline-teal:active {
+    transform: translateY(1px);
+    box-shadow: none;
+}
+
+.transcripts-modal-header {
+    background: linear-gradient(135deg, #0f766e, #14b8a6);
+    border-bottom: 0;
+}
+.transcripts-modal-header .modal-title { color: #fff; }
+
+/* Pill count — same recipe as .analysis-run-badge on the theme page. */
+.transcripts-modal-count {
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    white-space: nowrap;
+}
+
+/* Search sits on the gradient; mirror the .analysis-run-control treatment. */
+.transcripts-modal-search {
+    border-color: rgba(255, 255, 255, 0.38);
+    box-shadow: none;
+}
+.transcripts-modal-search:focus {
+    border-color: #fff;
+    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.24);
+}
+
+.transcript-link {
+    display: block;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #e2e8f0;
+    border-left: 3px solid transparent;
+    border-radius: 0.5rem;
+    color: #334155;
+    background: #fff;
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease,
+                color 0.15s ease, transform 0.12s ease;
+}
+.transcript-link:hover,
+.transcript-link:focus {
+    background: #f0fdfa;
+    border-color: #99f6e4;
+    border-left-color: #0d9488;
+    color: #0f766e;
+    transform: translateX(2px);
+}

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -192,27 +192,9 @@
                   &mdash;
                 {% endif %}
               </td>
-              <td>
-                {% if run.status == 'succeeded' and active_corpus_id and run.transcript_document_ids %}
-                  {% set doc_ids = run.transcript_document_ids %}
-                  <div class="dropdown">
-                    <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
-                            data-bs-toggle="dropdown" aria-expanded="false">
-                      {{ doc_ids | length }} transcript{{ 's' if doc_ids | length != 1 else '' }}
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-end" style="max-height: 260px; overflow-y: auto;">
-                      {% for doc_id in doc_ids %}
-                        {% set matched = transcripts | selectattr('id', 'equalto', doc_id) | list %}
-                        {% set doc_title = matched[0].title if matched else (doc_id[:8] + '…') %}
-                        <li>
-                          <a class="dropdown-item small"
-                             href="{{ url_for('ingestion.read_transcript', corpus_id=active_corpus_id, document_id=doc_id, run_id=run.id) }}">
-                            {{ doc_title }}
-                          </a>
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  </div>
+              <td class="text-secondary">
+                {% if run.transcript_docs %}
+                  {{ run.transcript_docs | length }}
                 {% else %}
                   <span class="text-muted small">—</span>
                 {% endif %}
@@ -222,6 +204,15 @@
                    href="{{ url_for('codebooks.codebook_themes_for_corpus', corpus_id=active_corpus_id, codebook_id=run.codebook_id, application_run_id=run.id) }}">
                   View Analysis
                 </a>
+                {% if run.status == 'succeeded' and active_corpus_id and run.transcript_docs %}
+                  <button type="button"
+                          class="btn btn-sm btn-outline-teal"
+                          data-view-transcripts
+                          data-run-id="{{ run.id }}"
+                          aria-label="View transcripts used in analysis run {{ run.name or run.custom_id or run.id }}">
+                    View Transcripts
+                  </button>
+                {% endif %}
               </td>
             </tr>
             {% endfor %}
@@ -329,6 +320,39 @@
     </div>
   </div>
 </div>
+
+{% if active_corpus_id %}
+<!-- Transcripts-in-run modal: one shared instance, populated on demand from
+     the previousRuns data already serialized for the duplicate-run check. -->
+<div class="modal fade" id="runTranscriptsModal" tabindex="-1"
+     aria-labelledby="runTranscriptsModalTitle" aria-hidden="true"
+     data-read-url-template="{{ url_for('ingestion.read_transcript', corpus_id=active_corpus_id, document_id='__DOC__', run_id='__RUN__') }}">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      {# Search lives in the header so it stays fixed while the body scrolls. #}
+      <div class="modal-header transcripts-modal-header flex-wrap gap-2">
+        <h5 class="modal-title" id="runTranscriptsModalTitle">Transcripts</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+        <div class="w-100 d-flex align-items-center gap-2">
+          <input type="search" id="runTranscriptsSearch"
+                 class="form-control form-control-sm transcripts-modal-search"
+                 placeholder="Search transcripts…" aria-label="Search transcripts">
+          <span id="runTranscriptsCount" class="transcripts-modal-count"></span>
+        </div>
+      </div>
+      <div class="modal-body">
+        <div id="runTranscriptsList" class="row row-cols-1 row-cols-md-2 g-2"></div>
+        <p id="runTranscriptsEmpty" class="text-secondary text-center py-3 mb-0 d-none">
+          No transcripts match your search.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}
@@ -395,6 +419,67 @@
         duplicateModal.hide();
         form.submit();
       });
+    }
+
+    /* ── View Transcripts modal ──────────────────────────────────────────
+     * One shared modal for every run row. On click, the run is looked up in
+     * the previousRuns constant above and its transcript_docs (id + resolved
+     * title, decorated by the controller) are rendered as links into the
+     * interview reader with run_id so theme highlights auto-select there.
+     * Everything is written via textContent — titles are user-supplied. */
+    const transcriptsModalEl = document.getElementById('runTranscriptsModal');
+    if (transcriptsModalEl) {
+      const transcriptsModal = new bootstrap.Modal(transcriptsModalEl);
+      const listEl   = document.getElementById('runTranscriptsList');
+      const searchEl = document.getElementById('runTranscriptsSearch');
+      const titleEl  = document.getElementById('runTranscriptsModalTitle');
+      const countEl  = document.getElementById('runTranscriptsCount');
+      const emptyEl  = document.getElementById('runTranscriptsEmpty');
+      const readUrlTemplate = transcriptsModalEl.dataset.readUrlTemplate;
+
+      function renderTranscriptList(docs, runId, filter) {
+        const needle = (filter || '').trim().toLowerCase();
+        const visible = needle
+          ? docs.filter((d) => (d.title || '').toLowerCase().includes(needle))
+          : docs;
+        listEl.replaceChildren();
+        for (const doc of visible) {
+          const col = document.createElement('div');
+          col.className = 'col';
+          const link = document.createElement('a');
+          link.className = 'transcript-link small text-truncate';
+          link.href = readUrlTemplate
+            .replace('__DOC__', encodeURIComponent(doc.id))
+            .replace('__RUN__', encodeURIComponent(runId));
+          link.textContent = doc.title;
+          link.title = doc.title;
+          col.appendChild(link);
+          listEl.appendChild(col);
+        }
+        emptyEl.classList.toggle('d-none', visible.length > 0);
+        countEl.textContent = needle
+          ? 'Showing ' + visible.length + ' of ' + docs.length
+          : docs.length + ' transcript' + (docs.length === 1 ? '' : 's');
+      }
+
+      document.querySelectorAll('[data-view-transcripts]').forEach((btn) => {
+        btn.addEventListener('click', function () {
+          const run = previousRuns.find((r) => r.id === btn.dataset.runId);
+          if (!run) return;
+          const docs = [...(run.transcript_docs || [])].sort((a, b) =>
+            (a.title || '').localeCompare(b.title || '', undefined, { sensitivity: 'base' })
+          );
+          titleEl.textContent =
+            'Transcripts — ' + (run.name || run.custom_id || run.id.slice(0, 8) + '…');
+          searchEl.value = '';
+          renderTranscriptList(docs, run.id, '');
+          /* Re-assign (not addEventListener) so re-opens don't stack handlers. */
+          searchEl.oninput = () => renderTranscriptList(docs, run.id, searchEl.value);
+          transcriptsModal.show();
+        });
+      });
+
+      transcriptsModalEl.addEventListener('shown.bs.modal', () => searchEl.focus());
     }
   });
 </script>


### PR DESCRIPTION

## Closes #230.

Replaces the hard-to-scroll transcripts dropdown in the **Previous Analysis Runs** table with a searchable pop-up window. The Transcripts column now shows a plain count, and each succeeded run gets a **View Transcripts** button that opens a modal listing every transcript used in that run built to stay comfortable at 100+ transcripts.

## How it works for the user

- The Transcripts column shows just the number of transcripts used in the run.
- A teal **View Transcripts** button (next to *View Analysis*) opens a pop-up with all transcripts of that run.
- Inside the pop-up:
  - A **search box** (fixed in the header, auto-focused) filters the list as you type, with a live "Showing X of Y" counter and an empty state when nothing matches.
  - Transcripts are listed **alphabetically in two columns** on wider screens, so long lists stay scannable.
  - Clicking a transcript opens it in the interview reader **with the run pre-selected**, so theme highlights from that analysis show up right away (same behavior as the old dropdown links).
- The modal scrolls natively at any list length (`modal-dialog-scrollable`) no more cramped 260px dropdown.


<img width="1287" height="484" alt="image" src="https://github.com/user-attachments/assets/0aceabe0-b993-4fcb-9756-5f5e0ebd15aa" />

<img width="852" height="374" alt="image" src="https://github.com/user-attachments/assets/479870fb-98da-42b7-90a2-a38dd3aa5310" />


## What changed

**Frontend only — no backend/API changes.**

- **Controller (`analysis.py`):** runs are decorated once with `transcript_docs` (document id + resolved title, falling back to a shortened id for deleted documents). This replaces the template's per-row `selectattr` scans and flows automatically into the `previousRuns` JSON the page already serializes for the duplicate-run check — so the modal needs no extra endpoint or payload.
- **Template (`analysis/index.html`):** dropdown removed; count cell + trigger button added; one shared modal for all rows (populated on demand via a small script that builds DOM nodes with `textContent` only — titles are user-supplied filenames, so nothing is string-concatenated into HTML). Links are built from a `url_for` template with `__DOC__`/`__RUN__` placeholders, following the existing pattern from the theme browser.
- **Styling (`main.css`):** the popup uses the app's existing teal family (`.btn-teal` / `.metric-card--teal`) to distinguish it from the indigo *View Analysis* : new `.btn-outline-teal` trigger, teal gradient modal header matching the app's gradient-bar language, pill count badge (same recipe as the analysis-run badge), and transcript rows with a teal-tint hover (background, left accent bar, slide) that also applies on keyboard focus.

