### PR TITLE
Update progress display in frontend to reflect new algorithm

### DIFF
--- a/Backend/app/services/codebook_application.py
+++ b/Backend/app/services/codebook_application.py
@@ -92,7 +92,7 @@ class CodebookApplicationService:
         codebook_id: UUID,
         transcript_document_ids: list[UUID] | None,
         provider: str | None = None,
-        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+        on_progress: Callable[[int, int, int, int], Awaitable[None]] | None = None,
         on_phase: Callable[[str], Awaitable[None]] | None = None,
         on_run_created: Callable[[UUID], Awaitable[None]] | None = None,
         should_cancel: Callable[[], Awaitable[bool]] | None = None,

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -98,13 +98,18 @@ class CodebookApplicationJobRunner:
                 active_provider = await get_active_provider(provider_session)
             service = CodebookApplicationService(session)
 
-            async def _on_progress(done: int, total: int) -> None:
+            async def _on_progress(done: int, total: int,
+                                   coded: int | None = None, failed: int | None = None) -> None:
                 async with session_factory() as progress_session:
                     progress_job = await progress_session.get(CodebookApplicationJob, job_id)
                     if progress_job is None:
                         return
                     progress_job.documents_done = done
                     progress_job.documents_total = total
+                    if coded is not None:  # stream coded/failed live, not just at the end
+                        progress_job.documents_coded = coded
+                    if failed is not None:
+                        progress_job.documents_failed = failed
                     await progress_session.commit()
 
             async def _on_phase(phase: str) -> None:

--- a/Backend/app/services/traceable_analysis.py
+++ b/Backend/app/services/traceable_analysis.py
@@ -3724,7 +3724,7 @@ class TraceableAnalysisService:
         synthesis: CodebookSynthesisResult,
         should_cancel: Callable[[], Awaitable[bool]] | None,
         provider: str | None = None,
-        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+        on_progress: Callable[[int, int, int, int], Awaitable[None]] | None = None,
     ) -> _ApplicationPassResult:
         # This is the deductive application pass. It intentionally ignores the
         # initial open-coding assignments and asks the model to use the finalized
@@ -3746,8 +3746,15 @@ class TraceableAnalysisService:
         applied: list[_AppliedEvidence] = []
         action_log: list[dict[str, object]] = []
         failed_document_ids: list[UUID] = []
-        if on_progress is not None:
-            await on_progress(0, len(documents))
+
+        async def _emit_progress(done: int) -> None:
+            # Report running coded/failed counts (a processed doc is coded unless it failed).
+            if on_progress is None:
+                return
+            failed = len(failed_document_ids)
+            await on_progress(done, len(documents), done - failed, failed)
+
+        await _emit_progress(0)
         for document_index, document in enumerate(documents, start=1):
             await self._raise_if_cancelled(should_cancel)
             result: TraceableApplicationResult | None = None
@@ -3778,8 +3785,7 @@ class TraceableAnalysisService:
                     )
                     await asyncio.sleep(0.5 * attempt)
             if result is None:
-                if on_progress is not None:
-                    await on_progress(document_index, len(documents))
+                await _emit_progress(document_index)
                 continue
             document_assignments_before = len(applied)
             document_assignment_keys: set[tuple[str, int | None, int | None, str]] = set()
@@ -3878,8 +3884,7 @@ class TraceableAnalysisService:
                 document.id,
                 len(applied) - document_assignments_before,
             )
-            if on_progress is not None:
-                await on_progress(document_index, len(documents))
+            await _emit_progress(document_index)
         return _ApplicationPassResult(
             evidence=applied,
             failed_document_ids=failed_document_ids,

--- a/Backend/tests/test_codebook_application_jobs_api.py
+++ b/Backend/tests/test_codebook_application_jobs_api.py
@@ -261,6 +261,39 @@ async def test_apply_codebook_job_retries_llm_and_fails_only_one_transcript(clie
     assert statuses == {"coded", "failed"}
 
 
+async def test_apply_codebook_job_streams_coded_and_failed_counts(client, db_engine, monkeypatch) -> None:
+    _, codebook_id, document_ids = await _seed_corpus_codebook(
+        db_engine, texts=["First transcript.", "Second transcript."]
+    )
+    first_coded = asyncio.Event()
+    release = asyncio.Event()
+
+    # Gate mid-run so we can read the job while it is still coding: doc 1 codes,
+    # doc 2 fails, and on_progress carries the running coded/failed counts.
+    async def _gated_apply(self, *, documents, on_progress=None, **_kwargs):
+        del self
+        await on_progress(1, len(documents), 1, 0)
+        first_coded.set()
+        await release.wait()
+        await on_progress(2, len(documents), 1, 1)
+        return _ApplicationPassResult(evidence=[], failed_document_ids=[documents[1].id])
+
+    monkeypatch.setattr(TraceableAnalysisService, "_apply_codebook_to_documents", _gated_apply)
+
+    job_id = (await client.post(
+        f"{API_CODEBOOKS}/{codebook_id}/apply-jobs",
+        json={"transcript_document_ids": document_ids},
+    )).json()["data"]["id"]
+
+    await asyncio.wait_for(first_coded.wait(), timeout=5.0)
+    running = (await client.get(f"{API_CODEBOOKS}/apply-jobs/{job_id}")).json()["data"]
+    assert (running["status"], running["documents_coded"], running["documents_failed"]) == ("running", 1, 0)
+
+    release.set()
+    terminal = await _wait_for_terminal_job_status(client, job_id)
+    assert (terminal["status"], terminal["documents_coded"], terminal["documents_failed"]) == ("succeeded", 1, 1)
+
+
 async def test_apply_codebook_uses_traceable_application_method(db_engine, monkeypatch) -> None:
     corpus_id, codebook_id, document_ids = await _seed_corpus_codebook(
         db_engine,

--- a/Frontend/tests/test_analysis.py
+++ b/Frontend/tests/test_analysis.py
@@ -107,6 +107,40 @@ def test_analysis_job_cancel(client, fake_backend):
     assert resp.json["cancel_requested"] is True
 
 
+# Scripted demo run (analysis progress preview) ------------------------------
+
+
+def test_analysis_demo_streams_and_reaches_succeeded(client):
+    from web.controllers.analysis import _DEMO_ANALYSIS_JOBS, _DEMO_ANALYSIS_PHASES
+
+    resp = client.get("/analysis/demo")
+    assert resp.status_code == 302
+    job_id = resp.headers["Location"].rsplit("/", 1)[1]
+
+    # Mid-run: the coding phase streams coded/failed counts with one failed transcript.
+    _DEMO_ANALYSIS_JOBS[job_id]["started_at"] -= 8.5
+    running = client.get(f"/analysis/job/{job_id}/status").json
+    assert running["status"] == "running" and running["phase"] == "coding_documents"
+    assert running["documents_coded"] + running["documents_failed"] == running["documents_done"]
+    assert running["documents_failed"] == 1
+
+    # Fast-forward past the timeline: terminal, failure retained.
+    _DEMO_ANALYSIS_JOBS[job_id]["started_at"] -= _DEMO_ANALYSIS_PHASES[-1][0] + 1
+    final = client.get(f"/analysis/job/{job_id}/status").json
+    assert (final["status"], final["documents_coded"], final["documents_failed"]) == ("succeeded", 9, 1)
+
+
+def test_analysis_demo_can_be_cancelled(client):
+    job_id = client.get("/analysis/demo").headers["Location"].rsplit("/", 1)[1]
+    assert client.post(f"/analysis/job/{job_id}/cancel").json["status"] == "cancelled"
+    assert client.get(f"/analysis/job/{job_id}/status").json["status"] == "cancelled"
+
+
+def test_analysis_index_shows_demo_link(client, fake_backend):
+    resp = client.get("/analysis/")
+    assert b"/analysis/demo" in resp.data and b"Preview with sample data" in resp.data
+
+
 # Delete Analysis Runs (issue #203) ------------------------------------------
 
 

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -1,5 +1,7 @@
 import io
+import time
 import zipfile
+from uuid import uuid4
 
 from flask import Blueprint, Response, flash, jsonify, redirect, render_template, request, url_for
 
@@ -128,6 +130,8 @@ def wait(job_id: str) -> str:
 
 @bp.get("/job/<job_id>/status")
 def job_status(job_id: str):
+    if job_id.startswith(_DEMO_ANALYSIS_PREFIX):
+        return jsonify(_demo_analysis_state(job_id))
     client = _backend()
     try:
         job = client.get_analysis_job(job_id)
@@ -138,11 +142,60 @@ def job_status(job_id: str):
 
 @bp.post("/job/<job_id>/cancel")
 def cancel_job(job_id: str):
+    entry = _DEMO_ANALYSIS_JOBS.get(job_id)
+    if entry is not None:
+        entry["cancelled"] = True
+        return jsonify({"id": job_id, "status": "cancelled", "phase": "cancelled"})
     try:
         job = _backend().cancel_analysis_job(job_id)
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 400
     return jsonify(job)
+
+
+# Demo flow: scripted /analysis/demo run (no backend) 
+_DEMO_ANALYSIS_PREFIX = "demo-analysis-"
+_DEMO_ANALYSIS_DOCS = 10
+_DEMO_ANALYSIS_PHASES = [
+    (1.0, "queued"), (2.5, "loading_codebook"),
+    (9.0, "coding_documents"), (10.5, "persisting"),
+]
+_DEMO_ANALYSIS_JOBS: dict[str, dict] = {}
+
+
+def _demo_analysis_state(job_id: str) -> dict:
+    entry = _DEMO_ANALYSIS_JOBS.get(job_id)
+    if entry is None:
+        return {"error": "Demo run expired — start a new one from the Analysis page."}
+    if entry.get("cancelled"):
+        return {"id": job_id, "status": "cancelled", "phase": "cancelled"}
+    elapsed = time.monotonic() - entry["started_at"]
+    total = _DEMO_ANALYSIS_DOCS
+    phase = next((name for end, name in _DEMO_ANALYSIS_PHASES if elapsed < end), "succeeded")
+
+    if phase == "queued":
+        return {"id": job_id, "status": "queued", "phase": "queued",
+                "progress_percent": 0, "documents_total": 0, "documents_done": 0}
+
+    # documents_done ramps through coding; one transcript fails so both cards stream.
+    ramp = max(0.0, min(1.0, (elapsed - 2.5) / 6.5))
+    done = total if phase in ("persisting", "succeeded") else round(ramp * total)
+    failed = 1 if done >= 7 else 0
+    terminal = phase == "succeeded"
+    return {
+        "id": job_id, "status": "succeeded" if terminal else "running", "phase": phase,
+        "progress_percent": 100 if terminal else max(2, min(99, round(done / total * 99))),
+        "documents_total": total, "documents_done": done,
+        "documents_coded": done - failed, "documents_failed": failed,
+    }
+
+
+@bp.get("/demo")
+def analysis_demo():
+    """Play a scripted analysis-progress run without touching the backend."""
+    job_id = f"{_DEMO_ANALYSIS_PREFIX}{uuid4().hex}"
+    _DEMO_ANALYSIS_JOBS[job_id] = {"started_at": time.monotonic()}
+    return redirect(url_for("analysis.wait", job_id=job_id))
 
 @bp.post("/runs/export")
 def export_selected_runs() -> Response | str:

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -846,18 +846,24 @@ def _demo_job_state(job_id: str) -> dict:
     total = 8  # cosmetic; matches the number of themes+codes in the payload
     if elapsed < 1:
         return {"id": job_id, "status": "queued",
+                "phase": "queued",
                 "documents_total": 0, "documents_done": 0,
                 "passages_total": 0, "passages_done": 0}
     if elapsed < _DEMO_TIMELINE_SECONDS:
         done = min(total, int((elapsed - 1) / (_DEMO_TIMELINE_SECONDS - 1) * total))
+        phase = "extracting_quote_codes" if done < total // 2 else "synthesizing_themes"
         return {"id": job_id, "status": "running",
+                "phase": phase,
                 "progress_percent": max(2, min(99, int((done / total) * 100))),
                 "documents_total": total, "documents_done": done,
-                "passages_total": total, "passages_done": done}
+                "passages_total": total, "passages_done": done,
+                "analysis_units_total": total, "analysis_units_done": done}
     return {"id": job_id, "status": "succeeded",
+            "phase": "succeeded",
             "progress_percent": 100,
             "documents_total": total, "documents_done": total,
             "passages_total": total, "passages_done": total,
+            "quotes_created": 8, "themes_created": 6, "codes_created": 4,
             "codebook_id": entry["codebook_id"]}
 
 

--- a/Frontend/web/static/js/job_tracker.js
+++ b/Frontend/web/static/js/job_tracker.js
@@ -88,6 +88,9 @@
                  data-job-progress="${job.id}"
                  style="width: 2%">2%</div>
           </div>
+          <div class="small text-secondary mt-1" data-job-caption="${job.id}">
+            Waiting for worker
+          </div>
         </div>
         <a class="btn btn-sm btn-outline-secondary" href="/codebooks/new/jobs/${job.id}?mode=${job.mode || 'auto'}">
           Watch
@@ -98,13 +101,59 @@
 
   function paintProgress(jobId, status) {
     const bar = document.querySelector(`[data-job-progress="${jobId}"]`);
-    if (!bar) return;
+    const caption = document.querySelector(`[data-job-caption="${jobId}"]`);
+    if (!bar && !caption) return;
     const total = status.documents_total || status.analysis_units_total || status.passages_total || 0;
     const done = status.documents_done || status.analysis_units_done || status.passages_done || 0;
     const raw = status.progress_percent || (total > 0 ? Math.round(done / total * 100) : 2);
     const pct = Math.min(99, Math.max(2, raw));
-    bar.style.width = pct + "%";
-    bar.textContent = pct + "%";
+    if (bar) {
+      bar.style.width = pct + "%";
+      bar.textContent = pct + "%";
+    }
+    if (caption) {
+      caption.textContent = statusCaption(status);
+    }
+  }
+
+  function formatCount(value) {
+    return Number(value || 0).toLocaleString();
+  }
+
+  function statusCaption(status) {
+    if (status.status === "queued") return "Waiting for worker";
+    if (status.status === "succeeded") {
+      const pieces = [];
+      if (status.quotes_created !== null && status.quotes_created !== undefined) {
+        pieces.push(`${formatCount(status.quotes_created)} quotes`);
+      }
+      if (status.codes_created !== null && status.codes_created !== undefined) {
+        pieces.push(`${formatCount(status.codes_created)} codes`);
+      }
+      return pieces.length ? `Complete — ${pieces.join(", ")}` : "Complete";
+    }
+    if (status.status === "failed") return "Failed";
+    if (status.status === "cancelled") return "Cancelled";
+
+    const labels = {
+      extracting_quote_codes: "Finding evidence",
+      consolidating_codes: "Consolidating codes",
+      synthesizing_themes: "Building themes",
+      evaluating_iterations: "Evaluating fit",
+      persisting_codebook: "Saving codebook",
+      applying_codebook: "Applying codebook",
+    };
+    const label = labels[status.phase] || "Running";
+    if (status.phase === "consolidating_codes" && status.analysis_units_total > 0) {
+      return `${label} — ${formatCount(status.analysis_units_done)} / ${formatCount(status.analysis_units_total)}`;
+    }
+    if (status.phase === "applying_codebook" && status.analysis_units_total > 0) {
+      return `${label} — ${formatCount(status.analysis_units_done)} / ${formatCount(status.analysis_units_total)}`;
+    }
+    if (status.documents_total > 0) {
+      return `${label} — ${formatCount(status.documents_done)} / ${formatCount(status.documents_total)}`;
+    }
+    return label;
   }
 
   // ---- Terminal handling --------------------------------------------

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -114,6 +114,11 @@
             Run Analysis
           </button>
         </span>
+        <a class="text-secondary small align-self-center ms-md-2"
+           href="{{ url_for('analysis.analysis_demo') }}"
+           title="Preview the progress page with a scripted sample run (no codebook or LLM call)">
+          Preview with sample data &rarr;
+        </a>
       </div>
     </form>
   </div>

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -2,14 +2,7 @@
 {% block title %}Applying Codebook{% endblock %}
 {% block content %}
   <div class="mb-4">
-    <h1 class="h3 mb-1">Applying Codebook</h1>
-    <p class="text-secondary mb-0 d-flex align-items-center gap-2">
-      <span id="status-spinner"
-            class="spinner-border spinner-border-sm text-secondary"
-            role="status"
-            aria-hidden="true"></span>
-      <span id="status-line">Starting analysis run&hellip;</span>
-    </p>
+    <h1 class="h3 mb-0">Applying Codebook</h1>
   </div>
 
   <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
@@ -20,7 +13,13 @@
        id="progress-app">
 
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <span id="progress-step" class="badge text-bg-light border text-secondary">Preparing</span>
+      <span class="text-secondary small d-flex align-items-center gap-2">
+        <span id="status-spinner"
+              class="spinner-border spinner-border-sm text-secondary"
+              role="status"
+              aria-hidden="true"></span>
+        <span id="status-line">Starting analysis run&hellip;</span>
+      </span>
       <span id="progress-percent" class="small fw-semibold text-secondary">0%</span>
     </div>
 
@@ -74,7 +73,6 @@
       const statusSpinner = document.getElementById("status-spinner");
       const bar = document.getElementById("progress-bar");
       const percentLabel = document.getElementById("progress-percent");
-      const stepLabel = document.getElementById("progress-step");
       const counts = document.getElementById("progress-counts");
       const metricProcessed = document.getElementById("metric-processed");
       const metricCoded = document.getElementById("metric-coded");
@@ -134,7 +132,6 @@
         const total = job.documents_total || 0;
         const done = job.documents_done || 0;
         const step = phaseLabel(job);
-        stepLabel.textContent = step;
         updateMetrics(job);
 
         if (job.status === "queued") {
@@ -166,7 +163,6 @@
 
         if (job.status === "succeeded") {
           setBar(100);
-          stepLabel.textContent = "Complete";
           counts.textContent = `${formatCount(job.documents_coded || done || total)} transcripts coded`;
           statusLine.textContent = "Done. Redirecting to results…";
         } else {

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -19,14 +19,40 @@
        data-list-url="{{ url_for('analysis.index') }}"
        id="progress-app">
 
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <span id="progress-step" class="badge text-bg-light border text-secondary">Preparing</span>
+      <span id="progress-percent" class="small fw-semibold text-secondary">0%</span>
+    </div>
+
     <div class="progress mb-3" role="progressbar" aria-label="Analysis progress">
       <div id="progress-bar"
            class="progress-bar progress-bar-striped progress-bar-animated"
-           style="width: 0%">0%</div>
+           style="width: 0%"></div>
     </div>
 
-    <div class="text-secondary small mb-3">
+    <div class="text-secondary small mb-3" aria-live="polite">
       <span id="progress-counts">Preparing&hellip;</span>
+    </div>
+
+    <div class="row g-2 mb-3" aria-label="Application metrics">
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Processed</div>
+          <div id="metric-processed" class="fw-semibold">Waiting</div>
+        </div>
+      </div>
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Coded</div>
+          <div id="metric-coded" class="fw-semibold">Pending</div>
+        </div>
+      </div>
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Failed</div>
+          <div id="metric-failed" class="fw-semibold">0</div>
+        </div>
+      </div>
     </div>
 
     <div id="progress-error" class="alert alert-danger d-none" role="alert"></div>
@@ -47,7 +73,12 @@
       const statusLine = document.getElementById("status-line");
       const statusSpinner = document.getElementById("status-spinner");
       const bar = document.getElementById("progress-bar");
+      const percentLabel = document.getElementById("progress-percent");
+      const stepLabel = document.getElementById("progress-step");
       const counts = document.getElementById("progress-counts");
+      const metricProcessed = document.getElementById("metric-processed");
+      const metricCoded = document.getElementById("metric-coded");
+      const metricFailed = document.getElementById("metric-failed");
       const errorEl = document.getElementById("progress-error");
       const cancelBtn = document.getElementById("cancel-btn");
 
@@ -64,13 +95,47 @@
 
       function setBar(pct) {
         bar.style.width = pct + "%";
-        bar.textContent = pct + "%";
         bar.setAttribute("aria-valuenow", String(pct));
+        percentLabel.textContent = pct + "%";
+      }
+
+      function formatCount(value) {
+        if (value === null || value === undefined) return "0";
+        return Number(value).toLocaleString();
+      }
+
+      function phaseLabel(job) {
+        const phase = job.phase || job.status || "queued";
+        const labels = {
+          queued: "Queued",
+          loading_codebook: "Loading codebook",
+          coding_documents: "Coding transcripts",
+          persisting: "Saving results",
+          succeeded: "Complete",
+          failed: "Failed",
+          cancelled: "Cancelled",
+        };
+        return labels[phase] || phase.replaceAll("_", " ");
+      }
+
+      function updateMetrics(job) {
+        const done = job.documents_done || 0;
+        const total = job.documents_total || 0;
+        metricProcessed.textContent = total > 0
+          ? `${formatCount(done)} / ${formatCount(total)}`
+          : "Waiting";
+        metricCoded.textContent = job.documents_coded !== null && job.documents_coded !== undefined
+          ? formatCount(job.documents_coded)
+          : "Pending";
+        metricFailed.textContent = formatCount(job.documents_failed || 0);
       }
 
       function paint(job) {
         const total = job.documents_total || 0;
         const done = job.documents_done || 0;
+        const step = phaseLabel(job);
+        stepLabel.textContent = step;
+        updateMetrics(job);
 
         if (job.status === "queued") {
           setBar(0);
@@ -80,28 +145,29 @@
         }
 
         if (job.status === "running" && done === 0) {
-          setBar(2);
+          setBar(job.progress_percent || 2);
           counts.textContent = total > 0
-            ? ("0 / " + total + " transcripts")
-            : "Connected — waiting to process first transcript…";
-          statusLine.textContent = "Connected to worker — initializing analysis…";
+            ? `0 of ${formatCount(total)} transcripts processed`
+            : "Connected — preparing transcripts…";
+          statusLine.textContent = `${step}…`;
           return;
         }
 
         if (job.status === "running") {
-          const raw = total > 0 ? Math.round((done / total) * 100) : 2;
+          const raw = job.progress_percent || (total > 0 ? Math.round((done / total) * 100) : 2);
           const pct = Math.min(99, Math.max(2, raw));
           setBar(pct);
-          counts.textContent = done + " / " + total + " transcripts";
+          counts.textContent = `${formatCount(done)} of ${formatCount(total)} transcripts processed`;
           statusLine.textContent = total > 0
-            ? "Applying codebook — " + done + " of " + total + " transcripts analyzed…"
-            : "Applying codebook…";
+            ? `${step} — ${formatCount(done)} of ${formatCount(total)} transcripts…`
+            : `${step}…`;
           return;
         }
 
         if (job.status === "succeeded") {
           setBar(100);
-          counts.textContent = (done || total) + " / " + (total || done) + " transcripts";
+          stepLabel.textContent = "Complete";
+          counts.textContent = `${formatCount(job.documents_coded || done || total)} transcripts coded`;
           statusLine.textContent = "Done. Redirecting to results…";
         } else {
           statusLine.textContent = "Status: " + job.status;

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -38,6 +38,9 @@
               <div class="progress-bar progress-bar-striped progress-bar-animated"
                    data-job-progress="{{ job.id }}" style="width: 2%">2%</div>
             </div>
+            <div class="small text-secondary mt-1" data-job-caption="{{ job.id }}">
+              {{ "Waiting for worker" if job.status == "queued" else "Preparing analysis" }}
+            </div>
           </div>
           <a class="btn btn-sm btn-outline-secondary"
              href="{{ url_for('codebooks.new_codebook_job_progress', job_id=job.id) }}">

--- a/Frontend/web/templates/codebooks/new/progress.html
+++ b/Frontend/web/templates/codebooks/new/progress.html
@@ -21,14 +21,40 @@
        data-review-base="/codebooks/"
        id="progress-app">
 
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <span id="progress-step" class="badge text-bg-light border text-secondary">Preparing</span>
+      <span id="progress-percent" class="small fw-semibold text-secondary">0%</span>
+    </div>
+
     <div class="progress mb-3" role="progressbar" aria-label="Generation progress">
       <div id="progress-bar"
            class="progress-bar progress-bar-striped progress-bar-animated"
-           style="width: 0%">0%</div>
+           style="width: 0%"></div>
     </div>
 
-    <div class="text-secondary small mb-3">
+    <div class="text-secondary small mb-3" aria-live="polite">
       <span id="progress-counts">Preparing&hellip;</span>
+    </div>
+
+    <div class="row g-2 mb-3" aria-label="Job metrics">
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Transcripts</div>
+          <div id="metric-documents" class="fw-semibold">Waiting</div>
+        </div>
+      </div>
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Evidence</div>
+          <div id="metric-evidence" class="fw-semibold">Pending</div>
+        </div>
+      </div>
+      <div class="col-12 col-sm-4">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Codebook</div>
+          <div id="metric-codebook" class="fw-semibold">Pending</div>
+        </div>
+      </div>
     </div>
 
     <div id="progress-error" class="alert alert-danger d-none" role="alert"></div>
@@ -51,7 +77,12 @@
       const statusLine = document.getElementById("status-line");
       const statusSpinner = document.getElementById("status-spinner");
       const bar = document.getElementById("progress-bar");
+      const percentLabel = document.getElementById("progress-percent");
+      const stepLabel = document.getElementById("progress-step");
       const counts = document.getElementById("progress-counts");
+      const metricDocuments = document.getElementById("metric-documents");
+      const metricEvidence = document.getElementById("metric-evidence");
+      const metricCodebook = document.getElementById("metric-codebook");
       const errorEl = document.getElementById("progress-error");
       const cancelBtn = document.getElementById("cancel-btn");
 
@@ -69,14 +100,73 @@
 
       function setBar(pct) {
         bar.style.width = pct + "%";
-        bar.textContent = pct + "%";
         bar.setAttribute("aria-valuenow", String(pct));
+        percentLabel.textContent = pct + "%";
+      }
+
+      function formatCount(value) {
+        if (value === null || value === undefined) return "0";
+        return Number(value).toLocaleString();
+      }
+
+      function phaseLabel(job) {
+        const phase = job.phase || job.status || "queued";
+        const labels = {
+          queued: "Queued",
+          loading: "Preparing",
+          extracting_quote_codes: "Finding evidence",
+          consolidating_codes: "Consolidating codes",
+          synthesizing_themes: "Building themes",
+          evaluating_iterations: "Evaluating fit",
+          persisting_codebook: "Saving codebook",
+          applying_codebook: "Applying codebook",
+          succeeded: "Complete",
+          failed: "Failed",
+          cancelled: "Cancelled",
+        };
+        return labels[phase] || phase.replaceAll("_", " ");
+      }
+
+      function activeCounter(job) {
+        if (job.phase === "consolidating_codes" && job.analysis_units_total > 0) {
+          return `${formatCount(job.analysis_units_done)} of ${formatCount(job.analysis_units_total)} relationships checked`;
+        }
+        if (job.phase === "applying_codebook" && job.analysis_units_total > 0) {
+          return `${formatCount(job.analysis_units_done)} of ${formatCount(job.analysis_units_total)} transcripts coded`;
+        }
+        if (job.documents_total > 0) {
+          return `${formatCount(job.documents_done)} of ${formatCount(job.documents_total)} transcripts reviewed`;
+        }
+        return "Worker is preparing the analysis";
+      }
+
+      function updateMetrics(job) {
+        const docsDone = job.documents_done || 0;
+        const docsTotal = job.documents_total || 0;
+        metricDocuments.textContent = docsTotal > 0
+          ? `${formatCount(docsDone)} / ${formatCount(docsTotal)}`
+          : "Waiting";
+
+        metricEvidence.textContent = job.quotes_created !== null && job.quotes_created !== undefined
+          ? `${formatCount(job.quotes_created)} quotes`
+          : (job.analysis_units_done > 0 ? `${formatCount(job.analysis_units_done)} reviewed` : "Pending");
+
+        const pieces = [];
+        if (job.codes_created !== null && job.codes_created !== undefined) {
+          pieces.push(`${formatCount(job.codes_created)} codes`);
+        }
+        if (job.themes_created !== null && job.themes_created !== undefined) {
+          pieces.push(`${formatCount(job.themes_created)} themes`);
+        }
+        metricCodebook.textContent = pieces.length ? pieces.join(" / ") : "Pending";
       }
 
       function paint(job) {
-        const total = job.documents_total || job.analysis_units_total || job.passages_total || 0;
-        const done = job.documents_done || job.analysis_units_done || job.passages_done || 0;
-        const phase = (job.phase || "").replaceAll("_", " ");
+        const total = job.documents_total || job.analysis_units_total || 0;
+        const done = job.documents_done || job.analysis_units_done || 0;
+        const step = phaseLabel(job);
+        stepLabel.textContent = step;
+        updateMetrics(job);
 
         if (job.status === "queued") {
           setBar(0);
@@ -87,10 +177,8 @@
 
         if (job.status === "running" && done === 0) {
           setBar(job.progress_percent || 2);
-          counts.textContent = total > 0
-            ? ("0 / " + total + " documents")
-            : "Connected — " + (phase || "starting") + "…";
-          statusLine.textContent = "Connected to worker — " + (phase || "starting traceable analysis") + "…";
+          counts.textContent = activeCounter(job);
+          statusLine.textContent = `${step}…`;
           return;
         }
 
@@ -99,16 +187,17 @@
           const raw = job.progress_percent || (total > 0 ? Math.round((done / total) * 100) : 2);
           const pct = Math.min(99, Math.max(2, raw));
           setBar(pct);
-          counts.textContent = done + " / " + total + " documents";
-          statusLine.textContent = total > 0
-            ? "Traceable analysis — " + (phase || "running") + ", " + done + " of " + total + " documents…"
-            : "Traceable analysis — " + (phase || "running") + "…";
+          counts.textContent = activeCounter(job);
+          statusLine.textContent = `${step}…`;
           return;
         }
 
         if (job.status === "succeeded") {
           setBar(100);
-          counts.textContent = (done || total) + " / " + (total || done) + " documents";
+          stepLabel.textContent = "Complete";
+          counts.textContent = job.application_run_id
+            ? "Codebook generated and applied."
+            : "Codebook generated.";
           statusLine.textContent = "Done. Opening results…";
         } else {
           statusLine.textContent = "Status: " + job.status;

--- a/Frontend/web/templates/codebooks/new/progress.html
+++ b/Frontend/web/templates/codebooks/new/progress.html
@@ -2,14 +2,7 @@
 {% block title %}Generating Codebook{% endblock %}
 {% block content %}
   <div class="mb-4">
-    <h1 class="h3 mb-1">Generating Codebook</h1>
-    <p class="text-secondary mb-0 d-flex align-items-center gap-2">
-      <span id="status-spinner"
-            class="spinner-border spinner-border-sm text-secondary"
-            role="status"
-            aria-hidden="true"></span>
-      <span id="status-line">Starting job&hellip;</span>
-    </p>
+    <h1 class="h3 mb-0">Generating Codebook</h1>
   </div>
 
   <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
@@ -22,7 +15,13 @@
        id="progress-app">
 
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <span id="progress-step" class="badge text-bg-light border text-secondary">Preparing</span>
+      <span class="text-secondary small d-flex align-items-center gap-2">
+        <span id="status-spinner"
+              class="spinner-border spinner-border-sm text-secondary"
+              role="status"
+              aria-hidden="true"></span>
+        <span id="status-line">Starting job&hellip;</span>
+      </span>
       <span id="progress-percent" class="small fw-semibold text-secondary">0%</span>
     </div>
 
@@ -78,7 +77,6 @@
       const statusSpinner = document.getElementById("status-spinner");
       const bar = document.getElementById("progress-bar");
       const percentLabel = document.getElementById("progress-percent");
-      const stepLabel = document.getElementById("progress-step");
       const counts = document.getElementById("progress-counts");
       const metricDocuments = document.getElementById("metric-documents");
       const metricEvidence = document.getElementById("metric-evidence");
@@ -165,7 +163,6 @@
         const total = job.documents_total || job.analysis_units_total || 0;
         const done = job.documents_done || job.analysis_units_done || 0;
         const step = phaseLabel(job);
-        stepLabel.textContent = step;
         updateMetrics(job);
 
         if (job.status === "queued") {
@@ -194,7 +191,6 @@
 
         if (job.status === "succeeded") {
           setBar(100);
-          stepLabel.textContent = "Complete";
           counts.textContent = job.application_run_id
             ? "Codebook generated and applied."
             : "Codebook generated.";


### PR DESCRIPTION
resolves #234. adds demo run for analysis, similar to the codebook generation. modifies traceable analysis to display coded/failed transcript counts **during** analysis.