### PR TITLE
Fix: codebook schema validation and clean up ghost jobs from frontend…

### DIFF
--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -771,6 +771,8 @@ def new_codebook_job_status(job_id: str):
         return jsonify(_demo_job_state(job_id))
     try:
         job = _backend().get_generation_job(job_id)
+    except BackendNotFoundError as exc:
+        return jsonify({"error": exc.user_message, "not_found": True}), 200
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 200
     return jsonify(job)

--- a/Frontend/web/static/js/job_tracker.js
+++ b/Frontend/web/static/js/job_tracker.js
@@ -228,7 +228,13 @@
     const jobs = loadJobs();
     for (const job of jobs) {
       const status = await fetchStatus(job.id);
-      if (!status || status.error) continue;
+      if (!status) continue;
+      if (status.error) {
+        if (status.not_found) {
+          untrackJob(job.id);
+        }
+        continue;
+      }
       paintProgress(job.id, status);
       if (["succeeded", "failed", "cancelled"].includes(status.status)) {
         onTerminal(job, status);


### PR DESCRIPTION
… tracker.

I ran into an issue with ghost jobs in my local browser and wanted to make this more robust against ghost jobs:
- Removed strict  and  requirements from CodebookSchema to fix 500 internal server errors when loading generated codebook themes
- Updated  and codebooks polling route to gracefully untrack and remove cached jobs from local storage if the backend reports a 404 Not Found (eg. after wiping database volumes)



Here are some screenshots from the codebook i found, even afterpurging docker / running ./setup.sh again etc:

<img width="711" height="887" alt="Screenshot 2026-07-13 at 10 39 06" src="https://github.com/user-attachments/assets/4576edeb-d96b-4705-9e7c-3a3879a841a9" />

<img width="1385" height="601" alt="Screenshot 2026-07-13 at 10 39 01" src="https://github.com/user-attachments/assets/837ea711-5fbf-401b-9528-1f1398a38190" />
