### PR TITLE
feat: add numeric variable binning and decouple codebook generation f…

### DIFF
--- a/Backend/app/main.py
+++ b/Backend/app/main.py
@@ -38,6 +38,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     )
     await codebook_generation_job_runner.start()
     await codebook_application_job_runner.start()
+    await codebook_generation_job_runner.reconcile_orphaned_jobs()
+    await codebook_application_job_runner.reconcile_orphaned_jobs()
 
     try:
         yield

--- a/Backend/app/routers/demographic.py
+++ b/Backend/app/routers/demographic.py
@@ -161,7 +161,7 @@ async def list_demographic_dimensions(
 ) -> ResponseEnvelope[DemographicDimensionsResponse]:
     """Return the demographic variables that can be used to break down a theme."""
     service = ThemeDemographicBreakdownService(session)
-    dimensions = await service.list_available_dimensions(corpus_id=corpus_id)
+    dimensions = await service.get_dimension_infos(corpus_id=corpus_id)
     return ResponseEnvelope[DemographicDimensionsResponse].ok(
         data=DemographicDimensionsResponse(dimensions=dimensions)
     )

--- a/Backend/app/routers/themes.py
+++ b/Backend/app/routers/themes.py
@@ -14,7 +14,11 @@ from app.schemas.theme_views import (
     ThemeFrequencyItem,
     ThemeQuoteItem,
 )
-from app.services.theme_demographic_breakdown import ThemeDemographicBreakdownService
+from app.services.theme_demographic_breakdown import (
+    MAX_BIN_COUNT,
+    MIN_BIN_COUNT,
+    ThemeDemographicBreakdownService,
+)
 from app.services.theme_frequency import ThemeFrequencyService
 from app.services.theme_graph import ThemeGraphService, ThemeNotFoundError, ThemeValidationError
 from app.services.theme_quotes import ThemeQuotesService
@@ -94,8 +98,18 @@ async def get_theme_demographic_breakdown(
         description="Comma-separated demographic dimension names to break down by.",
     ),
     application_run_id: UUID | None = Query(default=None),
+    bins: str = Query(
+        default="",
+        description=(
+            "Comma-separated dimension:bin_count pairs (e.g. 'age:5'), for "
+            "grouping a numeric dimension into equal-width intervals instead "
+            "of one group per raw value. Only meaningful for numeric "
+            "dimensions; ignored for dimensions not also passed in `dimensions`."
+        ),
+    ),
 ) -> JSONResponse:
     requested = [part.strip() for part in dimensions.split(",") if part.strip()]
+    requested_bins = _parse_bins_param(bins)
     service = ThemeDemographicBreakdownService(
         session,
         small_sample_threshold=settings.DEMOGRAPHIC_SMALL_SAMPLE_THRESHOLD,
@@ -106,11 +120,38 @@ async def get_theme_demographic_breakdown(
             theme_id=theme_id,
             dimensions=requested,
             application_run_id=application_run_id,
+            bins=requested_bins,
         )
     except ThemeNotFoundError as exc:
         raise NotFoundError(str(exc)) from exc
 
     return JSONResponse(content=ResponseEnvelope.ok(payload).model_dump(mode="json"))
+
+
+def _parse_bins_param(raw: str) -> dict[str, int]:
+    bins: dict[str, int] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        name, _, count_text = part.partition(":")
+        name = name.strip()
+        count_text = count_text.strip()
+        if not name or not count_text:
+            continue
+        try:
+            count = int(count_text)
+        except ValueError as exc:
+            raise UnprocessableError(
+                f"Invalid bin count for dimension '{name}': '{count_text}'"
+            ) from exc
+        if not (MIN_BIN_COUNT <= count <= MAX_BIN_COUNT):
+            raise UnprocessableError(
+                f"Bin count for dimension '{name}' must be between "
+                f"{MIN_BIN_COUNT} and {MAX_BIN_COUNT}; got {count}."
+            )
+        bins[name] = count
+    return bins
 
 
 @router.get("/{theme_id}/quotes", response_model=ResponseEnvelope[Page[ThemeQuoteItem]])

--- a/Backend/app/schemas/theme_views.py
+++ b/Backend/app/schemas/theme_views.py
@@ -38,10 +38,17 @@ class ThemeQuoteItem(BaseSchema):
     theme_ids: list[UUID]
 
 
+class DemographicDimensionInfo(BaseSchema):
+    """One demographic variable available for breakdowns, with its inferred type."""
+
+    name: str
+    is_numeric: bool = False
+
+
 class DemographicDimensionsResponse(BaseSchema):
     """Demographic variables available for breaking down a theme in one corpus."""
 
-    dimensions: list[str]
+    dimensions: list[DemographicDimensionInfo]
 
 
 class DemographicGroupStat(BaseSchema):

--- a/Backend/app/services/codebook_application_jobs.py
+++ b/Backend/app/services/codebook_application_jobs.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_session_factory
@@ -26,7 +27,48 @@ class CodebookApplicationJobRunner:
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
 
     async def start(self) -> None:
+        # Kept as a no-op: routers also call start() defensively before every
+        # enqueue() (in case app lifespan startup was skipped), so it must
+        # stay safe to call repeatedly mid-request. Orphaned-job reconciliation
+        # lives in reconcile_orphaned_jobs() instead, called exactly once from
+        # app lifespan — never from a request handler.
         return
+
+    async def reconcile_orphaned_jobs(self) -> None:
+        # Mirrors CodebookGenerationJobRunner.reconcile_orphaned_jobs(): jobs
+        # left "queued"/"running" belong to a worker task that no longer
+        # exists in this process after a restart, so their DB status would
+        # otherwise never leave queued/running and the UI would show a
+        # progress bar that can never finish.
+        session_factory = get_session_factory()
+        async with session_factory() as session:
+            orphaned_jobs = list(
+                (
+                    await session.scalars(
+                        select(CodebookApplicationJob).where(
+                            CodebookApplicationJob.status.in_(("queued", "running"))
+                        )
+                    )
+                ).all()
+            )
+            if not orphaned_jobs:
+                return
+            now = _utc_now_naive()
+            for job in orphaned_jobs:
+                job.status = "failed"
+                job.phase = "failed"
+                job.error_message = "Codebook application was interrupted by a server restart."
+                job.finished_at = now
+                if job.application_run_id is not None:
+                    run = await session.get(CodebookApplicationRun, job.application_run_id)
+                    if run is not None:
+                        run.status = "failed"
+                        run.finished_at = now
+            await session.commit()
+            logger.warning(
+                "Reconciled {} orphaned codebook application job(s) on startup",
+                len(orphaned_jobs),
+            )
 
     async def stop(self) -> None:
         tasks = list(self._tasks.values())

--- a/Backend/app/services/codebook_generation_jobs.py
+++ b/Backend/app/services/codebook_generation_jobs.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.database import get_session_factory
@@ -68,7 +69,43 @@ class CodebookGenerationJobRunner:
             self._phase_updated_at.pop(evict_job_id, None)
 
     async def start(self) -> None:
+        # Kept as a no-op: routers also call start() defensively before every
+        # enqueue() (in case app lifespan startup was skipped), so it must
+        # stay safe to call repeatedly mid-request. Orphaned-job reconciliation
+        # lives in reconcile_orphaned_jobs() instead, called exactly once from
+        # app lifespan — never from a request handler.
         return
+
+    async def reconcile_orphaned_jobs(self) -> None:
+        # Jobs left "queued"/"running" belong to a worker task that no longer
+        # exists in this process (a prior process was restarted mid-job).
+        # Without this, their DB status never leaves queued/running, so the
+        # UI shows a progress bar that can never finish.
+        session_factory = get_session_factory()
+        async with session_factory() as session:
+            orphaned_jobs = list(
+                (
+                    await session.scalars(
+                        select(CodebookGenerationJob).where(
+                            CodebookGenerationJob.status.in_(("queued", "running"))
+                        )
+                    )
+                ).all()
+            )
+            if not orphaned_jobs:
+                return
+            now = _utc_now_naive()
+            for job in orphaned_jobs:
+                job.status = "failed"
+                job.phase = "failed"
+                job.error_message = "Codebook generation was interrupted by a server restart."
+                job.finished_at = now
+                self.set_phase(job.id, "failed")
+            await session.commit()
+            logger.warning(
+                "Reconciled {} orphaned codebook generation job(s) on startup",
+                len(orphaned_jobs),
+            )
 
     async def stop(self) -> None:
         tasks = list(self._tasks.values())

--- a/Backend/app/services/theme_demographic_breakdown.py
+++ b/Backend/app/services/theme_demographic_breakdown.py
@@ -18,6 +18,7 @@ from app.models import (
     ThemeAssignment,
 )
 from app.schemas.theme_views import (
+    DemographicDimensionInfo,
     DemographicGroupStat,
     ThemeDemographicBreakdownResponse,
     ThemeDimensionBreakdown,
@@ -35,6 +36,11 @@ USERNAME_COLUMN = "username"
 NOT_SPECIFIED_LABEL = "Not specified"
 
 DEFAULT_SMALL_SAMPLE_THRESHOLD = 5
+
+# Bounds for the researcher-chosen bin count on a numeric dimension. Below 2
+# there is nothing to bin; above 20 the chart stops being readable.
+MIN_BIN_COUNT = 2
+MAX_BIN_COUNT = 20
 
 
 class ThemeDemographicBreakdownService:
@@ -79,6 +85,47 @@ class ThemeDemographicBreakdownService:
                     dimensions.append(column)
         return dimensions
 
+    async def get_dimension_infos(self, *, corpus_id: UUID) -> list[DemographicDimensionInfo]:
+        """Demographic variables for one corpus, each flagged numeric or not.
+
+        A dimension is numeric only when every non-empty value observed for it
+        across the corpus parses as a number. Any non-numeric value (or no
+        values at all) makes it categorical — a dimension can't be partially
+        binnable.
+        """
+        names = await self.list_available_dimensions(corpus_id=corpus_id)
+        if not names:
+            return []
+
+        rows = (
+            await self._session.execute(
+                select(DemographicRow.data)
+                .join(DemographicFiles, DemographicRow.demographic_file_id == DemographicFiles.id)
+                .where(DemographicFiles.corpus_id == corpus_id)
+            )
+        ).scalars().all()
+
+        has_value = dict.fromkeys(names, False)
+        all_numeric = dict.fromkeys(names, True)
+        for data in rows:
+            if not data:
+                continue
+            for name in names:
+                raw = data.get(name)
+                if raw is None:
+                    continue
+                text = str(raw).strip()
+                if not text:
+                    continue
+                has_value[name] = True
+                if not self._is_numeric_text(text):
+                    all_numeric[name] = False
+
+        return [
+            DemographicDimensionInfo(name=name, is_numeric=has_value[name] and all_numeric[name])
+            for name in names
+        ]
+
     async def get_theme_breakdown(
         self,
         *,
@@ -86,6 +133,7 @@ class ThemeDemographicBreakdownService:
         theme_id: UUID,
         dimensions: list[str],
         application_run_id: UUID | None = None,
+        bins: dict[str, int] | None = None,
     ) -> ThemeDemographicBreakdownResponse:
         corpus_id = await self._resolve_codebook_corpus(codebook_id=codebook_id)
         await self._ensure_node_in_codebook(codebook_id=codebook_id, node_id=theme_id)
@@ -119,6 +167,7 @@ class ThemeDemographicBreakdownService:
             run_id=run_id, node_ids=theme_ids
         )
 
+        effective_bins = bins or {}
         return ThemeDemographicBreakdownResponse(
             theme_id=theme_id,
             application_run_id=run_id,
@@ -127,6 +176,7 @@ class ThemeDemographicBreakdownService:
                     dimension=dimension,
                     population=population,
                     present_document_ids=present_document_ids,
+                    bin_count=effective_bins.get(dimension),
                 )
                 for dimension in selected
             ],
@@ -256,7 +306,16 @@ class ThemeDemographicBreakdownService:
         dimension: str,
         population: list[tuple[UUID, dict[str, Any] | None]],
         present_document_ids: set[UUID],
+        bin_count: int | None = None,
     ) -> ThemeDimensionBreakdown:
+        if bin_count is not None:
+            return self._build_binned_dimension_breakdown(
+                dimension=dimension,
+                population=population,
+                present_document_ids=present_document_ids,
+                bin_count=bin_count,
+            )
+
         group_total: dict[str, int] = defaultdict(int)
         group_present: dict[str, int] = defaultdict(int)
 
@@ -280,6 +339,139 @@ class ThemeDemographicBreakdownService:
             for value in sorted(group_total, key=self._group_sort_key)
         ]
         return ThemeDimensionBreakdown(dimension=dimension, groups=groups)
+
+    def _build_binned_dimension_breakdown(
+        self,
+        *,
+        dimension: str,
+        population: list[tuple[UUID, dict[str, Any] | None]],
+        present_document_ids: set[UUID],
+        bin_count: int,
+    ) -> ThemeDimensionBreakdown:
+        """Group a numeric dimension into equal-width intervals instead of raw values.
+
+        Participants whose value doesn't parse as a number (or is missing)
+        still land in the usual NOT_SPECIFIED_LABEL bucket rather than being
+        dropped.
+        """
+        bin_count = max(MIN_BIN_COUNT, min(MAX_BIN_COUNT, bin_count))
+
+        numeric_by_document: dict[UUID, float] = {}
+        for document_id, data in population:
+            raw = (data or {}).get(dimension)
+            if raw is None:
+                continue
+            text = str(raw).strip()
+            if not text or not self._is_numeric_text(text):
+                continue
+            numeric_by_document[document_id] = float(text)
+
+        if not numeric_by_document:
+            # Nothing in this population parses as a number for this
+            # dimension (e.g. it's numeric corpus-wide but empty in this
+            # run); fall back to categorical grouping so the panel still
+            # shows the "Not specified" bucket instead of an empty chart.
+            return self._build_dimension_breakdown(
+                dimension=dimension,
+                population=population,
+                present_document_ids=present_document_ids,
+            )
+
+        values = list(numeric_by_document.values())
+        minimum, maximum = min(values), max(values)
+        all_integers = all(value.is_integer() for value in values)
+        labels, edges = self._bin_edges_and_labels(
+            minimum=minimum, maximum=maximum, bin_count=bin_count, all_integers=all_integers
+        )
+
+        group_total: dict[str, int] = defaultdict(int)
+        group_present: dict[str, int] = defaultdict(int)
+        for document_id, _data in population:
+            value = numeric_by_document.get(document_id)
+            label = NOT_SPECIFIED_LABEL if value is None else labels[self._bin_index(value, edges)]
+            group_total[label] += 1
+            if document_id in present_document_ids:
+                group_present[label] += 1
+
+        # Show every interval (even empty ones) so the chart always reflects
+        # the requested bin count; the catch-all bucket only appears when
+        # something actually landed in it.
+        ordered_labels = [*labels, *([NOT_SPECIFIED_LABEL] if group_total.get(NOT_SPECIFIED_LABEL) else [])]
+        groups = [
+            DemographicGroupStat(
+                group_value=label,
+                present_count=group_present.get(label, 0),
+                group_total=group_total.get(label, 0),
+                percentage=self._to_percentage(
+                    present=group_present.get(label, 0),
+                    total=group_total.get(label, 0),
+                ),
+                small_sample=0 < group_total.get(label, 0) < self._small_sample_threshold,
+            )
+            for label in ordered_labels
+        ]
+        return ThemeDimensionBreakdown(dimension=dimension, groups=groups)
+
+    @staticmethod
+    def _bin_edges_and_labels(
+        *,
+        minimum: float,
+        maximum: float,
+        bin_count: int,
+        all_integers: bool,
+    ) -> tuple[list[str], list[float]]:
+        """Equal-width bin edges over [minimum, maximum], plus display labels.
+
+        Integer-valued dimensions (the common case: age, years, counts) get
+        integer, non-overlapping labels like "19-29"; the bin count is capped
+        to the number of distinct integers available so labels never collide.
+        Everything else uses one-decimal float labels.
+        """
+        if minimum == maximum:
+            bound = str(int(minimum)) if all_integers else f"{minimum:.1f}"
+            return [bound], [minimum, maximum]
+
+        effective_bin_count = bin_count
+        if all_integers:
+            effective_bin_count = max(1, min(bin_count, int(maximum - minimum)))
+
+        width = (maximum - minimum) / effective_bin_count
+        edges = [minimum + (index * width) for index in range(effective_bin_count + 1)]
+        edges[-1] = maximum
+
+        if all_integers:
+            edges = [round(edge) for edge in edges]
+            edges[0] = int(minimum)
+            edges[-1] = int(maximum)
+            for index in range(1, len(edges)):
+                if edges[index] <= edges[index - 1]:
+                    edges[index] = edges[index - 1] + 1
+            labels = [
+                f"{edges[index]}-{edges[index + 1]}"
+                if index == effective_bin_count - 1
+                else f"{edges[index]}-{edges[index + 1] - 1}"
+                for index in range(effective_bin_count)
+            ]
+            return labels, [float(edge) for edge in edges]
+
+        labels = [f"{edges[index]:.1f}-{edges[index + 1]:.1f}" for index in range(effective_bin_count)]
+        return labels, edges
+
+    @staticmethod
+    def _bin_index(value: float, edges: list[float]) -> int:
+        bin_count = len(edges) - 1
+        for index in range(bin_count - 1):
+            if value < edges[index + 1]:
+                return index
+        return bin_count - 1
+
+    @staticmethod
+    def _is_numeric_text(text: str) -> bool:
+        try:
+            float(text)
+        except ValueError:
+            return False
+        return True
 
     @staticmethod
     def _group_value(data: dict[str, Any] | None, dimension: str) -> str:

--- a/Backend/tests/test_job_runner_reconciliation.py
+++ b/Backend/tests/test_job_runner_reconciliation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import (
+    Base,
+    Codebook,
+    CodebookApplicationJob,
+    CodebookApplicationRun,
+    CodebookGenerationJob,
+    Corpus,
+)
+from app.services.codebook_application_jobs import CodebookApplicationJobRunner
+from app.services.codebook_generation_jobs import CodebookGenerationJobRunner
+
+AIOSQLITE_AVAILABLE = importlib.util.find_spec("aiosqlite") is not None
+
+
+@unittest.skipUnless(AIOSQLITE_AVAILABLE, "These tests require aiosqlite.")
+class JobRunnerReconciliationTests(unittest.IsolatedAsyncioTestCase):
+    """A backend restart clears in-memory job tasks but leaves DB rows behind.
+
+    ``start()`` on each runner must sweep those orphaned rows so the UI never
+    shows a progress bar for a job nothing is actually working on anymore.
+    """
+
+    async def asyncSetUp(self) -> None:
+        self.engine = create_async_engine(
+            "sqlite+aiosqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        self.session_factory = async_sessionmaker(
+            self.engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    async def asyncTearDown(self) -> None:
+        await self.engine.dispose()
+
+    async def test_generation_runner_marks_orphaned_jobs_failed_on_start(self) -> None:
+        corpus_id = uuid4()
+        running_job_id = uuid4()
+        queued_job_id = uuid4()
+        finished_job_id = uuid4()
+        async with self.session_factory() as session:
+            session.add(Corpus(id=corpus_id, project_id=uuid4(), name="Corpus"))
+            session.add(
+                CodebookGenerationJob(
+                    id=running_job_id,
+                    status="running",
+                    phase="synthesizing_themes",
+                    codebook_name="Interview Codebook",
+                    corpus_id=corpus_id,
+                    transcript_document_ids_json="[]",
+                )
+            )
+            session.add(
+                CodebookGenerationJob(
+                    id=queued_job_id,
+                    status="queued",
+                    phase="queued",
+                    codebook_name="Another Codebook",
+                    corpus_id=corpus_id,
+                    transcript_document_ids_json="[]",
+                )
+            )
+            session.add(
+                CodebookGenerationJob(
+                    id=finished_job_id,
+                    status="succeeded",
+                    phase="succeeded",
+                    codebook_name="Finished Codebook",
+                    corpus_id=corpus_id,
+                    transcript_document_ids_json="[]",
+                )
+            )
+            await session.commit()
+
+        runner = CodebookGenerationJobRunner()
+        with patch(
+            "app.services.codebook_generation_jobs.get_session_factory",
+            return_value=self.session_factory,
+        ):
+            await runner.reconcile_orphaned_jobs()
+
+        async with self.session_factory() as session:
+            running_job = await session.get(CodebookGenerationJob, running_job_id)
+            queued_job = await session.get(CodebookGenerationJob, queued_job_id)
+            finished_job = await session.get(CodebookGenerationJob, finished_job_id)
+
+        self.assertEqual(running_job.status, "failed")
+        self.assertEqual(running_job.phase, "failed")
+        self.assertIsNotNone(running_job.error_message)
+        self.assertIn("restart", running_job.error_message.lower())
+        self.assertIsNotNone(running_job.finished_at)
+
+        self.assertEqual(queued_job.status, "failed")
+        self.assertIsNotNone(queued_job.finished_at)
+
+        # Already-terminal jobs are left untouched.
+        self.assertEqual(finished_job.status, "succeeded")
+        self.assertIsNone(finished_job.error_message)
+
+    async def test_generation_runner_reconcile_is_a_no_op_with_no_orphaned_jobs(self) -> None:
+        runner = CodebookGenerationJobRunner()
+        with patch(
+            "app.services.codebook_generation_jobs.get_session_factory",
+            return_value=self.session_factory,
+        ):
+            await runner.reconcile_orphaned_jobs()  # must not raise on an empty table
+
+    async def test_application_runner_marks_orphaned_jobs_and_runs_failed_on_start(self) -> None:
+        corpus_id = uuid4()
+        codebook_id = uuid4()
+        run_id = uuid4()
+        running_job_id = uuid4()
+        async with self.session_factory() as session:
+            session.add(Corpus(id=corpus_id, project_id=uuid4(), name="Corpus"))
+            session.add(
+                Codebook(
+                    id=codebook_id,
+                    corpus_id=corpus_id,
+                    name="Codebook",
+                    description="Fixture",
+                    version=1,
+                    created_by="system",
+                )
+            )
+            session.add(
+                CodebookApplicationRun(
+                    id=run_id,
+                    corpus_id=corpus_id,
+                    codebook_id=codebook_id,
+                    status="running",
+                    documents_total=3,
+                )
+            )
+            session.add(
+                CodebookApplicationJob(
+                    id=running_job_id,
+                    status="running",
+                    phase="coding_documents",
+                    corpus_id=corpus_id,
+                    codebook_id=codebook_id,
+                    transcript_document_ids_json="[]",
+                    application_run_id=run_id,
+                )
+            )
+            await session.commit()
+
+        runner = CodebookApplicationJobRunner()
+        with patch(
+            "app.services.codebook_application_jobs.get_session_factory",
+            return_value=self.session_factory,
+        ):
+            await runner.reconcile_orphaned_jobs()
+
+        async with self.session_factory() as session:
+            job = await session.get(CodebookApplicationJob, running_job_id)
+            run = await session.get(CodebookApplicationRun, run_id)
+
+        self.assertEqual(job.status, "failed")
+        self.assertIsNotNone(job.error_message)
+        self.assertIn("restart", job.error_message.lower())
+        self.assertEqual(run.status, "failed")
+        self.assertIsNotNone(run.finished_at)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Backend/tests/test_theme_demographic_breakdown_api.py
+++ b/Backend/tests/test_theme_demographic_breakdown_api.py
@@ -129,7 +129,7 @@ async def test_dimensions_endpoint_lists_variables(client, db_engine):
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
-    assert payload["data"]["dimensions"] == ["gender"]
+    assert payload["data"]["dimensions"] == [{"name": "gender", "is_numeric": False}]
 
 
 async def test_dimensions_endpoint_empty_when_no_data(client):

--- a/Backend/tests/test_theme_demographic_breakdown_service.py
+++ b/Backend/tests/test_theme_demographic_breakdown_service.py
@@ -525,5 +525,173 @@ class ThemeDemographicBreakdownServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(groups["South"].percentage, 0.0)
 
 
+    # --- numeric dimension detection -----------------------------------------
+
+    async def test_get_dimension_infos_flags_numeric_and_categorical_columns(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age", "gender"],
+                people={
+                    "p1": {"age": "25", "gender": "male"},
+                    "p2": {"age": "30", "gender": "female"},
+                    "p3": {"age": "45", "gender": "male"},
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            infos = await ThemeDemographicBreakdownService(session).get_dimension_infos(
+                corpus_id=seed.corpus_id
+            )
+            by_name = {info.name: info.is_numeric for info in infos}
+            self.assertEqual(by_name, {"age": True, "gender": False})
+
+    async def test_get_dimension_infos_treats_mixed_column_as_categorical(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={
+                    "p1": {"age": "25"},
+                    "p2": {"age": "thirty"},  # one non-numeric value taints the whole column
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            infos = await ThemeDemographicBreakdownService(session).get_dimension_infos(
+                corpus_id=seed.corpus_id
+            )
+            by_name = {info.name: info.is_numeric for info in infos}
+            self.assertFalse(by_name["age"])
+
+    async def test_get_dimension_infos_empty_column_is_categorical(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={"p1": {}, "p2": None},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            infos = await ThemeDemographicBreakdownService(session).get_dimension_infos(
+                corpus_id=seed.corpus_id
+            )
+            by_name = {info.name: info.is_numeric for info in infos}
+            self.assertFalse(by_name["age"])
+
+    # --- numeric binning -------------------------------------------------------
+
+    async def test_binned_breakdown_creates_integer_intervals(self) -> None:
+        async with self.session_factory() as session:
+            ages = {
+                "p20": "20", "p21": "21", "p29": "29",
+                "p30": "30", "p31": "31",
+                "p39": "39", "p40": "40", "p41": "41", "p49": "49",
+            }
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={name: {"age": age} for name, age in ages.items()},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p20", "p30", "p39"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["age"],
+                bins={"age": 3},
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(set(groups), {"20-29", "30-38", "39-49"})
+            self.assertEqual(groups["20-29"].group_total, 3)
+            self.assertEqual(groups["20-29"].present_count, 1)
+            self.assertEqual(groups["30-38"].group_total, 2)
+            self.assertEqual(groups["30-38"].present_count, 1)
+            self.assertEqual(groups["39-49"].group_total, 4)
+            self.assertEqual(groups["39-49"].present_count, 1)
+
+    async def test_binned_breakdown_buckets_non_numeric_and_missing_into_not_specified(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={
+                    "numeric_a": {"age": "20"},
+                    "numeric_b": {"age": "40"},
+                    "blank": {"age": "  "},
+                    "unlinked": None,
+                },
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"numeric_a", "unlinked"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["age"],
+                bins={"age": 2},
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(groups[NOT_SPECIFIED_LABEL].group_total, 2)
+            self.assertEqual(groups[NOT_SPECIFIED_LABEL].present_count, 1)
+            # The two numeric people land in separate bins on either side of the midpoint.
+            numeric_groups = [g for label, g in groups.items() if label != NOT_SPECIFIED_LABEL]
+            self.assertEqual(sum(g.group_total for g in numeric_groups), 2)
+
+    async def test_binned_breakdown_single_value_collapses_to_one_bin(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={"p1": {"age": "30"}, "p2": {"age": "30"}, "p3": {"age": "30"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["age"],
+                bins={"age": 5},
+            )
+            groups = result.dimensions[0].groups
+            self.assertEqual(len(groups), 1)
+            self.assertEqual(groups[0].group_value, "30")
+            self.assertEqual(groups[0].group_total, 3)
+
+    async def test_binned_breakdown_clamps_bin_count_below_minimum(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "age"],
+                people={"p1": {"age": "20"}, "p2": {"age": "25"}, "p3": {"age": "30"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"p1"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["age"],
+                bins={"age": 1},  # below MIN_BIN_COUNT; must clamp up to 2
+            )
+            self.assertEqual(len(result.dimensions[0].groups), 2)
+
+    async def test_binned_breakdown_falls_back_to_categorical_for_non_numeric_dimension(self) -> None:
+        async with self.session_factory() as session:
+            seed = await _seed_breakdown(
+                session,
+                columns=["username", "gender"],
+                people={"m1": {"gender": "male"}, "f1": {"gender": "female"}},
+                theme_labels=["Theme A"],
+                present_by_theme={"Theme A": {"m1"}},
+            )
+            result = await ThemeDemographicBreakdownService(session).get_theme_breakdown(
+                codebook_id=seed.codebook_id,
+                theme_id=seed.theme_ids["Theme A"],
+                dimensions=["gender"],
+                bins={"gender": 5},  # nonsensical for a categorical column
+            )
+            groups = {g.group_value: g for g in result.dimensions[0].groups}
+            self.assertEqual(set(groups), {"male", "female"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Frontend/tests/conftest.py
+++ b/Frontend/tests/conftest.py
@@ -64,7 +64,7 @@ class FakeBackend:
         # Demographic data
         self.demographic_files: list[dict] = []
         self.demographic_rows: list[dict] = []
-        self.demographic_dimensions: list[str] = []
+        self.demographic_dimensions: list[dict] = []
         self.theme_demographic_breakdown: dict = {"theme_id": None, "dimensions": []}
         self.last_breakdown_request: dict | None = None
         self.demographic_link_summary: dict = {
@@ -210,7 +210,7 @@ class FakeBackend:
         self._maybe_raise("get_theme_tree")
         return self.theme_tree
 
-    def get_demographic_dimensions(self, corpus_id: str) -> list[str]:
+    def get_demographic_dimensions(self, corpus_id: str) -> list[dict]:
         self._maybe_raise("get_demographic_dimensions")
         return self.demographic_dimensions
 
@@ -220,6 +220,7 @@ class FakeBackend:
         theme_id: str,
         dimensions: list[str],
         application_run_id: str | None = None,
+        bins: dict[str, int] | None = None,
     ) -> dict:
         self._maybe_raise("get_theme_demographic_breakdown")
         self.last_breakdown_request = {
@@ -227,6 +228,7 @@ class FakeBackend:
             "theme_id": theme_id,
             "dimensions": dimensions,
             "application_run_id": application_run_id,
+            "bins": bins,
         }
         return self.theme_demographic_breakdown
 

--- a/Frontend/tests/test_backend_client.py
+++ b/Frontend/tests/test_backend_client.py
@@ -188,6 +188,25 @@ def test_create_generation_job_sends_payload_and_unwraps_envelope():
     assert job == {"id": "job-1", "status": "queued"}
 
 
+def test_create_generation_job_defaults_apply_after_generation_to_false():
+    # Regression test: codebook generation must not auto-apply to the corpus
+    # unless a caller explicitly opts back in — applying is now a separate,
+    # user-named step (see analysis.trigger_analysis).
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read()
+        return httpx.Response(
+            202,
+            json={"success": True, "data": {"id": "job-3"}, "error": None, "meta": None},
+        )
+
+    client = _client_with_handler(handler)
+    client.create_generation_job(codebook_name="cb", corpus_id="cid")
+    body = captured["body"].decode()
+    assert '"apply_after_generation": false' in body or '"apply_after_generation":false' in body
+
+
 def test_create_generation_job_includes_transcript_ids_when_provided():
     captured: dict = {}
 

--- a/Frontend/tests/test_codebook_breakdown.py
+++ b/Frontend/tests/test_codebook_breakdown.py
@@ -34,7 +34,10 @@ def _seed_themes_page(fake_backend):
 
 def test_themes_page_shows_dimension_picker_when_data_present(client, fake_backend):
     _seed_themes_page(fake_backend)
-    fake_backend.demographic_dimensions = ["gender", "age_group"]
+    fake_backend.demographic_dimensions = [
+        {"name": "gender", "is_numeric": False},
+        {"name": "age_group", "is_numeric": True},
+    ]
 
     resp = client.get(THEMES_PATH)
     assert resp.status_code == 200
@@ -45,6 +48,9 @@ def test_themes_page_shows_dimension_picker_when_data_present(client, fake_backe
     assert b"No demographic data available" not in resp.data
     # The dimensions are also embedded for the JS to read.
     assert b"data-demographic-dimensions" in resp.data
+    # Only the numeric dimension gets a bin-count input.
+    assert b'data-breakdown-bin-count="age_group"' in resp.data
+    assert b'data-breakdown-bin-count="gender"' not in resp.data
 
 
 def test_themes_page_shows_disabled_state_when_no_data(client, fake_backend):
@@ -109,6 +115,20 @@ def test_breakdown_json_parses_multiple_dimensions(client, fake_backend):
     resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=gender,age_group,party")
     assert resp.status_code == 200
     assert fake_backend.last_breakdown_request["dimensions"] == ["gender", "age_group", "party"]
+
+
+def test_breakdown_json_parses_bins_param(client, fake_backend):
+    fake_backend.theme_demographic_breakdown = {"theme_id": "theme-1", "dimensions": []}
+    resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=age_group&bins=age_group:5")
+    assert resp.status_code == 200
+    assert fake_backend.last_breakdown_request["bins"] == {"age_group": 5}
+
+
+def test_breakdown_json_ignores_malformed_bins_entries(client, fake_backend):
+    fake_backend.theme_demographic_breakdown = {"theme_id": "theme-1", "dimensions": []}
+    resp = client.get(BREAKDOWN_JSON_PATH + "?dimensions=age_group&bins=age_group:five,,gender:")
+    assert resp.status_code == 200
+    assert fake_backend.last_breakdown_request["bins"] is None
 
 
 def test_breakdown_json_handles_empty_dimensions(client, fake_backend):

--- a/Frontend/web/controllers/analysis.py
+++ b/Frontend/web/controllers/analysis.py
@@ -25,7 +25,8 @@ def index() -> str:
     codebook = None
     transcripts_count = 0
     active_corpus_id = None
-    
+    requested_codebook_id = request.args.get("codebook_id") or ""
+
     requested_corpus_id = request.args.get("corpus_id")
     try:
         active_corpus_id, corpus_options, active_corpus = resolve_active_corpus(
@@ -63,8 +64,11 @@ def index() -> str:
             if not codebooks:
                 disabled_reason = "Please configure a codebook for this corpus."
             else:
-                codebook = codebooks[0] # Default selection
-                
+                codebook = next(
+                    (cb for cb in codebooks if str(cb.get("id")) == requested_codebook_id),
+                    codebooks[0],
+                )
+
                 if transcripts_count == 0:
                     disabled_reason = "Corpus has no transcripts."
                 else:

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -382,18 +382,35 @@ def codebook_themes_for_corpus(corpus_id: str, codebook_id: str) -> str:
 def theme_demographic_breakdown_json(corpus_id: str, codebook_id: str, theme_id: str):
     dimensions = [d for d in request.args.get("dimensions", "").split(",") if d]
     application_run_id = request.args.get("application_run_id") or None
+    bins = _parse_bins_param(request.args.get("bins", ""))
     try:
         result = _backend().get_theme_demographic_breakdown(
             codebook_id,
             theme_id,
             dimensions,
             application_run_id=application_run_id,
+            bins=bins or None,
         )
         return jsonify(result)
     except BackendError as exc:
         return jsonify({"error": exc.user_message}), 502
     except Exception:
         return jsonify({"error": "An unexpected error occurred."}), 500
+
+
+def _parse_bins_param(raw: str) -> dict[str, int]:
+    bins: dict[str, int] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        name, _, count_text = part.partition(":")
+        name = name.strip()
+        count_text = count_text.strip()
+        if not name or not count_text.isdigit():
+            continue
+        bins[name] = int(count_text)
+    return bins
 
 
 @bp.get("/<corpus_id>/<codebook_id>/themes/<theme_id>/quotes.json")

--- a/Frontend/web/services/backend_client.py
+++ b/Frontend/web/services/backend_client.py
@@ -245,11 +245,18 @@ class BackendClient:
         theme_id: str,
         dimensions: list[str],
         application_run_id: str | None = None,
+        bins: dict[str, int] | None = None,
     ) -> dict:
-        """Break a theme's frequency down by the given demographic dimensions."""
+        """Break a theme's frequency down by the given demographic dimensions.
+
+        ``bins`` maps a numeric dimension name to a bin count, grouping that
+        dimension into equal-width intervals instead of one group per value.
+        """
         params: dict = {"dimensions": ",".join(dimensions)}
         if application_run_id:
             params["application_run_id"] = application_run_id
+        if bins:
+            params["bins"] = ",".join(f"{name}:{count}" for name, count in bins.items())
         return self._get(
             f"/codebooks/{codebook_id}/themes/{theme_id}/demographic-breakdown",
             params=params,
@@ -257,8 +264,11 @@ class BackendClient:
 
     # ---- Demographic --------------------------------------------------------
 
-    def get_demographic_dimensions(self, corpus_id: str) -> list[str]:
-        """List demographic variables available for breaking down a theme."""
+    def get_demographic_dimensions(self, corpus_id: str) -> list[dict]:
+        """List demographic variables available for breaking down a theme.
+
+        Each item is ``{"name": str, "is_numeric": bool}``.
+        """
         return self._get(
             f"/demographic/{corpus_id}/dimensions",
             sub_key="dimensions",
@@ -465,7 +475,7 @@ class BackendClient:
         analysis_name: str | None = None,
         custom_id: str | None = None,
         max_refinement_rounds: int | None = None,
-        apply_after_generation: bool | None = None,
+        apply_after_generation: bool | None = False,
     ) -> dict:
         payload: dict = {"codebook_name": codebook_name, "corpus_id": corpus_id}
         if analysis_name:

--- a/Frontend/web/static/js/job_tracker.js
+++ b/Frontend/web/static/js/job_tracker.js
@@ -161,19 +161,20 @@
     untrackJob(job.id);
     const cbId = status.codebook_id;
     if (status.status === "succeeded" && cbId) {
-      const runQuery = status.application_run_id
-        ? `?application_run_id=${encodeURIComponent(status.application_run_id)}`
-        : "";
+      // Generation no longer auto-applies the codebook (that's a separate,
+      // user-named step), so auto mode sends the researcher to the Analysis
+      // page with the new codebook preselected instead of a themes page that
+      // would otherwise show no results yet.
       const link = job.mode === "semi"
         ? `/codebooks/${cbId}/review`
         : (status.corpus_id
-            ? `/codebooks/${status.corpus_id}/${cbId}/themes${runQuery}`
-            : `/codebooks/${cbId}/themes${runQuery}`);
+            ? `/analysis/?corpus_id=${encodeURIComponent(status.corpus_id)}&codebook_id=${encodeURIComponent(cbId)}`
+            : `/analysis/?codebook_id=${encodeURIComponent(cbId)}`);
       const verb = job.mode === "semi" ? "ready for review" : "ready";
       showToast({
         title: "Codebook ready",
         body: `"${job.name || "Codebook"}" is ${verb}.` +
-              (job.mode === "semi" ? " Opening the review editor…" : " Click to open."),
+              (job.mode === "semi" ? " Opening the review editor…" : " Click to run an analysis."),
         link,
         kind: "success",
       });

--- a/Frontend/web/static/js/theme_breakdown.js
+++ b/Frontend/web/static/js/theme_breakdown.js
@@ -20,6 +20,8 @@
     // and there is nothing to wire up here.
     if (!Array.isArray(dimensions) || dimensions.length === 0) return;
 
+    const dimensionNames = dimensions.map((d) => (typeof d === "string" ? d : d.name));
+
     const breakdownUrlTemplate = appRoot.dataset.breakdownUrlTemplate || "";
     const applicationRunId = appRoot.dataset.applicationRunId || "";
     const codebookId = appRoot.dataset.codebookId || "";
@@ -31,6 +33,7 @@
     const resultsEl = document.getElementById("breakdown-results");
     const themeNameEl = document.getElementById("breakdown-theme-name");
     const checkboxes = Array.from(document.querySelectorAll("[data-breakdown-dimension]"));
+    const binInputs = Array.from(document.querySelectorAll("[data-breakdown-bin-count]"));
 
     if (!picker || !resultsEl || checkboxes.length === 0) return;
 
@@ -46,21 +49,37 @@
         return `ata-breakdown:${codebookId}:${applicationRunId}:${themeId}`;
     }
 
+    // Selections are stored as {dimensions: [...], bins: {name: count}}. Older
+    // entries were a plain array of dimension names (no bins); that shape is
+    // still accepted so existing selections aren't dropped.
     function loadSelection(themeId) {
-        if (!themeId) return [];
+        if (!themeId) return { dimensions: [], bins: {} };
         try {
             const raw = window.localStorage.getItem(storageKey(themeId));
-            const parsed = raw ? JSON.parse(raw) : [];
-            return Array.isArray(parsed) ? parsed.filter((d) => dimensions.includes(d)) : [];
+            const parsed = raw ? JSON.parse(raw) : null;
+            if (Array.isArray(parsed)) {
+                return { dimensions: parsed.filter((d) => dimensionNames.includes(d)), bins: {} };
+            }
+            if (parsed && typeof parsed === "object") {
+                const selectedDims = Array.isArray(parsed.dimensions)
+                    ? parsed.dimensions.filter((d) => dimensionNames.includes(d))
+                    : [];
+                const bins = parsed.bins && typeof parsed.bins === "object" ? parsed.bins : {};
+                return { dimensions: selectedDims, bins };
+            }
+            return { dimensions: [], bins: {} };
         } catch (_) {
-            return [];
+            return { dimensions: [], bins: {} };
         }
     }
 
-    function saveSelection(themeId, selected) {
+    function saveSelection(themeId, selectedDims, bins) {
         if (!themeId) return;
         try {
-            window.localStorage.setItem(storageKey(themeId), JSON.stringify(selected));
+            window.localStorage.setItem(
+                storageKey(themeId),
+                JSON.stringify({ dimensions: selectedDims, bins })
+            );
         } catch (_) {
             // Storage may be unavailable (private mode); selection stays in-memory.
         }
@@ -70,9 +89,32 @@
         return checkboxes.filter((cb) => cb.checked).map((cb) => cb.value);
     }
 
+    // Only bin counts for currently-checked numeric dimensions are sent —
+    // an unchecked dimension's bin input is irrelevant to the request.
+    function selectedBins() {
+        const checkedNames = new Set(selectedDimensions());
+        const bins = {};
+        binInputs.forEach((input) => {
+            const name = input.dataset.breakdownBinCount;
+            if (!checkedNames.has(name)) return;
+            const count = parseInt(input.value, 10);
+            if (Number.isFinite(count) && count >= 2) bins[name] = count;
+        });
+        return bins;
+    }
+
     function applySelectionToCheckboxes(selected) {
         const set = new Set(selected);
         checkboxes.forEach((cb) => { cb.checked = set.has(cb.value); });
+    }
+
+    function applyBinsToInputs(bins) {
+        binInputs.forEach((input) => {
+            const name = input.dataset.breakdownBinCount;
+            if (bins && Object.prototype.hasOwnProperty.call(bins, name)) {
+                input.value = bins[name];
+            }
+        });
     }
 
     // ------------------------------------------------------------------
@@ -92,13 +134,17 @@
         if (empty || loading || error) resultsEl.replaceChildren();
     }
 
-    function breakdownUrl(themeId, dims) {
+    function breakdownUrl(themeId, dims, bins) {
         const url = new URL(
             breakdownUrlTemplate.replace("__THEME__", themeId),
             window.location.origin
         );
         url.searchParams.set("dimensions", dims.join(","));
         if (applicationRunId) url.searchParams.set("application_run_id", applicationRunId);
+        const binPairs = Object.entries(bins || {});
+        if (binPairs.length > 0) {
+            url.searchParams.set("bins", binPairs.map(([name, count]) => `${name}:${count}`).join(","));
+        }
         return url.toString();
     }
 
@@ -223,7 +269,8 @@
 
     async function refresh() {
         const dims = selectedDimensions();
-        if (currentThemeId) saveSelection(currentThemeId, dims);
+        const bins = selectedBins();
+        if (currentThemeId) saveSelection(currentThemeId, dims, bins);
 
         if (!currentThemeId || dims.length === 0) {
             setState({ empty: true });
@@ -234,7 +281,7 @@
         setState({ loading: true });
 
         try {
-            const response = await fetch(breakdownUrl(currentThemeId, dims));
+            const response = await fetch(breakdownUrl(currentThemeId, dims, bins));
             const data = await response.json();
             if (token !== requestToken) return; // a newer request superseded this one
             if (!response.ok || data.error) {
@@ -257,11 +304,14 @@
         if (themeNameEl) {
             themeNameEl.textContent = currentThemeName || "the selected theme";
         }
-        applySelectionToCheckboxes(loadSelection(currentThemeId));
+        const selection = loadSelection(currentThemeId);
+        applySelectionToCheckboxes(selection.dimensions);
+        applyBinsToInputs(selection.bins);
         refresh();
     }
 
     checkboxes.forEach((cb) => cb.addEventListener("change", refresh));
+    binInputs.forEach((input) => input.addEventListener("change", refresh));
 
     document.addEventListener("theme:selected", (event) => {
         const detail = event.detail || {};

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -64,7 +64,7 @@
           <label for="codebook_id" class="form-label fw-semibold">Select Codebook</label>
           <select class="form-select" id="codebook_id" name="codebook_id" required>
             {% for cb in codebooks %}
-              <option value="{{ cb.id }}">{{ cb.name }} (v{{ cb.version }})</option>
+              <option value="{{ cb.id }}" {% if codebook and cb.id == codebook.id %}selected{% endif %}>{{ cb.name }} (v{{ cb.version }})</option>
             {% endfor %}
           </select>
         </div>

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -263,11 +263,19 @@
 
             <div id="breakdown-dimension-picker" class="d-flex flex-wrap gap-3 mb-3">
               {% for dim in demographic_dimensions %}
-                <div class="form-check form-check-inline m-0">
+                <div class="form-check form-check-inline m-0 d-flex align-items-center gap-1">
                   <input class="form-check-input" type="checkbox"
                          id="breakdown-dim-{{ loop.index }}"
-                         value="{{ dim }}" data-breakdown-dimension>
-                  <label class="form-check-label" for="breakdown-dim-{{ loop.index }}">{{ dim }}</label>
+                         value="{{ dim.name }}" data-breakdown-dimension>
+                  <label class="form-check-label" for="breakdown-dim-{{ loop.index }}">{{ dim.name }}</label>
+                  {% if dim.is_numeric %}
+                    <label class="visually-hidden" for="breakdown-bins-{{ loop.index }}">Number of bins for {{ dim.name }}</label>
+                    <input type="number" class="form-control form-control-sm ms-1" style="width: 4.5rem;"
+                           id="breakdown-bins-{{ loop.index }}"
+                           data-breakdown-bin-count="{{ dim.name }}"
+                           min="2" max="20" step="1" value="5"
+                           title="Number of bins for {{ dim.name }}">
+                  {% endif %}
                 </div>
               {% endfor %}
             </div>


### PR DESCRIPTION
…rom application

Numeric binning:
- Detect demographic dimensions where every value parses as numeric and expose that via the demographic-dimensions endpoint.
- Add equal-width interval binning (2-20 bins) to the theme demographic breakdown endpoint, with integer-aware edge rounding and a categorical fallback for non-numeric data.
- Let users pick a bin count per numeric dimension in the Analysis Breakdown panel; selection persists across refreshes.

Fixes:
- Stop automatic codebook generation from auto-applying the codebook to the corpus; the frontend no longer opts into apply_after_generation by default, so generation and application are two distinct, user-initiated steps. This also fixes the auto-run sharing the codebook's name with no distinct run ID, and the combined generation+application token counts bleeding into both the codebook and the analysis run.
- After generation completes, redirect to the Analysis page with the new codebook pre-selected instead of auto-navigating to a run that was never named by the user.
- Reconcile codebook generation/application jobs left "queued" or "running" in the database after a server restart, so the progress bar no longer polls a job that can never finish.