### PR TITLE
Display quotes and demographics from child themes when parent theme is selected

### DIFF
--- a/Backend/app/routers/themes.py
+++ b/Backend/app/routers/themes.py
@@ -121,6 +121,7 @@ async def list_theme_quotes(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     application_run_id: UUID | None = Query(default=None),
+    include_descendants: bool = Query(default=True),
 ) -> JSONResponse:
     service = ThemeQuotesService(session)
     payload = await service.list_theme_quotes(
@@ -129,5 +130,6 @@ async def list_theme_quotes(
         page=page,
         page_size=page_size,
         application_run_id=application_run_id,
+        include_descendants=include_descendants,
     )
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))

--- a/Backend/app/schemas/theme_views.py
+++ b/Backend/app/schemas/theme_views.py
@@ -35,6 +35,7 @@ class ThemeQuoteItem(BaseSchema):
     document_id: UUID
     document_title: str
     interviewee_id: str | None
+    theme_ids: list[UUID]
 
 
 class DemographicDimensionsResponse(BaseSchema):

--- a/Backend/app/services/theme_demographic_breakdown.py
+++ b/Backend/app/services/theme_demographic_breakdown.py
@@ -23,6 +23,7 @@ from app.schemas.theme_views import (
     ThemeDimensionBreakdown,
 )
 from app.services.theme_graph import ThemeNotFoundError
+from app.services.theme_hierarchy import load_descendants_and_self
 
 # The username column links a demographic row to a transcript; it is an
 # identifier, not a demographic variable, so it is never offered as a dimension.
@@ -111,8 +112,11 @@ class ThemeDemographicBreakdownService:
             )
 
         population = await self._load_population(run_id=run_id)
+        theme_ids = await load_descendants_and_self(
+            self._session, codebook_id=codebook_id, theme_id=theme_id
+        )
         present_document_ids = await self._load_present_document_ids(
-            run_id=run_id, theme_id=theme_id
+            run_id=run_id, theme_ids=theme_ids
         )
 
         return ThemeDemographicBreakdownResponse(
@@ -203,7 +207,7 @@ class ThemeDemographicBreakdownService:
         return [(row.document_id, row.data) for row in rows]
 
     async def _load_present_document_ids(
-        self, *, run_id: UUID, theme_id: UUID
+        self, *, run_id: UUID, theme_ids: set[UUID]
     ) -> set[UUID]:
         rows = (
             await self._session.execute(
@@ -214,7 +218,7 @@ class ThemeDemographicBreakdownService:
                 )
                 .where(
                     DocumentCoding.application_run_id == run_id,
-                    ThemeAssignment.theme_id == theme_id,
+                    ThemeAssignment.theme_id.in_(theme_ids),
                     ThemeAssignment.is_present.is_(True),
                 )
             )

--- a/Backend/app/services/theme_frequency.py
+++ b/Backend/app/services/theme_frequency.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from uuid import UUID
 
 from sqlalchemy import and_, desc, select
@@ -13,10 +12,10 @@ from app.models import (
     DocumentCoding,
     Theme,
     ThemeAssignment,
-    ThemeHierarchyRelationship,
 )
 from app.schemas.theme_views import ThemeFrequencyItem
 from app.services.theme_graph import ThemeNotFoundError
+from app.services.theme_hierarchy import descendants_and_self, load_children_map
 
 
 class ThemeFrequencyService:
@@ -43,16 +42,16 @@ class ThemeFrequencyService:
             application_run_id=selected_run_id,
             theme_ids=theme_ids,
         )
-        children_by_theme_id = await self._load_hierarchy_children(
-            codebook_id=codebook_id,
-            theme_ids=theme_ids,
-        )
 
-        parent_occurrence_by_theme_id = self._aggregate_occurrence_counts(
-            theme_ids=theme_ids,
-            document_ids_by_theme_id=document_ids_by_theme_id,
-            children_by_theme_id=children_by_theme_id,
-        )
+        children_map = await load_children_map(self._session, codebook_id=codebook_id)
+        parent_occurrence_by_theme_id = {
+            theme_id: len(
+                set().union(
+                    *(document_ids_by_theme_id.get(d, set()) for d in descendants_and_self(theme_id, children_map))
+                )
+            )
+            for theme_id in theme_ids
+        }
         total_interviews_in_corpus = await self._load_total_interviews_in_corpus(
             codebook_id=codebook_id,
             application_run_id=selected_run_id,
@@ -161,55 +160,6 @@ class ThemeFrequencyService:
         for theme_id, document_id in rows:
             document_ids[theme_id].add(document_id)
         return document_ids
-
-    async def _load_hierarchy_children(
-        self,
-        *,
-        codebook_id: UUID,
-        theme_ids: set[UUID],
-    ) -> dict[UUID, set[UUID]]:
-        if not theme_ids:
-            return {}
-        stmt = select(
-            ThemeHierarchyRelationship.parent_theme_id,
-            ThemeHierarchyRelationship.child_theme_id,
-        ).where(
-            ThemeHierarchyRelationship.codebook_id == codebook_id,
-            ThemeHierarchyRelationship.is_active.is_(True),
-            ThemeHierarchyRelationship.parent_theme_id.in_(theme_ids),
-            ThemeHierarchyRelationship.child_theme_id.in_(theme_ids),
-        )
-        rows = (await self._session.execute(stmt)).all()
-        children: dict[UUID, set[UUID]] = defaultdict(set)
-        for parent_id, child_id in rows:
-            children[parent_id].add(child_id)
-        return children
-
-    @staticmethod
-    def _aggregate_occurrence_counts(
-        *,
-        theme_ids: set[UUID],
-        document_ids_by_theme_id: dict[UUID, set[UUID]],
-        children_by_theme_id: dict[UUID, set[UUID]],
-    ) -> dict[UUID, int]:
-        # Roll each theme's own document set up through its descendants, unioning so shared documents are counted once
-        resolved: dict[UUID, frozenset[UUID]] = {}
-
-        def resolve(theme_id: UUID, ancestry: frozenset[UUID]) -> frozenset[UUID]:
-            cached = resolved.get(theme_id)
-            if cached is not None:
-                return cached
-            documents = set(document_ids_by_theme_id.get(theme_id, ()))
-            next_ancestry = ancestry | {theme_id} # prevents cycles
-            for child_id in children_by_theme_id.get(theme_id, ()):
-                if child_id in next_ancestry:
-                    continue
-                documents |= resolve(child_id, next_ancestry)
-            result = frozenset(documents)
-            resolved[theme_id] = result
-            return result
-
-        return {theme_id: len(resolve(theme_id, frozenset())) for theme_id in theme_ids}
 
     async def _load_total_interviews_in_corpus(
         self,

--- a/Backend/app/services/theme_hierarchy.py
+++ b/Backend/app/services/theme_hierarchy.py
@@ -1,0 +1,56 @@
+"""
+Shared helpers for walking a codebook's theme hierarchy.
+For coverage, quotes and demographic breakdowns.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ThemeHierarchyRelationship
+
+
+async def load_children_map(
+    session: AsyncSession, *, codebook_id: UUID
+) -> dict[UUID, set[UUID]]:
+    """Active parent-theme -> {child-theme} edges for one codebook."""
+    rows = (
+        await session.execute(
+            select(
+                ThemeHierarchyRelationship.parent_theme_id,
+                ThemeHierarchyRelationship.child_theme_id,
+            ).where(
+                ThemeHierarchyRelationship.codebook_id == codebook_id,
+                ThemeHierarchyRelationship.is_active.is_(True),
+            )
+        )
+    ).all()
+    children: dict[UUID, set[UUID]] = defaultdict(set)
+    for parent_id, child_id in rows:
+        children[parent_id].add(child_id)
+
+    return dict(children)
+
+
+def descendants_and_self(theme_id: UUID, children_map: dict[UUID, set[UUID]]) -> set[UUID]:
+    """A theme plus every descendant; the visited set tolerates cyclic data."""
+    resolved: set[UUID] = set()
+    stack = [theme_id]
+    while stack:
+        current = stack.pop()
+        if current in resolved:
+            continue
+        resolved.add(current)
+        stack.extend(children_map.get(current, ()))
+    return resolved
+
+
+async def load_descendants_and_self(
+    session: AsyncSession, *, codebook_id: UUID, theme_id: UUID
+) -> set[UUID]:
+    """A theme + all its descendants, resolved from the codebook's active hierarchy."""
+    return descendants_and_self(theme_id, await load_children_map(session, codebook_id=codebook_id))

--- a/Backend/app/services/theme_quotes.py
+++ b/Backend/app/services/theme_quotes.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import math
+from collections import defaultdict
 from uuid import UUID
 
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import CodebookApplicationRun, CorpusDocument, DocumentCoding, ThemeAssignment
+from app.models import (
+    CodebookApplicationRun,
+    CorpusDocument,
+    DocumentCoding,
+    ThemeAssignment,
+    ThemeHierarchyRelationship,
+)
 from app.models.demographic import DemographicRow
 from app.schemas.common import Page, PageMeta
 from app.schemas.theme_views import ThemeQuoteItem
@@ -24,36 +31,47 @@ class ThemeQuotesService:
         page: int = 1,
         page_size: int = 20,
         application_run_id: UUID | None = None,
+        include_descendants: bool = True,
     ) -> Page[ThemeQuoteItem]:
         run_id = await self._resolve_run_id(codebook_id, application_run_id)
         if run_id is None:
             return Page(items=[], meta=PageMeta(total=0, page=page, page_size=page_size, pages=0))
 
+        theme_ids = await self._resolve_theme_ids(
+            codebook_id=codebook_id,
+            theme_id=theme_id,
+            include_descendants=include_descendants,
+        )
+
         base_filter = (
             DocumentCoding.application_run_id == run_id,
-            ThemeAssignment.theme_id == theme_id,
+            ThemeAssignment.theme_id.in_(theme_ids),
             ThemeAssignment.is_present.is_(True),
             ThemeAssignment.quote.is_not(None),
         )
 
         total: int = (
             await self._session.execute(
-                select(func.count())
-                .select_from(ThemeAssignment)
-                .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
-                .where(*base_filter)
+                select(func.count()).select_from(
+                    select(DocumentCoding.document_id, ThemeAssignment.quote)
+                    .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+                    .where(*base_filter)
+                    .group_by(DocumentCoding.document_id, ThemeAssignment.quote)
+                    .subquery()
+                )
             )
         ).scalar_one()
 
         pages = math.ceil(total / page_size) if total > 0 else 0
         offset = (page - 1) * page_size
 
-        rows = (
+        confidence = func.max(ThemeAssignment.confidence).label("confidence")
+        page_rows = (
             await self._session.execute(
                 select(
-                    ThemeAssignment.quote,
-                    ThemeAssignment.confidence,
                     DocumentCoding.document_id,
+                    ThemeAssignment.quote,
+                    confidence,
                     CorpusDocument.title,
                     DemographicRow.interviewee_id,
                 )
@@ -61,11 +79,22 @@ class ThemeQuotesService:
                 .join(CorpusDocument, DocumentCoding.document_id == CorpusDocument.id)
                 .outerjoin(DemographicRow, CorpusDocument.demographic_row_id == DemographicRow.id)
                 .where(*base_filter)
-                .order_by(desc(ThemeAssignment.confidence))
+                .group_by(
+                    DocumentCoding.document_id,
+                    ThemeAssignment.quote,
+                    CorpusDocument.title,
+                    DemographicRow.interviewee_id,
+                )
+                .order_by(desc(confidence), DocumentCoding.document_id, ThemeAssignment.quote)
                 .offset(offset)
                 .limit(page_size)
             )
         ).all()
+
+        theme_ids_by_key = await self._load_tags_for_quotes(
+            base_filter=base_filter,
+            document_ids={row.document_id for row in page_rows},
+        )
 
         items = [
             ThemeQuoteItem(
@@ -74,11 +103,73 @@ class ThemeQuotesService:
                 document_id=row.document_id,
                 document_title=row.title,
                 interviewee_id=row.interviewee_id,
+                theme_ids=theme_ids_by_key.get((row.document_id, row.quote), []),
             )
-            for row in rows
+            for row in page_rows
         ]
 
         return Page(items=items, meta=PageMeta(total=total, page=page, page_size=page_size, pages=pages))
+
+    async def _load_tags_for_quotes(
+        self,
+        *,
+        base_filter: tuple,
+        document_ids: set[UUID],
+    ) -> dict[tuple[UUID, str], list[UUID]]:
+        if not document_ids:
+            return {}
+        rows = (
+            await self._session.execute(
+                select(
+                    DocumentCoding.document_id,
+                    ThemeAssignment.quote,
+                    ThemeAssignment.theme_id,
+                )
+                .join(DocumentCoding, ThemeAssignment.document_coding_id == DocumentCoding.id)
+                .where(*base_filter, DocumentCoding.document_id.in_(document_ids))
+                .order_by(desc(ThemeAssignment.confidence), ThemeAssignment.id)
+            )
+        ).all()
+        theme_ids_by_key: dict[tuple[UUID, str], list[UUID]] = defaultdict(list)
+        for row in rows:
+            ids = theme_ids_by_key[(row.document_id, row.quote)]
+            if row.theme_id not in ids:
+                ids.append(row.theme_id)
+        return theme_ids_by_key
+
+    async def _resolve_theme_ids(
+        self,
+        *,
+        codebook_id: UUID,
+        theme_id: UUID,
+        include_descendants: bool,
+    ) -> set[UUID]:
+        if not include_descendants:
+            return {theme_id}
+        rows = (
+            await self._session.execute(
+                select(
+                    ThemeHierarchyRelationship.parent_theme_id,
+                    ThemeHierarchyRelationship.child_theme_id,
+                ).where(
+                    ThemeHierarchyRelationship.codebook_id == codebook_id,
+                    ThemeHierarchyRelationship.is_active.is_(True),
+                )
+            )
+        ).all()
+        children_by_parent: dict[UUID, set[UUID]] = defaultdict(set)
+        for parent_id, child_id in rows:
+            children_by_parent[parent_id].add(child_id)
+
+        resolved: set[UUID] = set()
+        stack = [theme_id]
+        while stack:
+            current = stack.pop()
+            if current in resolved:
+                continue
+            resolved.add(current)
+            stack.extend(children_by_parent.get(current, ()))
+        return resolved
 
     async def _resolve_run_id(self, codebook_id: UUID, application_run_id: UUID | None) -> UUID | None:
         if application_run_id is not None:

--- a/Backend/app/services/theme_quotes.py
+++ b/Backend/app/services/theme_quotes.py
@@ -13,11 +13,11 @@ from app.models import (
     CorpusDocument,
     DocumentCoding,
     ThemeAssignment,
-    ThemeHierarchyRelationship,
 )
 from app.models.demographic import DemographicRow
 from app.schemas.common import Page, PageMeta
 from app.schemas.theme_views import ThemeQuoteItem
+from app.services.theme_hierarchy import load_descendants_and_self
 
 
 class ThemeQuotesService:
@@ -38,10 +38,10 @@ class ThemeQuotesService:
         if run_id is None:
             return Page(items=[], meta=PageMeta(total=0, page=page, page_size=page_size, pages=0))
 
-        theme_ids = await self._resolve_theme_ids(
-            codebook_id=codebook_id,
-            theme_id=theme_id,
-            include_descendants=include_descendants,
+        theme_ids = (
+            await load_descendants_and_self(self._session, codebook_id=codebook_id, theme_id=theme_id)
+            if include_descendants
+            else {theme_id}
         )
 
         base_filter = (
@@ -137,40 +137,6 @@ class ThemeQuotesService:
             if row.theme_id not in ids:
                 ids.append(row.theme_id)
         return theme_ids_by_key
-
-    async def _resolve_theme_ids(
-        self,
-        *,
-        codebook_id: UUID,
-        theme_id: UUID,
-        include_descendants: bool,
-    ) -> set[UUID]:
-        if not include_descendants:
-            return {theme_id}
-        rows = (
-            await self._session.execute(
-                select(
-                    ThemeHierarchyRelationship.parent_theme_id,
-                    ThemeHierarchyRelationship.child_theme_id,
-                ).where(
-                    ThemeHierarchyRelationship.codebook_id == codebook_id,
-                    ThemeHierarchyRelationship.is_active.is_(True),
-                )
-            )
-        ).all()
-        children_by_parent: dict[UUID, set[UUID]] = defaultdict(set)
-        for parent_id, child_id in rows:
-            children_by_parent[parent_id].add(child_id)
-
-        resolved: set[UUID] = set()
-        stack = [theme_id]
-        while stack:
-            current = stack.pop()
-            if current in resolved:
-                continue
-            resolved.add(current)
-            stack.extend(children_by_parent.get(current, ()))
-        return resolved
 
     async def _resolve_run_id(self, codebook_id: UUID, application_run_id: UUID | None) -> UUID | None:
         if application_run_id is not None:

--- a/Backend/app/services/theme_quotes.py
+++ b/Backend/app/services/theme_quotes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import desc, func, select
@@ -113,7 +114,7 @@ class ThemeQuotesService:
     async def _load_tags_for_quotes(
         self,
         *,
-        base_filter: tuple,
+        base_filter: tuple[Any, ...],
         document_ids: set[UUID],
     ) -> dict[tuple[UUID, str], list[UUID]]:
         if not document_ids:

--- a/Backend/tests/test_theme_demographic_breakdown_service.py
+++ b/Backend/tests/test_theme_demographic_breakdown_service.py
@@ -19,6 +19,7 @@ from app.models import (
     DocumentCoding,
     Theme,
     ThemeAssignment,
+    ThemeHierarchyRelationship,
 )
 from app.services.theme_demographic_breakdown import (
     NOT_SPECIFIED_LABEL,
@@ -47,6 +48,8 @@ async def _seed_breakdown(
     # theme label -> set of interviewees for whom the theme is present
     present_by_theme: dict[str, set[str]],
     run_status: str = "succeeded",
+    # optional parent->child hierarchy edges by theme label
+    edges_by_label: list[tuple[str, str]] | None = None,
 ) -> BreakdownSeed:
     corpus_id = uuid4()
     codebook_id = uuid4()
@@ -70,6 +73,16 @@ async def _seed_breakdown(
         session.add(
             CodebookThemeRelationship(
                 id=uuid4(), codebook_id=codebook_id, theme_id=theme_id, is_active=True
+            )
+        )
+    for parent_label, child_label in edges_by_label or []:
+        session.add(
+            ThemeHierarchyRelationship(
+                id=uuid4(),
+                codebook_id=codebook_id,
+                parent_theme_id=theme_ids[parent_label],
+                child_theme_id=theme_ids[child_label],
+                is_active=True,
             )
         )
 
@@ -441,6 +454,75 @@ class ThemeDemographicBreakdownServiceTests(unittest.IsolatedAsyncioTestCase):
                     theme_id=uuid4(),
                     dimensions=["gender"],
                 )
+
+    async def test_parent_theme_rolls_up_descendant_present_counts(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "Region"],
+                people={
+                    "Alice": {"Region": "North"},
+                    "Bob": {"Region": "North"},
+                    "Carol": {"Region": "South"},
+                    "Dave": {"Region": "South"},
+                },
+                theme_labels=["Parent", "Child A", "Child B"],
+                present_by_theme={
+                    "Child A": {"Alice", "Bob"},
+                    "Child B": {"Bob", "Carol"},
+                    "Parent": set(),
+                },
+                edges_by_label=[("Parent", "Child A"), ("Parent", "Child B")],
+            )
+
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Parent"],
+                dimensions=["Region"],
+            )
+
+        groups = {g.group_value: g for g in result.dimensions[0].groups}
+        # North: Alice + Bob present (Bob once) out of 2 → 100%.
+        self.assertEqual(groups["North"].present_count, 2)
+        self.assertEqual(groups["North"].group_total, 2)
+        self.assertEqual(groups["North"].percentage, 100.0)
+        # South: only Carol (via Child B) out of 2 → 50%.
+        self.assertEqual(groups["South"].present_count, 1)
+        self.assertEqual(groups["South"].group_total, 2)
+        self.assertEqual(groups["South"].percentage, 50.0)
+
+    async def test_leaf_theme_breakdown_is_not_affected_by_rollup(self) -> None:
+        # Selecting a child theme still counts only its own assignments.
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "Region"],
+                people={
+                    "Alice": {"Region": "North"},
+                    "Bob": {"Region": "North"},
+                    "Carol": {"Region": "South"},
+                    "Dave": {"Region": "South"},
+                },
+                theme_labels=["Parent", "Child A", "Child B"],
+                present_by_theme={
+                    "Child A": {"Alice", "Bob"},
+                    "Child B": {"Bob", "Carol"},
+                    "Parent": set(),
+                },
+                edges_by_label=[("Parent", "Child A"), ("Parent", "Child B")],
+            )
+
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Child A"],
+                dimensions=["Region"],
+            )
+
+        groups = {g.group_value: g for g in result.dimensions[0].groups}
+        # Child A alone: Alice + Bob (North); South has none.
+        self.assertEqual(groups["North"].present_count, 2)
+        self.assertEqual(groups["South"].present_count, 0)
+        self.assertEqual(groups["South"].percentage, 0.0)
 
 
 if __name__ == "__main__":

--- a/Backend/tests/test_theme_quotes_service.py
+++ b/Backend/tests/test_theme_quotes_service.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
-from app.models import Base, Codebook, CorpusDocument, Theme
+from app.models import Base, Codebook, CorpusDocument, Theme, ThemeHierarchyRelationship
 from app.models.analysis import CodebookApplicationRun, DocumentCoding, ThemeAssignment
 from app.services.theme_quotes import ThemeQuotesService
 
@@ -60,6 +60,7 @@ async def _add_document_with_assignment(
     is_present: bool,
     confidence: float,
     quote: str | None,
+    theme_id: UUID | None = None,
 ) -> None:
     doc_id = uuid4()
     coding_id = uuid4()
@@ -83,12 +84,64 @@ async def _add_document_with_assignment(
         ThemeAssignment(
             id=uuid4(),
             document_coding_id=coding_id,
-            theme_id=seed.theme_id,
+            theme_id=theme_id or seed.theme_id,
             is_present=is_present,
             confidence=confidence,
             quote=quote,
         )
     )
+
+
+async def _add_document_with_theme_quotes(
+    session: AsyncSession,
+    seed: _QuoteSeed,
+    *,
+    assignments: list[tuple[UUID, str, float]],
+) -> None:
+    """Add one document/coding with several theme assignments (theme_id, quote, confidence)."""
+    doc_id = uuid4()
+    coding_id = uuid4()
+    session.add(
+        CorpusDocument(id=doc_id, corpus_id=_CORPUS_ID, title=f"Interview {doc_id.hex[:6]}", content="...")
+    )
+    session.add(
+        DocumentCoding(
+            id=coding_id,
+            application_run_id=seed.run_id,
+            document_id=doc_id,
+            codebook_id=seed.codebook_id,
+        )
+    )
+    for theme_id, quote, confidence in assignments:
+        session.add(
+            ThemeAssignment(
+                id=uuid4(),
+                document_coding_id=coding_id,
+                theme_id=theme_id,
+                is_present=True,
+                confidence=confidence,
+                quote=quote,
+            )
+        )
+
+
+async def _add_child_theme(
+    session: AsyncSession, seed: _QuoteSeed, *, label: str = "Child Theme"
+) -> UUID:
+    """Add a child theme under the seed's theme and return its id."""
+    child_id = uuid4()
+    session.add(Theme(id=child_id, codebook_id=seed.codebook_id, label=label, is_active=True))
+    session.add(
+        ThemeHierarchyRelationship(
+            id=uuid4(),
+            codebook_id=seed.codebook_id,
+            parent_theme_id=seed.theme_id,
+            child_theme_id=child_id,
+            is_active=True,
+        )
+    )
+    await session.flush()
+    return child_id
 
 
 @unittest.skipUnless(AIOSQLITE_AVAILABLE, "These tests require aiosqlite.")
@@ -215,3 +268,68 @@ class ThemeQuotesServiceTests(unittest.IsolatedAsyncioTestCase):
 
         # Explicit run has no assignments → empty even though another run has quotes
         self.assertEqual(result.meta.total, 0)
+
+    async def test_parent_rolls_up_child_theme_quotes_with_owning_theme_id(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            child_id = await _add_child_theme(session, seed, label="Sub Theme")
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.9, quote="parent own"
+            )
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.8, quote="child quote", theme_id=child_id
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        self.assertEqual(result.meta.total, 2)
+
+        owning_by_quote = {item.quote: item.theme_ids for item in result.items}
+        self.assertEqual(
+            owning_by_quote, {"parent own": [seed.theme_id], "child quote": [child_id]}
+        )
+
+    async def test_same_quote_on_parent_and_child_merges_into_one_multi_tag_item(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            child_id = await _add_child_theme(session, seed, label="Sub Theme")
+            # One physical quote in one document, assigned to both parent and child.
+            await _add_document_with_theme_quotes(
+                session,
+                seed,
+                assignments=[(seed.theme_id, "shared quote", 0.9), (child_id, "shared quote", 0.8)],
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id, theme_id=seed.theme_id
+            )
+
+        # Collapsed into a single card carrying both themes as tags.
+        self.assertEqual(result.meta.total, 1)
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(set(result.items[0].theme_ids), {seed.theme_id, child_id})
+
+    async def test_own_only_excludes_child_theme_quotes(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_base(session)
+            child_id = await _add_child_theme(session, seed, label="Sub Theme")
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.9, quote="parent own"
+            )
+            await _add_document_with_assignment(
+                session, seed, is_present=True, confidence=0.8, quote="child quote", theme_id=child_id
+            )
+            await session.commit()
+
+            result = await ThemeQuotesService(session).list_theme_quotes(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_id,
+                include_descendants=False,
+            )
+
+        self.assertEqual(result.meta.total, 1)
+        self.assertEqual([item.quote for item in result.items], ["parent own"])

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -207,7 +207,7 @@ def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     assert b"View Quotes" not in body
     # Quote-count stat in the Theme Details header (filled by the quotes JS).
     assert b'id="theme-details-quotes"' in body
-    assert b'id="quotes-own-only"' in body
+    assert b'id="quotes-hide-subthemes"' in body
 
 
 def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -192,7 +192,6 @@ def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
     body = resp.data
-    # One merged box replaces the two separate panels (issue #226).
     assert b'panel-title">Themes</h2>' in body
     assert b"Theme Frequency" not in body
     assert b"Theme Hierarchy" not in body
@@ -201,7 +200,6 @@ def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     assert b'id="themes-table-body"' in body
     assert b"Occurrences" in body
     assert b"Interview Coverage" in body
-    # Quotes live inline in the same box, not in a pop-up (issue #227).
     assert b'id="quotes-panel-title"' in body
     assert b'id="quotes-none"' in body
     assert b'id="quotes-pagination"' in body
@@ -209,6 +207,7 @@ def test_codebook_themes_renders_single_merged_themes_box(client, fake_backend):
     assert b"View Quotes" not in body
     # Quote-count stat in the Theme Details header (filled by the quotes JS).
     assert b'id="theme-details-quotes"' in body
+    assert b'id="quotes-own-only"' in body
 
 
 def test_codebook_themes_selects_requested_analysis_run(client, fake_backend):

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -412,6 +412,8 @@ def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
         page_size = max(1, min(100, int(request.args.get("page_size", 20))))
     except (TypeError, ValueError):
         page, page_size = 1, 20
+
+    include_descendants = request.args.get("include_descendants", "true").lower() != "false"
     try:
         application_run_id = request.args.get("application_run_id") or None
         result = _backend().get_theme_quotes(
@@ -420,6 +422,7 @@ def theme_quotes_json(corpus_id: str, codebook_id: str, theme_id: str):
             page,
             page_size,
             application_run_id=application_run_id,
+            include_descendants=include_descendants,
         )
         return jsonify(result)
     except BackendError as exc:

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -213,8 +213,9 @@ class BackendClient:
         page: int = 1,
         page_size: int = 20,
         application_run_id: str | None = None,
+        include_descendants: bool = True,
     ) -> dict:
-        params = {"page": page, "page_size": page_size}
+        params = {"page": page, "page_size": page_size, "include_descendants": str(include_descendants).lower()}
         if application_run_id:
             params["application_run_id"] = application_run_id
         return self._get(

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -495,8 +495,7 @@
     const quotesPageInfo   = document.getElementById("quotes-page-info");
     const quotesPrev       = document.getElementById("quotes-prev");
     const quotesNext       = document.getElementById("quotes-next");
-    // Quote-count stat in the Theme Details header; owned by this module
-    // because the count only becomes known once the quotes fetch returns.
+    const quotesOwnOnly    = document.getElementById("quotes-own-only");
     const themeDetailsQuotes = document.getElementById("theme-details-quotes");
 
     if (!quotesList) return;
@@ -510,6 +509,7 @@
         const url = new URL(quotesUrlTemplate.replace("__THEME__", themeId), window.location.origin);
         url.searchParams.set("page", page);
         url.searchParams.set("page_size", PAGE_SIZE);
+        url.searchParams.set("include_descendants", quotesOwnOnly && quotesOwnOnly.checked ? "false" : "true");
         if (applicationRunId) {
             url.searchParams.set("application_run_id", applicationRunId);
         }
@@ -567,6 +567,16 @@
         for (const item of items) {
             const card = document.createElement("div");
             card.className = "border rounded-2 p-3 mb-2";
+
+            const tagWrap = document.createElement("div");
+            tagWrap.className = "d-flex flex-wrap gap-1 mb-2";
+            for (const themeId of (item.theme_ids || [])) {
+                const tag = document.createElement("span");
+                tag.className = "badge text-bg-light border";
+                tag.textContent = (currentThemeInfoById[themeId] || {}).theme_name || "Theme";
+                tagWrap.appendChild(tag);
+            }
+            card.appendChild(tagWrap);
 
             // Quote text — textContent prevents XSS on any user-supplied content.
             const quoteEl = document.createElement("blockquote");
@@ -646,6 +656,12 @@
         onQuotesThemeChange(initialTheme.themeId);
     } else {
         resetQuotesPanel();
+    }
+
+    if (quotesOwnOnly) {
+        quotesOwnOnly.addEventListener("change", () => {
+            if (activeQuoteThemeId) loadQuotes(activeQuoteThemeId, 1);
+        });
     }
 
     quotesPrev.addEventListener("click", () => {

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -469,6 +469,17 @@
     updateMetricCards();
     renderThemeTreeTable(tree);
 
+    // Hide toggle when there are no sub-themes
+    const themeIdsWithSubthemes = new Set();
+    (function markSubthemeParents(nodes) {
+        for (const node of nodes) {
+            if (!isCodeNode(node.theme) && (node.children ?? []).some(c => !isCodeNode(c.theme))) {
+                themeIdsWithSubthemes.add(node.theme.id);
+            }
+            markSubthemeParents(node.children ?? []);
+        }
+    })(tree);
+
     // Auto-select the top theme by frequency on load and make its row visible.
     const top = sortByFrequency(frequencies)[0];
     if (top) {
@@ -495,7 +506,8 @@
     const quotesPageInfo   = document.getElementById("quotes-page-info");
     const quotesPrev       = document.getElementById("quotes-prev");
     const quotesNext       = document.getElementById("quotes-next");
-    const quotesOwnOnly    = document.getElementById("quotes-own-only");
+    const quotesHideSubthemes     = document.getElementById("quotes-hide-subthemes");
+    const quotesHideSubthemesWrap = document.getElementById("quotes-hide-subthemes-wrap");
     const themeDetailsQuotes = document.getElementById("theme-details-quotes");
 
     if (!quotesList) return;
@@ -509,7 +521,7 @@
         const url = new URL(quotesUrlTemplate.replace("__THEME__", themeId), window.location.origin);
         url.searchParams.set("page", page);
         url.searchParams.set("page_size", PAGE_SIZE);
-        url.searchParams.set("include_descendants", quotesOwnOnly && quotesOwnOnly.checked ? "false" : "true");
+        url.searchParams.set("include_descendants", quotesHideSubthemes && quotesHideSubthemes.checked ? "false" : "true");
         if (applicationRunId) {
             url.searchParams.set("application_run_id", applicationRunId);
         }
@@ -543,7 +555,7 @@
         quotesPagination.classList.add("d-none");
     }
 
-    function renderQuotes(data, themeName) {
+    function renderQuotes(data, themeName, rollUp) {
         quotesLoading.classList.add("d-none");
 
         const items = data.items || [];
@@ -553,8 +565,8 @@
         const pages = meta.pages  ?? 0;
 
         quotesLabel.textContent = "Quotes for: " + (themeName || "Theme");
-        quotesTotal.textContent = total === 1 ? "1 quote across corpus" : total + " quotes across corpus";
-        if (themeDetailsQuotes) themeDetailsQuotes.textContent = String(total);
+        quotesTotal.textContent = total === 1 ? "1 quote" : total + " quotes";
+        if (rollUp && themeDetailsQuotes) themeDetailsQuotes.textContent = String(total);
 
         if (items.length === 0) {
             quotesEmpty.classList.remove("d-none");
@@ -616,6 +628,7 @@
         activeQuoteThemeId = themeId;
         activeQuotePage    = page;
         const token = ++quotesRequestToken;
+        const rollUp = !(quotesHideSubthemes && quotesHideSubthemes.checked);
         setQuotesLoading();
 
         const themeName = (currentThemeInfoById[themeId] || {}).theme_name || "";
@@ -625,7 +638,7 @@
             const data = await response.json();
             if (token !== quotesRequestToken) return; // superseded by a newer request
             if (!response.ok || data.error) throw new Error(data.error || "HTTP " + response.status);
-            renderQuotes(data, themeName);
+            renderQuotes(data, themeName, rollUp);
         } catch (err) {
             if (token !== quotesRequestToken) return;
             quotesLoading.classList.add("d-none");
@@ -638,9 +651,15 @@
         if (!themeId) {
             resetQuotesPanel();
             if (themeDetailsQuotes) themeDetailsQuotes.textContent = "";
+            if (quotesHideSubthemesWrap) quotesHideSubthemesWrap.classList.add("d-none");
             return;
         }
         if (themeId === activeQuoteThemeId) return; // same theme — keep page and stat
+
+        if (quotesHideSubthemes) quotesHideSubthemes.checked = false;
+        if (quotesHideSubthemesWrap) {
+            quotesHideSubthemesWrap.classList.toggle("d-none", !themeIdsWithSubthemes.has(themeId));
+        }
         // Placeholder until this theme's quote total arrives with the fetch.
         if (themeDetailsQuotes) themeDetailsQuotes.textContent = "—";
         loadQuotes(themeId, 1);
@@ -658,8 +677,8 @@
         resetQuotesPanel();
     }
 
-    if (quotesOwnOnly) {
-        quotesOwnOnly.addEventListener("change", () => {
+    if (quotesHideSubthemes) {
+        quotesHideSubthemes.addEventListener("change", () => {
             if (activeQuoteThemeId) loadQuotes(activeQuoteThemeId, 1);
         });
     }

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -226,12 +226,13 @@
               <h2 class="h6 panel-title" id="quotes-panel-title">Quotes</h2>
               <p class="text-secondary small mb-2" id="quotes-panel-total"></p>
 
-              {# Roll-up is the default; checking this limits the list to quotes
-                 assigned directly to the selected theme (not its sub-themes). #}
-              <div class="form-check form-switch mb-2" id="quotes-own-only-wrap">
-                <input class="form-check-input" type="checkbox" role="switch" id="quotes-own-only">
-                <label class="form-check-label small text-secondary" for="quotes-own-only">
-                  Only this theme's own quotes
+              {# Off by default: quotes roll up from sub-themes. Checking it limits
+                 the list to quotes assigned directly to the selected theme. The JS
+                 reveals it only for themes that actually have sub-themes. #}
+              <div class="form-check form-switch mb-2 d-none" id="quotes-hide-subthemes-wrap">
+                <input class="form-check-input" type="checkbox" role="switch" id="quotes-hide-subthemes">
+                <label class="form-check-label small text-secondary" for="quotes-hide-subthemes">
+                  Do not show sub-themes&#39; quotes
                 </label>
               </div>
 

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -226,6 +226,15 @@
               <h2 class="h6 panel-title" id="quotes-panel-title">Quotes</h2>
               <p class="text-secondary small mb-2" id="quotes-panel-total"></p>
 
+              {# Roll-up is the default; checking this limits the list to quotes
+                 assigned directly to the selected theme (not its sub-themes). #}
+              <div class="form-check form-switch mb-2" id="quotes-own-only-wrap">
+                <input class="form-check-input" type="checkbox" role="switch" id="quotes-own-only">
+                <label class="form-check-label small text-secondary" for="quotes-own-only">
+                  Only this theme's own quotes
+                </label>
+              </div>
+
               <p id="quotes-none" class="text-secondary mb-0 text-center py-4">
                 Select a theme to see its quotes.
               </p>


### PR DESCRIPTION
- Fixes the discrepancy #245 causes (stats header shows count(parent $\cup$ child quote sets) but the quotes list show only themes from the parent) 
- Theme_ids list is added to allow filtering and multi-theme tagging for the quotes. There is a toggle off option to still show quotes from the parent theme only.
- theme_hierarchy.py is added to walk the theme hierarchy to display rolled-up values when parent themes are selected in themes.html
- along with coverage and listed quotes, demographic breakdown also shows the rolled-up data (participants who talk about the sub-theme are part of the parent theme's demographic breakdown)
