### PR TITLE
227 quotes box in theme view

### DIFF
--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -201,6 +201,14 @@ def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     assert b'id="themes-table-body"' in body
     assert b"Occurrences" in body
     assert b"Interview Coverage" in body
+    # Quotes live inline in the same box, not in a pop-up (issue #227).
+    assert b'id="quotes-panel-title"' in body
+    assert b'id="quotes-none"' in body
+    assert b'id="quotes-pagination"' in body
+    assert b'id="quotes-modal"' not in body
+    assert b"View Quotes" not in body
+    # Quote-count stat in the Theme Details header (filled by the quotes JS).
+    assert b'id="theme-details-quotes"' in body
 
 
 def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -175,6 +175,34 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
     assert b'id="global-corpus-select"' in resp.data
 
 
+def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.theme_frequencies = [
+        {"theme_id": "t-1", "theme_name": "Work-Life Balance",
+         "occurrence_count": 5, "interview_coverage_percentage": 60.0},
+    ]
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Work-Life Balance", "is_active": True},
+         "children": []},
+    ]
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+    assert resp.status_code == 200
+    body = resp.data
+    # One merged box replaces the two separate panels (issue #226).
+    assert b'panel-title">Themes</h2>' in body
+    assert b"Theme Frequency" not in body
+    assert b"Theme Hierarchy" not in body
+    assert b'id="theme-tree"' not in body
+    # The table skeleton the JS renders into is still present.
+    assert b'id="themes-table-body"' in body
+    assert b"Occurrences" in body
+    assert b"Interview Coverage" in body
+
+
 def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):
     fake_backend.codebooks = [
         {"id": "cb-1", "name": "Interview Codebook", "version": 1,

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -206,14 +206,6 @@
 
 .theme-row-matched td:first-child { font-weight: 600; }
 
-/* Compact marker for the hierarchy tree. */
-.theme-topic-star {
-    color: #d97706;
-    margin-left: 6px;
-    font-size: 0.8rem;
-    cursor: default;
-}
-
 .coverage-label {
     font-size: 0.78rem;
     min-width: 48px;
@@ -328,81 +320,9 @@
     white-space: nowrap;
 }
 
-/* ── Tree with connector lines (file-explorer style) ────────────────────────── */
-.tree-container {
-    flex: 1 1 auto;
-    min-height: 380px;
-    overflow: auto;
-}
-
-.theme-tree-card { min-height: 100%; }
-
-/* Root list — border-left is the outer trunk connecting all root themes.
-   padding-left creates space for the horizontal stubs on each root row.
-   Scales to any number of themes since it's a single CSS border, not per-node. */
-.tree-root {
-    list-style: none;
-    padding: 4px 0;
-    margin: 0;
-    padding-left: 14px;
-    border-left: 1.5px solid #d1d5db;
-}
-
-/* Each root-theme group */
-.tree-group {
-    position: relative;   /* anchor for ::after trunk-cap on last group */
-    margin-bottom: 10px;
-}
-.tree-group:last-child { margin-bottom: 0; }
-
-/* Cap the outer trunk at the midpoint of the last root row (└── effect).
-   top: 16px ≈ half of root-row height (6px padding + ~10px half-line-height).
-   background: #fff covers the trunk below the last item's stub. */
-.tree-group:last-child::after {
-    content: '';
-    position: absolute;
-    left: -15px;          /* 1px past the trunk border-left */
-    top: 16px;
-    bottom: -4px;
-    width: 4px;
-    background: #fff;
-    z-index: 1;
-}
-
-/* Root node row */
-.tree-root-row {
-    position: relative;   /* anchor for ::before stub */
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 10px;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: #1f2937;
-    cursor: pointer;
-    user-select: none;
-    transition: background 0.13s ease, color 0.13s ease;
-    line-height: 1.4;
-}
-.tree-root-row:hover    { background: #f3f4f6; }
-.tree-root-row.selected { background: #eff6ff; color: #1d4ed8; }
-
-/* Horizontal stub from outer trunk to each root row.
-   top: 50% + translateY(-50%) keeps it centred regardless of text wrapping —
-   important when themes have long names at small viewports or with 100s of nodes. */
-.tree-root-row::before {
-    content: '';
-    position: absolute;
-    left: -14px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 14px;
-    height: 1.5px;
-    background: #d1d5db;
-}
-
-/* Expand / collapse arrow */
+/* ── Merged theme table: expand/collapse chevron (issue #226) ────────────────
+   The hierarchy lives inside the frequency table now; each parent row carries
+   a chevron button, children indent via inline padding set by the JS. */
 .tree-toggle {
     background: none;
     border: none;
@@ -412,6 +332,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    vertical-align: middle;
+    margin-right: 4px;
     flex-shrink: 0;
     cursor: pointer;
 }
@@ -425,62 +347,18 @@
     border-color: transparent transparent transparent #9ca3af;
     transition: transform 0.18s ease;
 }
-.tree-toggle[aria-expanded="true"]::before  { transform: rotate(90deg); }
-.tree-root-row.selected .tree-toggle::before { border-color: transparent transparent transparent #1d4ed8; }
-
-.tree-toggle-gap { width: 16px; flex-shrink: 0; }
-
-/* Children list — the border-left IS the vertical connector line */
-.tree-children {
-    list-style: none;
-    padding: 0 0 0 14px;   /* left padding = width of horizontal stub */
-    margin: 3px 0 0 16px;  /* left margin indents the whole group from root */
-    border-left: 1.5px solid #d1d5db;
+.tree-toggle[aria-expanded="true"]::before { transform: rotate(90deg); }
+.theme-row-selected .tree-toggle::before {
+    border-color: transparent transparent transparent #1d4ed8;
 }
 
-/* Each child item — provides the ::before anchor point */
-.tree-child-item {
-    position: relative;
-    margin-bottom: 2px;
+/* Alignment spacer for leaf rows (same footprint as the chevron). */
+.tree-toggle-gap {
+    display: inline-block;
+    width: 16px;
+    margin-right: 4px;
+    flex-shrink: 0;
 }
-.tree-child-item:last-child { margin-bottom: 0; }
-
-/* Horizontal stub: runs from the border-left to the child label */
-.tree-child-item::before {
-    content: '';
-    position: absolute;
-    left: -14px;   /* start exactly at the border-left edge */
-    top: 50%;
-    width: 14px;   /* matches padding-left of .tree-children */
-    height: 1.5px;
-    background: #d1d5db;
-}
-
-/* Cap the vertical line at the last child's midpoint (└── effect) */
-.tree-child-item:last-child::after {
-    content: '';
-    position: absolute;
-    left: -16px;              /* 1px past the border-left */
-    top: calc(50% + 1px);
-    bottom: 0;
-    width: 4px;
-    background: #fff;         /* matches the panel's bg-white background */
-}
-
-/* Child node row */
-.tree-child-row {
-    display: block;
-    padding: 5px 8px;
-    border-radius: 6px;
-    font-size: 0.84rem;
-    color: #4b5563;
-    cursor: pointer;
-    user-select: none;
-    transition: background 0.13s ease, color 0.13s ease;
-    line-height: 1.4;
-}
-.tree-child-row:hover   { background: #f3f4f6; color: #374151; }
-.tree-child-row.selected { background: #eff6ff; color: #1d4ed8; }
 
 /* ── Theme Details panel ────────────────────────────────────────────────────── */
 .td-name {

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -360,6 +360,36 @@
     flex-shrink: 0;
 }
 
+/* Connector guides (file-explorer style, drawn per row so they work inside
+   table rows): one .tree-indent column per ancestor level. --line is a
+   pass-through, --tee (├) marks a child with siblings below, --elbow (└)
+   the last child. Negative vertical margins bridge the cell padding so the
+   lines run continuously from row to row. */
+.theme-name-flex {
+    display: flex;
+    align-items: center;
+    min-height: 100%;
+}
+.tree-indent {
+    flex: 0 0 1.1rem;
+    align-self: stretch;
+    margin-top: -0.25rem;    /* .table-sm cell padding */
+    margin-bottom: -0.25rem;
+}
+.tree-indent--line {
+    background: linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 100%;
+}
+.tree-indent--tee {
+    background:
+        linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 100%,
+        linear-gradient(#d1d5db, #d1d5db) no-repeat right center / 50% 1.5px;
+}
+.tree-indent--elbow {
+    background:
+        linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 50%,
+        linear-gradient(#d1d5db, #d1d5db) no-repeat right center / 50% 1.5px;
+}
+
 /* Scroll cap for the themes table: a fully expanded hierarchy scrolls inside
    the box while the column headers stick to the top. 70vh fills a laptop
    viewport while leaving room for the surrounding chrome. */

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -390,10 +390,20 @@
         linear-gradient(#d1d5db, #d1d5db) no-repeat right center / 50% 1.5px;
 }
 
-/* Scroll cap for the themes table: a fully expanded hierarchy scrolls inside
-   the box while the column headers stick to the top. 70vh fills a laptop
-   viewport while leaving room for the surrounding chrome. */
-.themes-table-scroll {
+/* Divider between the themes table and the quotes panel inside the merged
+   box: a vertical rule when the columns sit side by side (xl+), a horizontal
+   rule when they stack on smaller screens. */
+.quotes-panel {
+    border-top: 1px solid #e5e7eb;
+    padding-top: 1rem;
+}
+
+/* Symmetric scroll caps: only the quote cards / theme rows scroll, so the
+   panel titles, sticky column headers, and pagination stay visible and the
+   two columns keep matching heights. 70vh fills a laptop viewport while
+   leaving room for the surrounding chrome. */
+.themes-table-scroll,
+.quotes-list-scroll {
     max-height: 70vh;
     overflow-y: auto;
     /* Keep content clear of the scrollbar (overlay scrollbars paint on top
@@ -409,6 +419,14 @@
     /* border-bottom doesn't travel with sticky cells; draw it as a shadow. */
     box-shadow: inset 0 -2px 0 #e5e7eb;
     border-bottom: 0;
+}
+@media (min-width: 1200px) {
+    .quotes-panel {
+        border-top: 0;
+        padding-top: 0;
+        border-left: 1px solid #e5e7eb;
+        padding-left: 1.5rem;
+    }
 }
 
 /* ── Theme Details panel ────────────────────────────────────────────────────── */

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -360,6 +360,27 @@
     flex-shrink: 0;
 }
 
+/* Scroll cap for the themes table: a fully expanded hierarchy scrolls inside
+   the box while the column headers stick to the top. 70vh fills a laptop
+   viewport while leaving room for the surrounding chrome. */
+.themes-table-scroll {
+    max-height: 70vh;
+    overflow-y: auto;
+    /* Keep content clear of the scrollbar (overlay scrollbars paint on top
+       of flush content, covering the coverage labels). */
+    padding-right: 0.75rem;
+    scrollbar-gutter: stable;
+}
+.themes-table-scroll .theme-table-head th {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 1;
+    /* border-bottom doesn't travel with sticky cells; draw it as a shadow. */
+    box-shadow: inset 0 -2px 0 #e5e7eb;
+    border-bottom: 0;
+}
+
 /* ── Theme Details panel ────────────────────────────────────────────────────── */
 .td-name {
     font-size: 1.35rem;

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -280,13 +280,18 @@
     function renderThemeTreeTable(treeData) {
         themesTableBody.innerHTML = "";
 
-        (function renderLevel(nodes, depth, parentId) {
+        // `ancestorGuides` carries one flag per ancestor indent column:
+        // true = that ancestor has further siblings below, so the column
+        // draws a vertical pass-through line (classic file-explorer capping —
+        // lines stop at each branch's last child instead of running on).
+        (function renderLevel(nodes, depth, parentId, ancestorGuides) {
             const sorted = [...nodes].sort((a, b) => byFrequencyThenName(nodeInfo(a), nodeInfo(b)));
-            for (const node of sorted) {
+            sorted.forEach((node, index) => {
                 const theme       = node.theme;
                 const children    = node.children ?? [];
                 const info        = nodeInfo(node);
                 const code        = isCodeNode(theme);
+                const isLast      = index === sorted.length - 1;
                 if (parentId) parentIdByThemeId[theme.id] = parentId;
 
                 const row = document.createElement("tr");
@@ -297,32 +302,46 @@
                     row.classList.add("d-none"); // children start collapsed
                 }
 
-                // Theme cell: indent by depth + chevron + label (+ badges).
+                // Theme cell: connector guides + chevron + label (+ badges).
                 const nameCell = document.createElement("td");
-                nameCell.style.paddingLeft = (0.5 + depth * 1.4) + "rem";
+                const nameWrap = document.createElement("div");
+                nameWrap.className = "theme-name-flex";
+                nameCell.appendChild(nameWrap);
+
+                for (const hasLine of ancestorGuides) {
+                    const guide = document.createElement("span");
+                    guide.className = "tree-indent" + (hasLine ? " tree-indent--line" : "");
+                    nameWrap.appendChild(guide);
+                }
+                if (depth > 0) {
+                    // ├ for children with siblings below, └ for the last one.
+                    const connector = document.createElement("span");
+                    connector.className = "tree-indent " + (isLast ? "tree-indent--elbow" : "tree-indent--tee");
+                    nameWrap.appendChild(connector);
+                }
                 if (children.length > 0) {
                     const toggle = document.createElement("button");
                     toggle.className = "tree-toggle";
                     toggle.setAttribute("aria-expanded", "false");
                     toggle.setAttribute("aria-label", "Toggle " + info.theme_name);
                     toggle.setAttribute("tabindex", "-1");
-                    nameCell.appendChild(toggle);
+                    nameWrap.appendChild(toggle);
                 } else {
                     const gap = document.createElement("span");
                     gap.className = "tree-toggle-gap";
-                    nameCell.appendChild(gap);
+                    nameWrap.appendChild(gap);
                 }
-                nameCell.appendChild(document.createTextNode(info.theme_name));
+                nameWrap.appendChild(document.createTextNode(info.theme_name));
                 const matchedTopic = matchedTopicFor(info.theme_name);
                 if (matchedTopic) {
                     row.classList.add("theme-row-matched");
-                    nameCell.appendChild(makeTopicBadge(matchedTopic));
+                    nameWrap.appendChild(makeTopicBadge(matchedTopic));
                 }
                 if (code) {
                     const chip = document.createElement("span");
                     chip.className = "badge text-bg-light border ms-1";
                     chip.textContent = "code";
-                    nameCell.appendChild(chip);
+                    nameWrap.appendChild(chip);
                 }
 
                 // Occurrences — codes have no frequency data, so show a dash
@@ -364,9 +383,16 @@
                 });
 
                 themesTableBody.appendChild(row);
-                renderLevel(children, depth + 1, theme.id);
-            }
-        })(treeData, 0, null);
+                // Children inherit this level's columns plus one for this node:
+                // a pass-through line while it still has siblings below.
+                renderLevel(
+                    children,
+                    depth + 1,
+                    theme.id,
+                    depth === 0 ? [] : [...ancestorGuides, !isLast]
+                );
+            });
+        })(treeData, 0, null, []);
 
         highlightSelectedRow();
     }

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -464,28 +464,33 @@
     }
 
     // ------------------------------------------------------------------
-    // Quotes modal
+    // Quotes panel (issue #227) — lives inside the merged themes box and
+    // follows the selected theme. Reacts to the theme:selected event (the
+    // same contract the demographic-breakdown panel uses), so it needs no
+    // direct coupling to showThemeDetails and survives the boot race via
+    // window.__ataCurrentTheme.
     // ------------------------------------------------------------------
 
-    const quotesModal      = document.getElementById("quotes-modal");
     const quotesLoading    = document.getElementById("quotes-loading");
     const quotesError      = document.getElementById("quotes-error");
     const quotesList       = document.getElementById("quotes-list");
     const quotesEmpty      = document.getElementById("quotes-empty");
-    const quotesTotal      = document.getElementById("quotes-modal-total");
-    const quotesLabel      = document.getElementById("quotes-modal-label");
+    const quotesNone       = document.getElementById("quotes-none");
+    const quotesTotal      = document.getElementById("quotes-panel-total");
+    const quotesLabel      = document.getElementById("quotes-panel-title");
     const quotesPagination = document.getElementById("quotes-pagination");
     const quotesPageInfo   = document.getElementById("quotes-page-info");
     const quotesPrev       = document.getElementById("quotes-prev");
     const quotesNext       = document.getElementById("quotes-next");
-    const viewQuotesBtn    = document.getElementById("theme-details-view-quotes");
+    // Quote-count stat in the Theme Details header; owned by this module
+    // because the count only becomes known once the quotes fetch returns.
+    const themeDetailsQuotes = document.getElementById("theme-details-quotes");
 
-    if (!quotesModal || !viewQuotesBtn) return;
-
-    const bsModal = new bootstrap.Modal(quotesModal);
+    if (!quotesList) return;
 
     let activeQuoteThemeId = null;
     let activeQuotePage    = 1;
+    let quotesRequestToken = 0; // drops stale responses after quick re-selection
     const PAGE_SIZE        = 20;
 
     function quotesUrl(themeId, page) {
@@ -503,7 +508,22 @@
     }
 
     function setQuotesLoading() {
+        quotesNone.classList.add("d-none");
         quotesLoading.classList.remove("d-none");
+        quotesError.classList.add("d-none");
+        quotesList.classList.add("d-none");
+        quotesEmpty.classList.add("d-none");
+        quotesPagination.classList.add("d-none");
+    }
+
+    // Blank panel shown while no theme is selected.
+    function resetQuotesPanel() {
+        activeQuoteThemeId = null;
+        quotesRequestToken++;
+        quotesLabel.textContent = "Quotes";
+        quotesTotal.textContent = "";
+        quotesNone.classList.remove("d-none");
+        quotesLoading.classList.add("d-none");
         quotesError.classList.add("d-none");
         quotesList.classList.add("d-none");
         quotesEmpty.classList.add("d-none");
@@ -521,6 +541,7 @@
 
         quotesLabel.textContent = "Quotes for: " + (themeName || "Theme");
         quotesTotal.textContent = total === 1 ? "1 quote across corpus" : total + " quotes across corpus";
+        if (themeDetailsQuotes) themeDetailsQuotes.textContent = String(total);
 
         if (items.length === 0) {
             quotesEmpty.classList.remove("d-none");
@@ -550,7 +571,7 @@
 
             const link = document.createElement("a");
             link.href      = interviewUrl(item.document_id);
-            link.className = "btn btn-sm btn-outline-secondary";
+            link.className = "btn btn-sm btn-outline-primary";
             link.textContent = "View Interview";
             meta.appendChild(link);
 
@@ -571,6 +592,7 @@
     async function loadQuotes(themeId, page) {
         activeQuoteThemeId = themeId;
         activeQuotePage    = page;
+        const token = ++quotesRequestToken;
         setQuotesLoading();
 
         const themeName = (currentThemeInfoById[themeId] || {}).theme_name || "";
@@ -578,20 +600,40 @@
         try {
             const response = await fetch(quotesUrl(themeId, page));
             const data = await response.json();
+            if (token !== quotesRequestToken) return; // superseded by a newer request
             if (!response.ok || data.error) throw new Error(data.error || "HTTP " + response.status);
             renderQuotes(data, themeName);
         } catch (err) {
+            if (token !== quotesRequestToken) return;
             quotesLoading.classList.add("d-none");
             quotesError.textContent = "Could not load quotes: " + err.message;
             quotesError.classList.remove("d-none");
         }
     }
 
-    viewQuotesBtn.addEventListener("click", () => {
-        if (!selectedThemeId) return;
-        bsModal.show();
-        loadQuotes(selectedThemeId, 1);
+    function onQuotesThemeChange(themeId) {
+        if (!themeId) {
+            resetQuotesPanel();
+            if (themeDetailsQuotes) themeDetailsQuotes.textContent = "";
+            return;
+        }
+        if (themeId === activeQuoteThemeId) return; // same theme — keep page and stat
+        // Placeholder until this theme's quote total arrives with the fetch.
+        if (themeDetailsQuotes) themeDetailsQuotes.textContent = "—";
+        loadQuotes(themeId, 1);
+    }
+
+    document.addEventListener("theme:selected", (event) => {
+        onQuotesThemeChange((event.detail || {}).themeId);
     });
+
+    // Boot race: the auto-selection above fires before this listener attaches.
+    const initialTheme = window.__ataCurrentTheme;
+    if (initialTheme && initialTheme.themeId) {
+        onQuotesThemeChange(initialTheme.themeId);
+    } else {
+        resetQuotesPanel();
+    }
 
     quotesPrev.addEventListener("click", () => {
         if (activeQuoteThemeId && activeQuotePage > 1) {

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -124,13 +124,18 @@
         return "theme-progress-bar--high";
     }
 
+    // Shared ordering: most frequent first, ties alphabetical. Used for the
+    // frequency list (boot auto-select) and for every sibling level of the
+    // merged theme table.
+    function byFrequencyThenName(a, b) {
+        if (b.occurrence_count !== a.occurrence_count) {
+            return b.occurrence_count - a.occurrence_count;
+        }
+        return a.theme_name.localeCompare(b.theme_name);
+    }
+
     function sortByFrequency(themes) {
-        return [...themes].sort((a, b) => {
-            if (b.occurrence_count !== a.occurrence_count) {
-                return b.occurrence_count - a.occurrence_count;
-            }
-            return a.theme_name.localeCompare(b.theme_name);
-        });
+        return [...themes].sort(byFrequencyThenName);
     }
 
     function flattenTreeNodes(nodes, out) {
@@ -213,13 +218,10 @@
         announceSelectedTheme({ themeId: null, themeName: "" });
     }
 
-    // Sync the visual selection highlight across both the table and tree.
+    // Sync the visual selection highlight across the merged theme table.
     function highlightSelectedRow() {
         themesTableBody.querySelectorAll("tr").forEach((row) => {
             row.classList.toggle("theme-row-selected", row.dataset.themeId === selectedThemeId);
-        });
-        document.querySelectorAll("#theme-tree [data-theme-id]").forEach((el) => {
-            el.classList.toggle("selected", el.dataset.themeId === selectedThemeId);
         });
     }
 
@@ -245,147 +247,178 @@
     }
 
     // ------------------------------------------------------------------
-    // Frequency table
-    // ------------------------------------------------------------------
-
-    function renderThemeTable(themes) {
-        themesTableBody.innerHTML = "";
-        const sorted = sortByFrequency(themes);
-
-        for (const theme of sorted) {
-            const row = document.createElement("tr");
-            row.dataset.themeId = theme.theme_id;
-            row.classList.add("theme-row-selectable");
-            row.addEventListener("click", () => showThemeDetails(theme.theme_id));
-
-            const nameCell = document.createElement("td");
-            nameCell.appendChild(document.createTextNode(theme.theme_name));
-            const matchedTopic = matchedTopicFor(theme.theme_name);
-            if (matchedTopic) {
-                row.classList.add("theme-row-matched");
-                nameCell.appendChild(makeTopicBadge(matchedTopic));
-            }
-
-            // Occurrence count
-            const countCell = document.createElement("td");
-            countCell.className   = "text-end";
-            countCell.textContent = String(theme.occurrence_count);
-            if (theme.occurrence_count === 0) countCell.classList.add("theme-zero");
-
-            // Coverage with mini progress bar
-            const pct      = theme.interview_coverage_percentage || 0;
-            const barWidth = Math.min(Math.max(pct, 0), 100);
-            const coverageCell = document.createElement("td");
-            coverageCell.style.paddingLeft = "3rem";
-            coverageCell.innerHTML = `
-                <div class="d-flex align-items-center gap-2">
-                    <div class="theme-progress">
-                        <div class="theme-progress-bar ${coverageBarClass(pct)}" style="width:${barWidth}%"></div>
-                    </div>
-                    <span class="coverage-label${pct === 0 ? " theme-zero" : ""}">${formatCoverage(pct)}</span>
-                </div>`;
-
-            row.append(nameCell, countCell, coverageCell);
-            themesTableBody.appendChild(row);
-        }
-
-        highlightSelectedRow();
-    }
-
-    // ------------------------------------------------------------------
-    // Tree with connector lines (file-explorer style, pure vanilla JS).
+    // Merged theme table: frequency + hierarchy in one box (issue #226).
+    //
+    // Each tree node becomes one <tr>; the Theme cell carries the hierarchy
+    // (depth indent + expand/collapse chevron) while the Occurrences and
+    // Coverage columns keep the frequency view. Sibling rows are ordered by
+    // frequency at every depth, so expanding a parent lists its children
+    // most-frequent first.
     //
     // Built with the DOM API (createElement + textContent + setAttribute)
     // — never innerHTML on user data — so a malicious theme label like
     // `<img src=x onerror=alert(1)>` is rendered as literal text and cannot
     // execute as JS.
-    //
-    // The recursive `buildNodeElement` handles arbitrary tree depth:
-    // any non-leaf node gets a toggle button and click-to-expand, regardless
-    // of how deeply nested it sits in the hierarchy.
     // ------------------------------------------------------------------
 
-    function renderTree(treeData) {
-        const container = document.getElementById("theme-tree");
-        if (!container) return;
+    // child theme id -> parent theme id; lets revealTheme expand ancestors.
+    const parentIdByThemeId = {};
 
-        container.replaceChildren();
-        const rootUl = document.createElement("ul");
-        rootUl.className = "tree-root";
-        rootUl.setAttribute("role", "tree");
-
-        for (const rootNode of treeData) {
-            rootUl.appendChild(buildNodeElement(rootNode, /*isRoot=*/ true));
-        }
-        container.appendChild(rootUl);
+    function isCodeNode(theme) {
+        return theme.type === "CODE" || theme.node_type === "CODE";
     }
 
-    function buildNodeElement(node, isRoot) {
-        const theme       = node.theme;
-        const children    = node.children ?? [];
-        const hasChildren = children.length > 0;
+    function nodeInfo(node) {
+        return currentThemeInfoById[node.theme.id] ?? {
+            theme_id:                      node.theme.id,
+            theme_name:                    node.theme.label,
+            occurrence_count:              0,
+            interview_coverage_percentage: 0,
+        };
+    }
 
-        const li = document.createElement("li");
-        li.className = isRoot ? "tree-group" : "tree-child-item";
-        li.setAttribute("role", "none");
+    function renderThemeTreeTable(treeData) {
+        themesTableBody.innerHTML = "";
 
-        const row = document.createElement("div");
-        row.className = isRoot ? "tree-root-row" : "tree-child-row";
-        row.setAttribute("role", "treeitem");
-        row.setAttribute("tabindex", "0");
-        row.dataset.themeId = theme.id;
+        (function renderLevel(nodes, depth, parentId) {
+            const sorted = [...nodes].sort((a, b) => byFrequencyThenName(nodeInfo(a), nodeInfo(b)));
+            for (const node of sorted) {
+                const theme       = node.theme;
+                const children    = node.children ?? [];
+                const info        = nodeInfo(node);
+                const code        = isCodeNode(theme);
+                if (parentId) parentIdByThemeId[theme.id] = parentId;
 
-        if (hasChildren) {
-            const toggle = document.createElement("button");
-            toggle.className = "tree-toggle";
-            toggle.setAttribute("aria-expanded", "false");
-            toggle.setAttribute("aria-label", "Toggle " + theme.label);
-            toggle.setAttribute("tabindex", "-1");
-            row.appendChild(toggle);
-        } else if (isRoot) {
-            // Keep root rows aligned when they have no children.
-            const gap = document.createElement("span");
-            gap.className = "tree-toggle-gap";
-            row.appendChild(gap);
-        }
+                const row = document.createElement("tr");
+                row.dataset.themeId = theme.id;
+                row.classList.add("theme-row-selectable");
+                if (parentId) {
+                    row.dataset.parentId = parentId;
+                    row.classList.add("d-none"); // children start collapsed
+                }
 
-        // Label rendered via textContent — auto-escapes any HTML in the label.
-        row.appendChild(document.createTextNode(theme.label));
-        const matchedTreeTopic = matchedTopicFor(theme.label);
-        if (matchedTreeTopic) {
-            const star = document.createElement("span");
-            star.className = "theme-topic-star";
-            star.textContent = "★";
-            star.title = "Matches your requested topic: " + matchedTreeTopic;
-            row.appendChild(star);
-        }
-        li.appendChild(row);
+                // Theme cell: indent by depth + chevron + label (+ badges).
+                const nameCell = document.createElement("td");
+                nameCell.style.paddingLeft = (0.5 + depth * 1.4) + "rem";
+                if (children.length > 0) {
+                    const toggle = document.createElement("button");
+                    toggle.className = "tree-toggle";
+                    toggle.setAttribute("aria-expanded", "false");
+                    toggle.setAttribute("aria-label", "Toggle " + info.theme_name);
+                    toggle.setAttribute("tabindex", "-1");
+                    nameCell.appendChild(toggle);
+                } else {
+                    const gap = document.createElement("span");
+                    gap.className = "tree-toggle-gap";
+                    nameCell.appendChild(gap);
+                }
+                nameCell.appendChild(document.createTextNode(info.theme_name));
+                const matchedTopic = matchedTopicFor(info.theme_name);
+                if (matchedTopic) {
+                    row.classList.add("theme-row-matched");
+                    nameCell.appendChild(makeTopicBadge(matchedTopic));
+                }
+                if (code) {
+                    const chip = document.createElement("span");
+                    chip.className = "badge text-bg-light border ms-1";
+                    chip.textContent = "code";
+                    nameCell.appendChild(chip);
+                }
 
-        let childrenUl = null;
-        if (hasChildren) {
-            childrenUl = document.createElement("ul");
-            childrenUl.className = "tree-children";
-            childrenUl.setAttribute("role", "group");
-            childrenUl.style.display = "none";
-            for (const child of children) {
-                childrenUl.appendChild(buildNodeElement(child, /*isRoot=*/ false));
+                // Occurrences — codes have no frequency data, so show a dash
+                // rather than a misleading 0.
+                const countCell = document.createElement("td");
+                countCell.className = "text-end";
+                if (code) {
+                    countCell.textContent = "—";
+                    countCell.classList.add("theme-zero");
+                } else {
+                    countCell.textContent = String(info.occurrence_count);
+                    if (info.occurrence_count === 0) countCell.classList.add("theme-zero");
+                }
+
+                // Coverage with mini progress bar (values are numeric, so the
+                // interpolated markup below contains no user-supplied strings).
+                const coverageCell = document.createElement("td");
+                coverageCell.style.paddingLeft = "3rem";
+                if (code) {
+                    coverageCell.innerHTML = '<span class="coverage-label theme-zero">—</span>';
+                } else {
+                    const pct      = info.interview_coverage_percentage || 0;
+                    const barWidth = Math.min(Math.max(pct, 0), 100);
+                    coverageCell.innerHTML = `
+                        <div class="d-flex align-items-center gap-2">
+                            <div class="theme-progress">
+                                <div class="theme-progress-bar ${coverageBarClass(pct)}" style="width:${barWidth}%"></div>
+                            </div>
+                            <span class="coverage-label${pct === 0 ? " theme-zero" : ""}">${formatCoverage(pct)}</span>
+                        </div>`;
+                }
+
+                row.append(nameCell, countCell, coverageCell);
+
+                // Every row selects; rows with children also toggle their subtree.
+                row.addEventListener("click", () => {
+                    showThemeDetails(theme.id);
+                    if (children.length > 0) toggleChildren(theme.id);
+                });
+
+                themesTableBody.appendChild(row);
+                renderLevel(children, depth + 1, theme.id);
             }
-            li.appendChild(childrenUl);
+        })(treeData, 0, null);
+
+        highlightSelectedRow();
+    }
+
+    function rowFor(themeId) {
+        return themesTableBody.querySelector(`tr[data-theme-id="${CSS.escape(themeId)}"]`);
+    }
+
+    function directChildRows(themeId) {
+        return [...themesTableBody.querySelectorAll(`tr[data-parent-id="${CSS.escape(themeId)}"]`)];
+    }
+
+    // Collapse a node's whole subtree and reset its toggle state, so a
+    // re-expanded parent shows only its direct children.
+    function collapseSubtree(themeId) {
+        const toggle = rowFor(themeId)?.querySelector(".tree-toggle");
+        if (toggle) toggle.setAttribute("aria-expanded", "false");
+        for (const child of directChildRows(themeId)) {
+            child.classList.add("d-none");
+            collapseSubtree(child.dataset.themeId);
         }
+    }
 
-        // Click handler: every row selects; rows with children also toggle.
-        // Uses the closure-captured `li` / `childrenUl` so it works at any depth
-        // (the old code's `row.closest(".tree-group")` only worked at root level).
-        row.addEventListener("click", () => {
-            showThemeDetails(row.dataset.themeId);
-            if (!hasChildren) return;
-            const toggle  = row.querySelector(".tree-toggle");
-            const expanded = toggle.getAttribute("aria-expanded") === "true";
-            toggle.setAttribute("aria-expanded", String(!expanded));
-            childrenUl.style.display = expanded ? "none" : "";
-        });
+    function setExpanded(themeId, expanded) {
+        const toggle = rowFor(themeId)?.querySelector(".tree-toggle");
+        if (!toggle) return;
+        toggle.setAttribute("aria-expanded", String(expanded));
+        for (const child of directChildRows(themeId)) {
+            if (expanded) {
+                child.classList.remove("d-none");
+            } else {
+                child.classList.add("d-none");
+                collapseSubtree(child.dataset.themeId);
+            }
+        }
+    }
 
-        return li;
+    function toggleChildren(themeId) {
+        const toggle = rowFor(themeId)?.querySelector(".tree-toggle");
+        if (!toggle) return;
+        setExpanded(themeId, toggle.getAttribute("aria-expanded") !== "true");
+    }
+
+    // Expand every ancestor so the given theme's row is visible.
+    function revealTheme(themeId) {
+        const ancestors = [];
+        let parent = parentIdByThemeId[themeId];
+        while (parent) {
+            ancestors.unshift(parent);
+            parent = parentIdByThemeId[parent];
+        }
+        for (const id of ancestors) setExpanded(id, true);
     }
 
     // ------------------------------------------------------------------
@@ -395,12 +428,14 @@
     currentThemeInfoById = buildThemeInfoMap(frequencies, tree);
     clearThemeDetails();
     updateMetricCards();
-    renderThemeTable(frequencies);
-    renderTree(tree);
+    renderThemeTreeTable(tree);
 
-    // Auto-select the top theme by frequency on load.
+    // Auto-select the top theme by frequency on load and make its row visible.
     const top = sortByFrequency(frequencies)[0];
-    if (top) showThemeDetails(top.theme_id);
+    if (top) {
+        showThemeDetails(top.theme_id);
+        revealTheme(top.theme_id);
+    }
 
     // ------------------------------------------------------------------
     // Quotes modal

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -203,7 +203,7 @@
             Ordered by frequency. Click a row to select a theme; rows with a
             chevron expand to show their sub-themes, also ordered by frequency.
           </p>
-          <div class="table-responsive">
+          <div class="table-responsive themes-table-scroll">
             <table class="table table-sm align-middle mb-0">
               <thead>
                 <tr class="theme-table-head">

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -180,11 +180,11 @@
                 <p id="theme-details-coverage" class="td-stat-number mb-0"></p>
                 <p class="td-stat-label mb-0">Interview Coverage</p>
               </div>
-            </div>
-            <div class="mt-3">
-              <button id="theme-details-view-quotes" class="btn btn-sm btn-outline-primary">
-                View Quotes
-              </button>
+              <div class="text-center">
+                {# Filled by the quotes module once the theme's quotes load. #}
+                <p id="theme-details-quotes" class="td-stat-number mb-0"></p>
+                <p class="td-stat-label mb-0">Quotes</p>
+              </div>
             </div>
           </div>
 
@@ -192,28 +192,61 @@
       </div>
     </div>
 
-    {# Merged themes box: hierarchy + frequency in one table (issue #226).
-       Rows are rendered client-side by codebook_themes.js — siblings ordered
-       by frequency at every depth, expandable parents, coverage bars. #}
+    {# Merged themes box: hierarchy + frequency in one table (issue #226) with
+       the selected theme's quotes alongside (issue #227). Rows are rendered
+       client-side by codebook_themes.js — siblings ordered by frequency at
+       every depth, expandable parents, coverage bars. The quotes panel reacts
+       to the theme:selected event and pages through the theme's quotes. #}
     <div class="row g-3">
       <div class="col-12">
         <div class="bg-white border rounded-3 p-3">
-          <h2 class="h6 panel-title">Themes</h2>
-          <p class="text-secondary small mb-2">
-            Ordered by frequency. Click a row to select a theme; rows with a
-            chevron expand to show their sub-themes, also ordered by frequency.
-          </p>
-          <div class="table-responsive themes-table-scroll">
-            <table class="table table-sm align-middle mb-0">
-              <thead>
-                <tr class="theme-table-head">
-                  <th style="width:45%">Theme</th>
-                  <th class="text-end" style="width:120px">Occurrences</th>
-                  <th style="width:220px; padding-left:3rem">Interview Coverage</th>
-                </tr>
-              </thead>
-              <tbody id="themes-table-body"></tbody>
-            </table>
+          <div class="row g-3">
+
+            <div class="col-12 col-xl-7">
+              <h2 class="h6 panel-title">Themes</h2>
+              <p class="text-secondary small mb-2">
+                Ordered by frequency. Click a row to select a theme; rows with a
+                chevron expand to show their sub-themes, also ordered by frequency.
+              </p>
+              <div class="table-responsive themes-table-scroll">
+                <table class="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr class="theme-table-head">
+                      <th style="width:45%">Theme</th>
+                      <th class="text-end" style="width:120px">Occurrences</th>
+                      <th style="width:220px; padding-left:3rem">Interview Coverage</th>
+                    </tr>
+                  </thead>
+                  <tbody id="themes-table-body"></tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="col-12 col-xl-5 quotes-panel">
+              <h2 class="h6 panel-title" id="quotes-panel-title">Quotes</h2>
+              <p class="text-secondary small mb-2" id="quotes-panel-total"></p>
+
+              <p id="quotes-none" class="text-secondary mb-0 text-center py-4">
+                Select a theme to see its quotes.
+              </p>
+              <div id="quotes-loading" class="d-none text-center py-5">
+                <div class="spinner-border text-primary" role="status">
+                  <span class="visually-hidden">Loading quotes…</span>
+                </div>
+              </div>
+              <div id="quotes-error" class="d-none alert alert-danger"></div>
+              <div id="quotes-list" class="d-none quotes-list-scroll"></div>
+              <p id="quotes-empty" class="d-none text-secondary text-center py-4">No quotes found for this theme.</p>
+
+              {# d-none is declared after d-flex in Bootstrap, so it wins while
+                 present; the JS only ever toggles d-none. #}
+              <div class="d-flex d-none justify-content-between align-items-center mt-2" id="quotes-pagination">
+                <button class="btn btn-sm btn-outline-secondary" id="quotes-prev">&#8592; Previous</button>
+                <span class="text-secondary small" id="quotes-page-info"></span>
+                <button class="btn btn-sm btn-outline-secondary" id="quotes-next">Next &#8594;</button>
+              </div>
+            </div>
+
           </div>
         </div>
       </div>
@@ -270,35 +303,6 @@
 
 </div>
 
-{# Quotes modal #}
-<div class="modal fade" id="quotes-modal" tabindex="-1" aria-labelledby="quotes-modal-label" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-scrollable">
-    <div class="modal-content">
-      <div class="modal-header">
-        <div>
-          <h5 class="modal-title mb-0" id="quotes-modal-label">Quotes</h5>
-          <p class="text-secondary small mb-0" id="quotes-modal-total"></p>
-        </div>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body" id="quotes-modal-body">
-        <div id="quotes-loading" class="text-center py-5">
-          <div class="spinner-border text-primary" role="status">
-            <span class="visually-hidden">Loading quotes…</span>
-          </div>
-        </div>
-        <div id="quotes-error" class="d-none alert alert-danger"></div>
-        <div id="quotes-list" class="d-none"></div>
-        <p id="quotes-empty" class="d-none text-secondary text-center py-4">No quotes found for this theme.</p>
-      </div>
-      <div class="modal-footer d-none" id="quotes-pagination">
-        <button class="btn btn-sm btn-outline-secondary" id="quotes-prev">&#8592; Previous</button>
-        <span class="text-secondary small" id="quotes-page-info"></span>
-        <button class="btn btn-sm btn-outline-secondary" id="quotes-next">Next &#8594;</button>
-      </div>
-    </div>
-  </div>
-</div>
 {% endblock %}
 
 {% block scripts %}

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -192,17 +192,22 @@
       </div>
     </div>
 
-    {# Main panels #}
-    <div class="row g-3 align-items-stretch">
-
-      <div class="col-12 col-xl-7">
-        <div class="bg-white border rounded-3 p-3 h-100">
-          <h2 class="h6 panel-title">Theme Frequency</h2>
+    {# Merged themes box: hierarchy + frequency in one table (issue #226).
+       Rows are rendered client-side by codebook_themes.js — siblings ordered
+       by frequency at every depth, expandable parents, coverage bars. #}
+    <div class="row g-3">
+      <div class="col-12">
+        <div class="bg-white border rounded-3 p-3">
+          <h2 class="h6 panel-title">Themes</h2>
+          <p class="text-secondary small mb-2">
+            Ordered by frequency. Click a row to select a theme; rows with a
+            chevron expand to show their sub-themes, also ordered by frequency.
+          </p>
           <div class="table-responsive">
             <table class="table table-sm align-middle mb-0">
               <thead>
                 <tr class="theme-table-head">
-                  <th style="width:35%">Theme</th>
+                  <th style="width:45%">Theme</th>
                   <th class="text-end" style="width:120px">Occurrences</th>
                   <th style="width:220px; padding-left:3rem">Interview Coverage</th>
                 </tr>
@@ -212,14 +217,6 @@
           </div>
         </div>
       </div>
-
-      <div class="col-12 col-xl-5">
-        <div class="bg-white border rounded-3 p-3 h-100 d-flex flex-column theme-tree-card">
-          <h2 class="h6 panel-title">Theme Hierarchy</h2>
-          <div id="theme-tree" class="tree-container border rounded-2 p-2 flex-grow-1"></div>
-        </div>
-      </div>
-
     </div>
 
     {# Demographic breakdown (UC 3.6) — per-theme, driven by the selected theme #}


### PR DESCRIPTION
Closes #227.

Moves the theme quotes out of the pop-up modal and into the merged Themes box, right next to the hierarchy so the quotes for the selected theme are readily visible instead of hidden behind a button.

## Working

- The merged Themes box now has two columns separated by a divider: the theme hierarchy/frequency table on the left, and a **Quotes panel** on the right.
- Selecting any theme loads its quotes automatically > no button, no pop-up. 
- Each quote card keeps its interviewee label and a **View Interview** link (now blue on hover) into the transcript reader.
- Only the quote cards scroll (capped at 70vh, symmetric with the table column), so the panel title and pagination stay visible.
- The **Theme Details** header gains a third stat  **Quotes**  next to Occurrences and Interview Coverage, filled from the same fetch that populates the panel.
- Clear states throughout: "Select a theme to see its quotes", a loading spinner, "No quotes found for this theme", and an error message.

<img width="1340" height="777" alt="image" src="https://github.com/user-attachments/assets/048194e4-7fea-4ff9-9231-6bef4b3ab0ad" />


## Changes

**Frontend only : no backend/API changes.** The quotes endpoint and its pagination are used exactly as before.

- `themes.html`: the merged box becomes two columns; the quotes panel reuses the modal's element ids; the `#quotes-modal` and the details-panel "View Quotes" button are removed.
- `codebook_themes.js`: the quotes logic (fetch/render/pagination) is kept and retargeted to the inline panel. It now subscribes to the existing `theme:selected` event (the same contract the demographic-breakdown panel uses, including the boot-race catch-up), with a request token that drops stale responses on fast selection changes. Re-selecting the same theme keeps the current page. The quote-count stat is owned by the quotes module (one-directional DOM write).
- `main.css`: divider between the columns, shared 70vh scroll caps with scrollbar clearance, and the panel styling.
