### PR TITLE
Refactoring occurrence calculation for parent themes

### DIFF
--- a/Backend/app/schemas/theme_views.py
+++ b/Backend/app/schemas/theme_views.py
@@ -23,6 +23,8 @@ class ThemeFrequencyItem(BaseSchema):
     theme_name: str
     occurrence_count: int = Field(ge=0)
     interview_coverage_percentage: float = Field(ge=0.0, le=100.0)
+    parent_occurrence_count: int = Field(ge=0)
+    parent_interview_coverage_percentage: float = Field(ge=0.0, le=100.0)
 
 
 class ThemeQuoteItem(BaseSchema):

--- a/Backend/app/services/theme_frequency.py
+++ b/Backend/app/services/theme_frequency.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from uuid import UUID
 
-from sqlalchemy import and_, desc, func, select
+from sqlalchemy import and_, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
@@ -12,6 +13,7 @@ from app.models import (
     DocumentCoding,
     Theme,
     ThemeAssignment,
+    ThemeHierarchyRelationship,
 )
 from app.schemas.theme_views import ThemeFrequencyItem
 from app.services.theme_graph import ThemeNotFoundError
@@ -35,28 +37,47 @@ class ThemeFrequencyService:
             application_run_id=application_run_id,
         )
         themes = await self._load_active_themes(codebook_id=codebook_id)
-        occurrence_count_by_theme_id = await self._load_occurrence_count_by_theme_id(
+        theme_ids = {theme.id for theme in themes}
+        document_ids_by_theme_id = await self._load_document_ids_by_theme_id(
             codebook_id=codebook_id,
             application_run_id=selected_run_id,
-            theme_ids={theme.id for theme in themes},
+            theme_ids=theme_ids,
+        )
+        children_by_theme_id = await self._load_hierarchy_children(
+            codebook_id=codebook_id,
+            theme_ids=theme_ids,
+        )
+
+        parent_occurrence_by_theme_id = self._aggregate_occurrence_counts(
+            theme_ids=theme_ids,
+            document_ids_by_theme_id=document_ids_by_theme_id,
+            children_by_theme_id=children_by_theme_id,
         )
         total_interviews_in_corpus = await self._load_total_interviews_in_corpus(
             codebook_id=codebook_id,
             application_run_id=selected_run_id,
         )
 
-        payload = [
-            ThemeFrequencyItem(
-                theme_id=theme.id,
-                theme_name=theme.label,
-                occurrence_count=occurrence_count_by_theme_id.get(theme.id, 0),
-                interview_coverage_percentage=self._to_coverage_percentage(
-                    occurrence_count=occurrence_count_by_theme_id.get(theme.id, 0),
-                    total_interviews=total_interviews_in_corpus,
-                ),
+        payload = []
+        for theme in themes:
+            own_occurrence = len(document_ids_by_theme_id.get(theme.id, set()))
+            parent_occurrence = parent_occurrence_by_theme_id.get(theme.id, own_occurrence)
+            payload.append(
+                ThemeFrequencyItem(
+                    theme_id=theme.id,
+                    theme_name=theme.label,
+                    occurrence_count=own_occurrence,
+                    interview_coverage_percentage=self._to_coverage_percentage(
+                        occurrence_count=own_occurrence,
+                        total_interviews=total_interviews_in_corpus,
+                    ),
+                    parent_occurrence_count=parent_occurrence,
+                    parent_interview_coverage_percentage=self._to_coverage_percentage(
+                        occurrence_count=parent_occurrence,
+                        total_interviews=total_interviews_in_corpus,
+                    ),
+                )
             )
-            for theme in themes
-        ]
         payload.sort(
             key=lambda item: (
                 -item.occurrence_count,
@@ -115,33 +136,80 @@ class ThemeFrequencyService:
         )
         return list((await self._session.scalars(stmt)).all())
 
-    async def _load_occurrence_count_by_theme_id(
+    async def _load_document_ids_by_theme_id(
         self,
         *,
         codebook_id: UUID,
         application_run_id: UUID | None,
         theme_ids: set[UUID],
-    ) -> dict[UUID, int]:
+    ) -> dict[UUID, set[UUID]]:
         del codebook_id
         if application_run_id is None or not theme_ids:
-            return {theme_id: 0 for theme_id in theme_ids}
+            return {theme_id: set() for theme_id in theme_ids}
         stmt = (
-            select(
-                ThemeAssignment.theme_id,
-                func.count(func.distinct(DocumentCoding.document_id)),
-            )
+            select(ThemeAssignment.theme_id, DocumentCoding.document_id)
             .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
             .where(
                 DocumentCoding.application_run_id == application_run_id,
                 ThemeAssignment.theme_id.in_(theme_ids),
                 ThemeAssignment.is_present.is_(True),
             )
-            .group_by(ThemeAssignment.theme_id)
+            .distinct()
         )
         rows = (await self._session.execute(stmt)).all()
-        counts = {theme_id: 0 for theme_id in theme_ids}
-        counts.update({theme_id: int(count) for theme_id, count in rows})
-        return counts
+        document_ids: dict[UUID, set[UUID]] = {theme_id: set() for theme_id in theme_ids}
+        for theme_id, document_id in rows:
+            document_ids[theme_id].add(document_id)
+        return document_ids
+
+    async def _load_hierarchy_children(
+        self,
+        *,
+        codebook_id: UUID,
+        theme_ids: set[UUID],
+    ) -> dict[UUID, set[UUID]]:
+        if not theme_ids:
+            return {}
+        stmt = select(
+            ThemeHierarchyRelationship.parent_theme_id,
+            ThemeHierarchyRelationship.child_theme_id,
+        ).where(
+            ThemeHierarchyRelationship.codebook_id == codebook_id,
+            ThemeHierarchyRelationship.is_active.is_(True),
+            ThemeHierarchyRelationship.parent_theme_id.in_(theme_ids),
+            ThemeHierarchyRelationship.child_theme_id.in_(theme_ids),
+        )
+        rows = (await self._session.execute(stmt)).all()
+        children: dict[UUID, set[UUID]] = defaultdict(set)
+        for parent_id, child_id in rows:
+            children[parent_id].add(child_id)
+        return children
+
+    @staticmethod
+    def _aggregate_occurrence_counts(
+        *,
+        theme_ids: set[UUID],
+        document_ids_by_theme_id: dict[UUID, set[UUID]],
+        children_by_theme_id: dict[UUID, set[UUID]],
+    ) -> dict[UUID, int]:
+        # Roll each theme's own document set up through its descendants, unioning so shared documents are counted once
+        resolved: dict[UUID, frozenset[UUID]] = {}
+
+        def resolve(theme_id: UUID, ancestry: frozenset[UUID]) -> frozenset[UUID]:
+            cached = resolved.get(theme_id)
+            if cached is not None:
+                return cached
+            documents = set(document_ids_by_theme_id.get(theme_id, ()))
+            next_ancestry = ancestry | {theme_id} # prevents cycles
+            for child_id in children_by_theme_id.get(theme_id, ()):
+                if child_id in next_ancestry:
+                    continue
+                documents |= resolve(child_id, next_ancestry)
+            result = frozenset(documents)
+            resolved[theme_id] = result
+            return result
+
+        return {theme_id: len(resolve(theme_id, frozenset())) for theme_id in theme_ids}
 
     async def _load_total_interviews_in_corpus(
         self,

--- a/Backend/tests/test_router_units.py
+++ b/Backend/tests/test_router_units.py
@@ -272,6 +272,8 @@ class RouterUnitTests(unittest.IsolatedAsyncioTestCase):
                             theme_name="Incident Recovery",
                             occurrence_count=0,
                             interview_coverage_percentage=0.0,
+                            parent_occurrence_count=0,
+                            parent_interview_coverage_percentage=0.0,
                         )
                     ]
                 ),

--- a/Backend/tests/test_theme_frequency_service.py
+++ b/Backend/tests/test_theme_frequency_service.py
@@ -8,7 +8,13 @@ from uuid import uuid4
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.models import Base
+from app.models import (
+    Base,
+    CodebookApplicationRun,
+    CorpusDocument,
+    DocumentCoding,
+    ThemeAssignment,
+)
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import ThemeNotFoundError
 from tests.fixtures.theme_graph_fixtures import (
@@ -58,16 +64,17 @@ class ThemeFrequencyServiceTests(unittest.IsolatedAsyncioTestCase):
             seed = await seed_three_theme_codebook(session)
             service = ThemeFrequencyService(session)
 
-            counts_by_theme_id = {
-                seed.theme_ids_by_label["Delivery Confidence"]: 2,
-                seed.theme_ids_by_label["Planning Clarity"]: 5,
-                seed.theme_ids_by_label["Scope Stability"]: 5,
+            d1, d2, d3 = uuid4(), uuid4(), uuid4()
+            document_ids_by_theme_id = {
+                seed.theme_ids_by_label["Delivery Confidence"]: {d1},
+                seed.theme_ids_by_label["Planning Clarity"]: {d1, d2},
+                seed.theme_ids_by_label["Scope Stability"]: {d2, d3},
             }
             with (
                 patch.object(
                     ThemeFrequencyService,
-                    "_load_occurrence_count_by_theme_id",
-                    new=AsyncMock(return_value=counts_by_theme_id),
+                    "_load_document_ids_by_theme_id",
+                    new=AsyncMock(return_value=document_ids_by_theme_id),
                 ),
                 patch.object(
                     ThemeFrequencyService,
@@ -82,8 +89,83 @@ class ThemeFrequencyServiceTests(unittest.IsolatedAsyncioTestCase):
                 ["Planning Clarity", "Scope Stability", "Delivery Confidence"],
             )
             self.assertEqual(
+                [item.occurrence_count for item in payload],
+                [2, 2, 1],
+            )
+            self.assertEqual(
                 [item.interview_coverage_percentage for item in payload],
-                [50.0, 50.0, 20.0],
+                [20.0, 20.0, 10.0],
+            )
+            self.assertEqual(
+                [item.parent_occurrence_count for item in payload],
+                [2, 2, 3],
+            )
+            self.assertEqual(
+                [item.parent_interview_coverage_percentage for item in payload],
+                [20.0, 20.0, 30.0],
+            )
+
+    async def test_parent_occurrence_is_union_of_children_over_real_rows(self) -> None:
+        async with self.session_factory() as session:
+            seed = await seed_three_theme_codebook(session)
+            corpus_id, run_id = uuid4(), uuid4()
+            document_ids = [uuid4() for _ in range(3)]
+            for document_id in document_ids:
+                session.add(
+                    CorpusDocument(id=document_id, corpus_id=corpus_id, title="doc", content="body")
+                )
+            session.add(
+                CodebookApplicationRun(
+                    id=run_id,
+                    corpus_id=corpus_id,
+                    codebook_id=seed.codebook_id,
+                    status="succeeded",
+                    documents_total=3,
+                    documents_coded=3,
+                )
+            )
+            await session.flush()
+
+            present_docs_by_label = {
+                "Planning Clarity": {document_ids[0], document_ids[1]},
+                "Scope Stability": {document_ids[1], document_ids[2]},
+            }
+            for document_id in document_ids:
+                coding_id = uuid4()
+                session.add(
+                    DocumentCoding(
+                        id=coding_id,
+                        application_run_id=run_id,
+                        document_id=document_id,
+                        codebook_id=seed.codebook_id,
+                        status="coded",
+                    )
+                )
+                await session.flush()
+                for label, present_docs in present_docs_by_label.items():
+                    session.add(
+                        ThemeAssignment(
+                            id=uuid4(),
+                            document_coding_id=coding_id,
+                            theme_id=seed.theme_ids_by_label[label],
+                            is_present=document_id in present_docs,
+                            confidence=0.9,
+                        )
+                    )
+            await session.commit()
+
+            payload = await ThemeFrequencyService(session).list_theme_frequencies(
+                codebook_id=seed.codebook_id
+            )
+            own_by_name = {item.theme_name: item.occurrence_count for item in payload}
+            parent_by_name = {item.theme_name: item.parent_occurrence_count for item in payload}
+            self.assertEqual(
+                own_by_name,
+                {"Delivery Confidence": 0, "Planning Clarity": 2, "Scope Stability": 2},
+            )
+            self.assertEqual(
+                parent_by_name,
+                {"Delivery Confidence": 3, "Planning Clarity": 2, "Scope Stability": 2},
             )
 
     async def test_raises_not_found_for_unknown_codebook(self) -> None:

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -5,6 +5,19 @@
     // Data is embedded server-side as JSON — no extra HTTP requests needed.
     const frequencies       = JSON.parse(appRoot.dataset.frequencies || "[]");
     const tree              = JSON.parse(appRoot.dataset.tree        || "[]");
+
+    // Surface the parent roll-up as the canonical occurrence/coverage so every
+    // consumer displays it. Keep each node's own numbers under `own_*`.
+    for (const f of frequencies) {
+        f.own_occurrence_count = f.occurrence_count;
+        f.own_interview_coverage_percentage = f.interview_coverage_percentage;
+        if (typeof f.parent_occurrence_count === "number") {
+            f.occurrence_count = f.parent_occurrence_count;
+        }
+        if (typeof f.parent_interview_coverage_percentage === "number") {
+            f.interview_coverage_percentage = f.parent_interview_coverage_percentage;
+        }
+    }
     const codes             = JSON.parse(appRoot.dataset.codes       || "[]");
     const quotesUrlTemplate = appRoot.dataset.quotesUrlTemplate || "";
     const readUrlTemplate   = appRoot.dataset.readUrlTemplate   || "";


### PR DESCRIPTION
Theme statistics now roll up the hierarchy: a parent theme's occurrence and interview coverage reflect **its own documents plus all of its descendants'**, deduplicated so a document shared across children is counted once (union, not sum).

### Changes
- **Backend:** `ThemeFrequencyItem` gains `parent_occurrence_count` and `parent_interview_coverage_percentage`. Each node keeps its own direct occurrence/coverage (unchanged); the roll-up is computed by unioning document-id sets up the theme tree in `ThemeFrequencyService`.  + tests
- **Frontend:** the Theme Browser displays the parent roll-up as the headline occurrence/coverage (each node's own numbers are retained under `own_*`). Wired in one normalization step in `codebook_themes.js`.


---

### Why this differs from the original ACs
The ACs are outdated, this is based on what we agreed in the team meeting. AC 1 (only leaf nodes applied to transcripts) is dropped: to keep the analysis working in its current form, non-leaf themes can still be applied to transcripts. That in turn makes AC 3 (merging single-child parents into their parent) non-trivial and lossy; folding the layers would discard assignments/quotes attached to those nodes, so it's dropped too. Only AC 2 (parent = union of children) remains, which is what this PR implements.