### PR TITLE
Feature/228 analysis in analysis tab

### DIFF
--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -85,6 +85,18 @@ def test_codebook_list_row_shows_review_button(client, fake_backend):
     assert b'href="/codebooks/cb-1/review"' in resp.data
 
 
+def test_codebook_list_row_has_no_view_themes_button(client, fake_backend):
+    # Navigating to the theme browser is only available from the Analysis
+    # tab now, so the Codebooks list no longer links there directly.
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    resp = client.get("/codebooks/", follow_redirects=True)
+    assert b"View themes" not in resp.data
+
+
 def test_codebook_list_shows_running_job_row(client, fake_backend):
     # In-progress runs are server-rendered so they're visible in any browser
     # or session, not just the one that started the run.
@@ -175,6 +187,26 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
     assert b'id="global-corpus-select"' in resp.data
 
 
+def test_codebook_themes_highlights_analysis_nav_tab(client, fake_backend):
+    # The theme browser is reached from the Analysis tab, so the nav bar
+    # should mark Analysis (not Codebooks) as active while viewing it.
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'href="/analysis/">Analysis</a>' in resp.data
+    body = resp.data.decode()
+    analysis_link_start = body.index('href="/analysis/">Analysis</a>')
+    analysis_class = body[:analysis_link_start].rsplit('class="', 1)[-1]
+    assert "active" in analysis_class
+    codebooks_link_start = body.index('>Codebooks</a>')
+    codebooks_class = body[:codebooks_link_start].rsplit('class="', 1)[-1]
+    assert "active" not in codebooks_class
+
+
 def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     fake_backend.codebooks = [
         {"id": "cb-1", "name": "Interview Codebook", "version": 1,
@@ -249,10 +281,10 @@ def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):
     assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
     assert b"Run Two Theme" in resp.data
     assert b"analysis-run-bar" in resp.data
-    assert b'id="application-run-select"' in resp.data
-    assert b'value="run-2" selected' in resp.data
+    assert b'id="application-run-select"' not in resp.data
     assert b"Latest successful" in resp.data
-    assert b"Follow-up Run - 2026-01-02 00:00" in resp.data
+    assert b"Follow-up Run" in resp.data
+    assert b"2026-01-02 00:00" in resp.data
     assert b"Latest successful run" not in resp.data
 
 
@@ -289,7 +321,7 @@ def test_codebook_themes_defaults_to_latest_successful_run(client, fake_backend)
 
     assert resp.status_code == 200
     assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
-    assert b'value="run-2" selected' in resp.data
+    assert b"Latest Run" in resp.data
     assert b"Latest Theme" in resp.data
     assert b"4 coded" in resp.data
     assert b"1 failed" in resp.data
@@ -313,9 +345,7 @@ def test_codebook_themes_shows_analysis_run_bar_without_runs(client, fake_backen
     assert b"analysis-run-bar" in resp.data
     assert b"Select an analysis run" in resp.data
     assert b"No analysis runs for this codebook." in resp.data
-    assert b'id="application-run-select"' in resp.data
-    assert b"disabled" in resp.data
-    assert b"No analysis runs available" in resp.data
+    assert b'id="application-run-select"' not in resp.data
 
 
 def test_codebook_themes_defaults_to_latest_failed_run_when_no_success(client, fake_backend):
@@ -349,7 +379,7 @@ def test_codebook_themes_defaults_to_latest_failed_run_when_no_success(client, f
 
     assert resp.status_code == 200
     assert fake_backend.last_theme_frequencies_application_run_id == "run-2"
-    assert b'value="run-2" selected' in resp.data
+    assert b"Failed Run 2" in resp.data
     assert b"Failed" in resp.data
     assert b"This analysis run failed." in resp.data
     assert b"2 coded" in resp.data
@@ -367,6 +397,33 @@ def test_codebook_themes_renders_name_from_query_param(client, fake_backend):
     resp = client.get("/codebooks/test-corpus-id/cb-1/themes?name=My+Codebook&version=3", follow_redirects=True)
     assert resp.status_code == 200
     assert b"My Codebook" in resp.data
+
+
+def test_codebook_themes_breadcrumb_shows_analysis_run_name(client, fake_backend):
+    # AC: breadcrumb reads "Analysis / {analysis_run_name}", not
+    # "Codebooks / {codebook_name}", and links back to the Analysis tab.
+    fake_backend.codebooks = [
+        {"id": "cb-1", "name": "Interview Codebook", "version": 1,
+         "project_id": "proj-1", "created_by": "alice", "description": None,
+         "corpus_id": fake_backend.corpus_id},
+    ]
+    fake_backend.application_runs = [
+        {"id": "run-1", "codebook_id": "cb-1", "name": "Initial Run",
+         "custom_id": "RUN-001", "status": "succeeded",
+         "created_at": "2026-01-01T00:00:00"},
+    ]
+    fake_backend.theme_tree = [
+        {"theme": {"id": "t-1", "label": "Work-Life Balance", "is_active": True},
+         "children": []},
+    ]
+    resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    breadcrumb_start = body.index('aria-label="breadcrumb"')
+    breadcrumb = body[breadcrumb_start:body.index("</nav>", breadcrumb_start)]
+    assert 'href="/analysis/?corpus_id=test-corpus-id">Analysis</a>' in breadcrumb
+    assert "Initial Run" in breadcrumb
+    assert "Codebooks" not in breadcrumb
 
 
 def test_codebook_themes_renders_empty_state(client, fake_backend):

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -64,15 +64,10 @@ def _prepare_application_runs(
     for run in application_runs:
         run_id = str(run.get("id"))
         timestamp = _format_run_timestamp(run)
-        run_name = run.get("name") or run.get("custom_id") or run_id
-        label = f"{run_name} - {timestamp}" if timestamp else run_name
-        if run_id == latest_successful_id:
-            label = f"{label} - Latest successful"
         decorated_runs.append({
             **run,
             "id": run_id,
             "timestamp_label": timestamp,
-            "select_label": label,
             "is_latest_successful": run_id == latest_successful_id,
         })
 

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -270,7 +270,6 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
     version = request.args.get("version", "")
     selected_application_run_id = request.args.get("application_run_id", "")
     active_codebook_id = codebook_id
-    application_runs: list[dict] = []
     selected_application_run: dict | None = None
     corpus_name = "Selected Corpus"
     corpus_options: list[dict] = [{"id": corpus_id, "name": corpus_name}]
@@ -303,7 +302,7 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         research_query = active_codebook.get("research_query") or ""
         researcher_topics = active_codebook.get("researcher_topics") or ""
         application_runs = client.list_codebook_application_runs(active_codebook_id)
-        application_runs, selected_application_run, selected_application_run_id = (
+        _, selected_application_run, selected_application_run_id = (
             _prepare_application_runs(application_runs, selected_application_run_id)
         )
 
@@ -336,7 +335,6 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             codes=[],
             research_query="",
             researcher_topics="",
-            application_runs=application_runs,
             selected_application_run_id=selected_application_run_id,
             selected_application_run=selected_application_run,
             demographic_dimensions=[],
@@ -357,7 +355,6 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
             codes=[],
             research_query="",
             researcher_topics="",
-            application_runs=application_runs,
             selected_application_run_id=selected_application_run_id,
             selected_application_run=selected_application_run,
             demographic_dimensions=[],
@@ -376,7 +373,6 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
         codes=codes,
         research_query=research_query,
         researcher_topics=researcher_topics,
-        application_runs=application_runs,
         selected_application_run_id=selected_application_run_id,
         selected_application_run=selected_application_run,
         demographic_dimensions=demographic_dimensions,

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -99,20 +99,6 @@
     color: rgba(255, 255, 255, 0.5);
 }
 
-.analysis-run-control {
-    width: min(100%, 360px);
-}
-
-.analysis-run-control .form-select {
-    border-color: rgba(255, 255, 255, 0.38);
-    box-shadow: none;
-}
-
-.analysis-run-control .form-select:focus {
-    border-color: #fff;
-    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.24);
-}
-
 .theme-version-badge {
     background: rgba(255, 255, 255, 0.18);
     color: #fff;
@@ -122,12 +108,6 @@
     border-radius: 20px;
     border: 1px solid rgba(255, 255, 255, 0.3);
     letter-spacing: 0.03em;
-}
-
-@media (max-width: 767.98px) {
-    .analysis-run-control {
-        width: 100%;
-    }
 }
 
 /* ── Metric cards ───────────────────────────────────────────────────────────── */
@@ -921,7 +901,7 @@
     white-space: nowrap;
 }
 
-/* Search sits on the gradient; mirror the .analysis-run-control treatment. */
+/* Search sits on the gradient; give the input a matching light border. */
 .transcripts-modal-search {
     border-color: rgba(255, 255, 255, 0.38);
     box-shadow: none;

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -22,19 +22,6 @@
     const quotesUrlTemplate = appRoot.dataset.quotesUrlTemplate || "";
     const readUrlTemplate   = appRoot.dataset.readUrlTemplate   || "";
     const applicationRunId  = appRoot.dataset.applicationRunId || "";
-    const applicationRunSelect = document.getElementById("application-run-select");
-
-    if (applicationRunSelect) {
-        applicationRunSelect.addEventListener("change", () => {
-            const url = new URL(window.location.href);
-            if (applicationRunSelect.value) {
-                url.searchParams.set("application_run_id", applicationRunSelect.value);
-            } else {
-                url.searchParams.delete("application_run_id");
-            }
-            window.location.href = url.toString();
-        });
-    }
 
     // Topics the researcher asked the AI to focus on.
     const researcherTopics = (() => {

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -51,11 +51,11 @@
                href="{{ url_for('demographic.demographic_landing') }}">Demographic Data</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint in ('codebooks.list_codebooks', 'codebooks.list_codebooks_for_corpus', 'codebooks.codebook_themes', 'codebooks.codebook_themes_for_corpus', 'codebooks.export_codebook', 'codebooks.success') %}active{% endif %}"
+            <a class="nav-link {% if request.endpoint in ('codebooks.list_codebooks', 'codebooks.list_codebooks_for_corpus', 'codebooks.export_codebook', 'codebooks.success') %}active{% endif %}"
                href="{{ url_for('codebooks.list_codebooks') }}">Codebooks</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {% if request.endpoint == 'analysis.index' %}active{% endif %}"
+            <a class="nav-link {% if request.endpoint in ('analysis.index', 'codebooks.codebook_themes', 'codebooks.codebook_themes_for_corpus') %}active{% endif %}"
                href="{{ url_for('analysis.index') }}">Analysis</a>
           </li>
           <li class="nav-item">

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -112,10 +112,6 @@
                 </td>
                 <td>
                   <a class="btn btn-sm btn-outline-primary"
-                     href="{{ url_for('codebooks.codebook_themes_for_corpus', corpus_id=corpus_id, codebook_id=cb.id, name=cb.name, version=cb.version) }}">
-                    View themes
-                  </a>
-                  <a class="btn btn-sm btn-outline-primary ms-1"
                      href="{{ url_for('codebooks.codebook_review', codebook_id=cb.id) }}">
                     Review &amp; edit
                   </a>

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -27,9 +27,11 @@
   <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb mb-0">
       <li class="breadcrumb-item">
-        <a href="{{ url_for('codebooks.list_codebooks_for_corpus', corpus_id=corpus_id) }}">Codebooks</a>
+        <a href="{{ url_for('analysis.index', corpus_id=corpus_id) }}">Analysis</a>
       </li>
-      <li class="breadcrumb-item active">{{ name or 'Theme Browser' }}</li>
+      <li class="breadcrumb-item active">
+        {{ (selected_application_run.name or selected_application_run.custom_id or selected_application_run.id) if selected_application_run else 'Theme Browser' }}
+      </li>
     </ol>
   </nav>
 
@@ -60,7 +62,7 @@
   </div>
 
   <div class="analysis-run-bar rounded-3 mb-4 p-4">
-    <div class="d-flex align-items-start justify-content-between flex-wrap gap-3">
+    <div class="d-flex align-items-start flex-wrap gap-3">
       <div>
         <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Analysis Run</p>
         <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
@@ -109,22 +111,6 @@
           {% endif %}
         {% else %}
           <p class="analysis-run-message mb-0">No analysis runs for this codebook.</p>
-        {% endif %}
-      </div>
-      <div class="analysis-run-control">
-        <label for="application-run-select" class="form-label text-white-50 small text-uppercase fw-semibold mb-1" style="letter-spacing:.07em">Select Run</label>
-        {% if application_runs %}
-          <select id="application-run-select" class="form-select form-select-sm">
-            {% for run in application_runs %}
-              <option value="{{ run.id }}" {% if selected_application_run_id == run.id|string %}selected{% endif %}>
-                {{ run.select_label }}
-              </option>
-            {% endfor %}
-          </select>
-        {% else %}
-          <select id="application-run-select" class="form-select form-select-sm" disabled>
-            <option selected>No analysis runs available</option>
-          </select>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
**View themes button removed**
Deleted the "View themes" button from the Codebooks list. Only "Review & edit" remains per row.

**No run/codebook picker at the top of Analysis view**
Removed the run-selector dropdown (and its label) from the theme browser page. The Analysis Run name/status/details and the codebook name still show at the top, but now as static text with no way to switch runs from there. Also cleaned up the now-dead JS click handler for that dropdown, the unused CSS rules for it, and an unused field in the backend controller that only existed to feed the dropdown's option labels.

Breadcrumb changed from "Codebook / {name}" to "Analysis / {analysis_run_name}"
The breadcrumb now links back to the Analysis tab and shows the name of the analysis run you're viewing, instead of the codebook name. Falls back to "Theme Browser" if there's no run yet.

**Nav bar grouping**
The theme browser page now highlights the "Analysis" tab instead of "Codebooks" in the nav bar, since it's only reachable from the Analysis tab now (via "View Analysis" on a previous run).


<img width="1621" height="367" alt="image" src="https://github.com/user-attachments/assets/9201b57e-55df-451b-8771-3250e56e2d23" />

<img width="1738" height="543" alt="image" src="https://github.com/user-attachments/assets/8a878354-2e9e-4bea-829e-fb80f7a6b5df" />
