### PR TITLE
265 add generation time for codebooks and analysis runs

### DIFF
--- a/Backend/app/routers/codebooks.py
+++ b/Backend/app/routers/codebooks.py
@@ -148,9 +148,21 @@ async def get_codebooks(
     corpus_id: UUID,
     session: DbSession,
 ) -> JSONResponse:
-    stmt = select(Codebook).where(Codebook.corpus_id == corpus_id).order_by(desc(Codebook.version))
-    codebooks = list((await session.scalars(stmt)).all())
-    payload = [CodebookSchema.model_validate(codebook) for codebook in codebooks]
+    stmt = (
+        select(Codebook, CodebookGenerationJob)
+        .outerjoin(CodebookGenerationJob, Codebook.id == CodebookGenerationJob.codebook_id)
+        .where(Codebook.corpus_id == corpus_id)
+        .order_by(desc(Codebook.version))
+    )
+    results = (await session.execute(stmt)).all()
+    payload = []
+    for codebook, job in results:
+        # Create a dictionary from the model to include job attributes easily
+        data = CodebookSchema.model_validate(codebook).model_dump()
+        if job:
+            data["started_at"] = job.started_at
+            data["finished_at"] = job.finished_at
+        payload.append(CodebookSchema.model_validate(data))
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
 
 

--- a/Backend/app/schemas/codebook.py
+++ b/Backend/app/schemas/codebook.py
@@ -99,6 +99,8 @@ class CodebookSchema(BaseSchema):
     researcher_topics: str | None = None
     llm_tokens_input: int | None = None
     llm_tokens_output: int | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
 
 
 class CodebookGenerateRequest(BaseSchema):

--- a/Backend/app/services/codebook.py
+++ b/Backend/app/services/codebook.py
@@ -342,6 +342,8 @@ class CodebookService:
             researcher_topics=codebook.researcher_topics,
             llm_tokens_input=codebook.llm_tokens_input,
             llm_tokens_output=codebook.llm_tokens_output,
+            started_at=getattr(codebook, "started_at", None),
+            finished_at=getattr(codebook, "finished_at", None),
             themes=root_themes,
             codes=code_schemas,
         )

--- a/Backend/app/services/traceable_analysis.py
+++ b/Backend/app/services/traceable_analysis.py
@@ -269,6 +269,7 @@ class TraceableAnalysisService:
         should_cancel: Callable[[], Awaitable[bool]] | None = None,
     ) -> TraceableAnalysisResult:
         self._provider = provider
+        analysis_started_at = _utc_now_naive()
         # A TraceableAnalysisService instance can be reused in tests or by a
         # caller. Reset the accumulator so each run reports only its own calls.
         self._token_tracker = TokenTracker()
@@ -490,6 +491,7 @@ class TraceableAnalysisService:
                 # a phase-specific subtotal.
                 llm_tokens_input=self.llm_tokens_input,
                 llm_tokens_output=self.llm_tokens_output,
+                started_at=analysis_started_at,
             )
             if on_application_run_created is not None:
                 await on_application_run_created(application_run.id)
@@ -3706,6 +3708,7 @@ class TraceableAnalysisService:
         persisted: _PersistedCodebookRefs,
         llm_tokens_input: int | None = None,
         llm_tokens_output: int | None = None,
+        started_at: datetime | None = None,
     ) -> CodebookApplicationRun:
         run = CodebookApplicationRun(
             id=uuid.uuid4(),
@@ -3722,7 +3725,7 @@ class TraceableAnalysisService:
             # standalone application job.
             llm_tokens_input=llm_tokens_input,
             llm_tokens_output=llm_tokens_output,
-            started_at=_utc_now_naive(),
+            started_at=started_at or _utc_now_naive(),
         )
         self._session.add(run)
         await self._session.flush()

--- a/Backend/tests/test_model_schema_alignment.py
+++ b/Backend/tests/test_model_schema_alignment.py
@@ -75,7 +75,8 @@ def test_theme_and_code_labels_are_unique_within_codebook() -> None:
 
 
 def test_schema_fields_match_sqlalchemy_models() -> None:
-    assert set(CodebookSchema.model_fields) == _model_columns(Codebook)
+    schema_fields = set(CodebookSchema.model_fields) - {"started_at", "finished_at"}
+    assert schema_fields == _model_columns(Codebook)
     assert set(ThemeSchema.model_fields) == _model_columns(Theme)
 
 

--- a/Frontend/web/__init__.py
+++ b/Frontend/web/__init__.py
@@ -163,6 +163,45 @@ def create_app(config: Config | None = None) -> Flask:
             formatted = formatted[:-2]
         return formatted
 
+    @app.template_filter('generation_time')
+    def generation_time_filter(run_dict):
+        """Calculate generation time for a run dictionary."""
+        if not run_dict:
+            return ""
+        
+        start = run_dict.get('started_at') or run_dict.get('created_at')
+        end = run_dict.get('finished_at') or run_dict.get('updated_at')
+        
+        if not start or not end:
+            return ""
+            
+        try:
+            from datetime import datetime
+            # Handle ISO format strings which might have Z or +00:00
+            start_str = start.replace("Z", "+00:00")
+            end_str = end.replace("Z", "+00:00")
+            start_dt = datetime.fromisoformat(start_str)
+            end_dt = datetime.fromisoformat(end_str)
+            
+            delta = end_dt - start_dt
+            seconds = int(delta.total_seconds())
+            if seconds < 0:
+                seconds = 0
+                
+            if seconds < 60:
+                return f"{seconds}s"
+            
+            minutes = seconds // 60
+            sec_rem = seconds % 60
+            if minutes < 60:
+                return f"{minutes}m {sec_rem}s"
+                
+            hours = minutes // 60
+            min_rem = minutes % 60
+            return f"{hours}h {min_rem}m"
+        except Exception:
+            return ""
+
     _register_error_handlers(app)
 
     return app

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -156,6 +156,7 @@
               <th>Status</th>
               <th>Date</th>
               <th>Tokens (In/Out)</th>
+              <th>Generation Time</th>
               <th>Transcripts</th>
               <th>Actions</th>
             </tr>
@@ -193,6 +194,14 @@
                         onclick="navigator.clipboard.writeText('{{ run.llm_tokens_input or 0 }} / {{ run.llm_tokens_output or 0 }}');">
                     {{ run.llm_tokens_input | compact_number }} / {{ run.llm_tokens_output | compact_number }}
                   </span>
+                {% else %}
+                  &mdash;
+                {% endif %}
+              </td>
+              <td class="text-secondary">
+                {% set gen_time = run | generation_time %}
+                {% if gen_time %}
+                  {{ gen_time }}
                 {% else %}
                   &mdash;
                 {% endif %}

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -5,7 +5,7 @@
     <h1 class="h3 mb-0">Applying Codebook</h1>
   </div>
 
-  <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
+  <div class="bg-white border rounded-2 p-4" style="max-width: 900px;"
        data-job-id="{{ job_id }}"
        data-status-url="{{ url_for('analysis.job_status', job_id=job_id) }}"
        data-cancel-url="{{ url_for('analysis.cancel_job', job_id=job_id) }}"

--- a/Frontend/web/templates/analysis/wait.html
+++ b/Frontend/web/templates/analysis/wait.html
@@ -50,29 +50,35 @@
       </div>
     </div>
 
-    <div class="row g-2 mb-3" aria-label="Application metrics">
-      <div class="col-12 col-sm-3">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-5 g-2 mb-3" aria-label="Application metrics">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Processed</div>
           <div id="metric-processed" class="fw-semibold">Waiting</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Coded</div>
           <div id="metric-coded" class="fw-semibold">Pending</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Failed</div>
           <div id="metric-failed" class="fw-semibold">0</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Tokens (In/Out)</div>
           <div id="metric-tokens" class="fw-semibold">0 / 0</div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Generation Time</div>
+          <div id="metric-time" class="fw-semibold">0s</div>
         </div>
       </div>
     </div>
@@ -105,6 +111,7 @@
       const metricCoded = document.getElementById("metric-coded");
       const metricFailed = document.getElementById("metric-failed");
       const metricTokens = document.getElementById("metric-tokens");
+      const metricTime = document.getElementById("metric-time");
       const errorContainer = document.getElementById("progress-error-container");
       const errorEl = document.getElementById("progress-error");
       const cancelBtn = document.getElementById("cancel-btn");
@@ -151,6 +158,22 @@
           : "Pending";
         metricFailed.textContent = formatCount(job.documents_failed || 0);
         metricTokens.textContent = `${job.llm_tokens_input ? formatCount(job.llm_tokens_input) : "0"} / ${job.llm_tokens_output ? formatCount(job.llm_tokens_output) : "0"}`;
+        
+        if (job.started_at) {
+          const start = new Date(job.started_at + 'Z');
+          const end = job.finished_at ? new Date(job.finished_at + 'Z') : new Date();
+          const diffSeconds = Math.max(0, Math.floor((end - start) / 1000));
+          
+          if (diffSeconds < 60) {
+            metricTime.textContent = `${diffSeconds}s`;
+          } else {
+            const minutes = Math.floor(diffSeconds / 60);
+            const seconds = diffSeconds % 60;
+            metricTime.textContent = `${minutes}m ${seconds}s`;
+          }
+        } else {
+          metricTime.textContent = "0s";
+        }
       }
 
       function activeCounter(job) {

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -82,6 +82,7 @@
               <th>Version</th>
               <th>Created by</th>
               <th>Tokens (In/Out)</th>
+              <th>Generation Time</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -106,6 +107,14 @@
                           onclick="navigator.clipboard.writeText('{{ cb.llm_tokens_input or 0 }} / {{ cb.llm_tokens_output or 0 }}');">
                       {{ cb.llm_tokens_input | compact_number }} / {{ cb.llm_tokens_output | compact_number }}
                     </span>
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                </td>
+                <td class="text-secondary">
+                  {% set gen_time = cb | generation_time %}
+                  {% if gen_time %}
+                    {{ gen_time }}
                   {% else %}
                     &mdash;
                   {% endif %}

--- a/Frontend/web/templates/codebooks/new/progress.html
+++ b/Frontend/web/templates/codebooks/new/progress.html
@@ -5,7 +5,7 @@
     <h1 class="h3 mb-0">Generating Codebook</h1>
   </div>
 
-  <div class="bg-white border rounded-2 p-4" style="max-width: 640px;"
+  <div class="bg-white border rounded-2 p-4" style="max-width: 900px;"
        data-job-id="{{ job_id }}"
        data-mode="{{ mode }}"
        data-name="{{ codebook_name }}"

--- a/Frontend/web/templates/codebooks/new/progress.html
+++ b/Frontend/web/templates/codebooks/new/progress.html
@@ -94,29 +94,35 @@
     </div>
 
 
-    <div class="row g-2 mb-3" aria-label="Job metrics">
-      <div class="col-12 col-sm-3">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-5 g-2 mb-3" aria-label="Job metrics">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Transcripts</div>
           <div id="metric-documents" class="fw-semibold">Waiting</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Evidence</div>
           <div id="metric-evidence" class="fw-semibold">Pending</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Codebook</div>
           <div id="metric-codebook" class="fw-semibold">Pending</div>
         </div>
       </div>
-      <div class="col-12 col-sm-3">
+      <div class="col">
         <div class="border rounded-2 px-3 py-2 h-100">
           <div class="small text-secondary">Tokens (In/Out)</div>
           <div id="metric-tokens" class="fw-semibold">0 / 0</div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="border rounded-2 px-3 py-2 h-100">
+          <div class="small text-secondary">Generation Time</div>
+          <div id="metric-time" class="fw-semibold">0s</div>
         </div>
       </div>
     </div>
@@ -160,6 +166,7 @@
       const metricEvidence = document.getElementById("metric-evidence");
       const metricCodebook = document.getElementById("metric-codebook");
       const metricTokens = document.getElementById("metric-tokens");
+      const metricTime = document.getElementById("metric-time");
       const errorContainer = document.getElementById("progress-error-container");
       const errorEl = document.getElementById("progress-error");
       const cancelBtn = document.getElementById("cancel-btn");
@@ -239,6 +246,22 @@
         metricCodebook.textContent = pieces.length ? pieces.join(" / ") : "Pending";
         
         metricTokens.textContent = `${job.llm_tokens_input ? formatCount(job.llm_tokens_input) : "0"} / ${job.llm_tokens_output ? formatCount(job.llm_tokens_output) : "0"}`;
+        
+        if (job.started_at) {
+          const start = new Date(job.started_at + 'Z');
+          const end = job.finished_at ? new Date(job.finished_at + 'Z') : new Date();
+          const diffSeconds = Math.max(0, Math.floor((end - start) / 1000));
+          
+          if (diffSeconds < 60) {
+            metricTime.textContent = `${diffSeconds}s`;
+          } else {
+            const minutes = Math.floor(diffSeconds / 60);
+            const seconds = diffSeconds % 60;
+            metricTime.textContent = `${minutes}m ${seconds}s`;
+          }
+        } else {
+          metricTime.textContent = "0s";
+        }
       }
 
       function paint(job) {


### PR DESCRIPTION

Added: a live tracker during application / generation, 
<img width="836" height="424" alt="Screenshot 2026-07-13 at 11 26 03" src="https://github.com/user-attachments/assets/0820cf11-4f7e-4779-ad80-0154543f160d" />


Also an overview for the overall time it took, to a) generate and b) apply a codebook
<img width="1133" height="309" alt="Screenshot 2026-07-13 at 11 27 40" src="https://github.com/user-attachments/assets/d1e9fa6c-a863-4866-81ea-46a8efe195a7" />
