### PR TITLE
261 coverage color scheme and percentage precision

### DIFF
--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -206,16 +206,11 @@
     border-radius: 10px;
     transition: width 0.4s ease;
     min-width: 3px;
+    /* One neutral indigo for every coverage level (issue #261) — low coverage
+       isn't "bad", so no traffic-light colors. Same gradient as .breakdown-bar
+       and the page headers, on the indigo-100 track above. */
+    background: linear-gradient(90deg, #4338ca, #6366f1);
 }
-
-/* 0–33 %: sparse — rose/red */
-.theme-progress-bar--low  { background: linear-gradient(90deg, #f43f5e, #fb7185); }
-
-/* 34–66 %: moderate — amber */
-.theme-progress-bar--mid  { background: linear-gradient(90deg, #d97706, #fbbf24); }
-
-/* 67–100 %: prevalent — emerald */
-.theme-progress-bar--high { background: linear-gradient(90deg, #059669, #34d399); }
 
 /* ── Demographic breakdown (UC 3.6) ─────────────────────────────────────────── */
 .breakdown-dimension { margin-bottom: 1.5rem; }

--- a/Frontend/web/static/js/codebook_themes.js
+++ b/Frontend/web/static/js/codebook_themes.js
@@ -118,12 +118,6 @@
         return typeof value === "number" ? `${value.toFixed(2)}%` : "0.00%";
     }
 
-    function coverageBarClass(pct) {
-        if (pct <= 33) return "theme-progress-bar--low";
-        if (pct <= 66) return "theme-progress-bar--mid";
-        return "theme-progress-bar--high";
-    }
-
     // Shared ordering: most frequent first, ties alphabetical. Used for the
     // frequency list (boot auto-select) and for every sibling level of the
     // merged theme table.
@@ -360,7 +354,7 @@
                     coverageCell.innerHTML = `
                         <div class="d-flex align-items-center gap-2">
                             <div class="theme-progress">
-                                <div class="theme-progress-bar ${coverageBarClass(pct)}" style="width:${barWidth}%"></div>
+                                <div class="theme-progress-bar" style="width:${barWidth}%"></div>
                             </div>
                             <span class="coverage-label${pct === 0 ? " theme-zero" : ""}">${formatCoverage(pct)}</span>
                         </div>`;


### PR DESCRIPTION
Closes #261.

Replaces the tthree color coded coverage bar colors with a single indigo, and keeps the 2-decimal percentage precision as it is.
