### PR TITLE
Task/231 improve demographic breakdown UI

### DIFF
--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -231,17 +231,15 @@
 }
 
 .breakdown-chart {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: minmax(90px, 160px) 1fr auto;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
     margin-bottom: 0.9rem;
 }
 
 .breakdown-row {
-    display: grid;
-    grid-template-columns: minmax(90px, 160px) 1fr;
-    align-items: center;
-    gap: 0.75rem;
+    display: contents;
 }
 
 .breakdown-row-label {
@@ -272,7 +270,6 @@
 .breakdown-bar-value {
     font-size: 0.75rem;
     color: #1e1b4b;
-    margin-left: 0.5rem;
     white-space: nowrap;
 }
 

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -232,7 +232,7 @@
 
 .breakdown-chart {
     display: grid;
-    grid-template-columns: minmax(90px, 160px) 1fr auto;
+    grid-template-columns: minmax(90px, 160px) 1fr auto auto;
     align-items: center;
     gap: 0.5rem 0.75rem;
     margin-bottom: 0.9rem;
@@ -267,9 +267,16 @@
     min-width: 2px;
 }
 
-.breakdown-bar-value {
+.breakdown-bar-pct {
     font-size: 0.75rem;
     color: #1e1b4b;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.breakdown-bar-count {
+    font-size: 0.75rem;
+    color: #6b7280;
     white-space: nowrap;
 }
 

--- a/Frontend/web/static/js/theme_breakdown.js
+++ b/Frontend/web/static/js/theme_breakdown.js
@@ -108,7 +108,7 @@
     }
 
     function formatPct(value) {
-        return (typeof value === "number" ? value : 0).toFixed(1) + "%";
+        return Math.round(typeof value === "number" ? value : 0) + "%";
     }
 
     function smallSampleBadge() {
@@ -133,24 +133,19 @@
             label.title = group.group_value;
             row.appendChild(label);
 
-            const right = document.createElement("div");
-            right.className = "d-flex align-items-center";
-
             const track = document.createElement("div");
-            track.className = "breakdown-track flex-grow-1";
+            track.className = "breakdown-track";
             const bar = document.createElement("div");
             bar.className = "breakdown-bar";
             bar.style.width = clampPct(group.percentage) + "%";
             track.appendChild(bar);
-            right.appendChild(track);
+            row.appendChild(track);
 
             const value = document.createElement("span");
             value.className = "breakdown-bar-value";
             value.textContent =
                 `${formatPct(group.percentage)} (${group.present_count}/${group.group_total})`;
-            right.appendChild(value);
-
-            row.appendChild(right);
+            row.appendChild(value);
             chart.appendChild(row);
         }
         return chart;

--- a/Frontend/web/static/js/theme_breakdown.js
+++ b/Frontend/web/static/js/theme_breakdown.js
@@ -141,11 +141,15 @@
             track.appendChild(bar);
             row.appendChild(track);
 
-            const value = document.createElement("span");
-            value.className = "breakdown-bar-value";
-            value.textContent =
-                `${formatPct(group.percentage)} (${group.present_count}/${group.group_total})`;
-            row.appendChild(value);
+            const pct = document.createElement("span");
+            pct.className = "breakdown-bar-pct";
+            pct.textContent = formatPct(group.percentage);
+            row.appendChild(pct);
+
+            const count = document.createElement("span");
+            count.className = "breakdown-bar-count";
+            count.textContent = `(${group.present_count}/${group.group_total})`;
+            row.appendChild(count);
             chart.appendChild(row);
         }
         return chart;


### PR DESCRIPTION
Fixes the demographic breakdown's UI:
<img width="138" height="115" alt="image" src="https://github.com/user-attachments/assets/afd02240-985c-41ab-bb6f-fd24ae883875" />

- Removes decimals and aligns percentages and fractions along "%" symbol
- Aligns the bars