### PR TITLE
fix: add button for manual codebook entry form

### DIFF
--- a/Frontend/tests/test_codebook_controller.py
+++ b/Frontend/tests/test_codebook_controller.py
@@ -135,8 +135,11 @@ def test_unified_upload_page_shows_codebook_card(client, fake_backend):
     assert resp.status_code == 200
     assert b"Upload Codebook" in resp.data
     assert b"CSV" in resp.data
-    assert b"Generate or enter manually" in resp.data
+
+    assert b"Generate" in resp.data
+    assert b"enter manually" in resp.data
     assert b"/codebooks/new/test-corpus-id" in resp.data
+    assert b"/codebooks/test-corpus-id/manual" in resp.data
 
 
 # ---------------------------------------------------------------------------

--- a/Frontend/web/controllers/codebooks.py
+++ b/Frontend/web/controllers/codebooks.py
@@ -527,6 +527,7 @@ def manual_form(corpus_id: str) -> str:
         codebook_name="New Codebook",
         nodes=blank_nodes,
         error=None,
+        cancel_url=url_for("ingestion.upload_form", corpus_id=corpus_id, focus="codebook"),
     )
 
 @bp.post("/<corpus_id>/confirm")

--- a/Frontend/web/templates/codebooks/review.html
+++ b/Frontend/web/templates/codebooks/review.html
@@ -125,7 +125,7 @@
 
     <div class="d-flex gap-2">
       <a class="btn btn-outline-secondary"
-         href="{{ url_for('codebooks.list_codebooks') }}">Cancel</a>
+         href="{{ cancel_url or url_for('codebooks.list_codebooks') }}">Cancel</a>
       <button type="submit" class="btn btn-primary">{% if codebook_id %}Save as new version{% else %}Save codebook{% endif %}</button>
     </div>
 

--- a/Frontend/web/templates/ingestion/upload.html
+++ b/Frontend/web/templates/ingestion/upload.html
@@ -229,9 +229,12 @@
               <button id="codebook-submit-btn" type="submit" class="btn btn-teal w-100" disabled>
                 Upload &amp; preview
               </button>
-              <div class="mt-2">
+              <div class="mt-2 small">
                 <a href="{{ url_for('codebooks.new_codebook_mode_select', corpus_id=corpus_id) }}"
-                   class="small text-secondary">Generate or enter manually &rarr;</a>
+                   class="text-secondary">Generate &rarr;</a>
+                <span class="text-secondary mx-1">or</span>
+                <a href="{{ url_for('codebooks.manual_form', corpus_id=corpus_id) }}"
+                   class="text-secondary">enter manually &rarr;</a>
               </div>
             </div>
           </form>


### PR DESCRIPTION
- "enter manually" on upload codebook box links to `/codebooks/<corpus_id>/manual`
- Cancel button on `review.html`, when on Create Codebook mode links to codebook upload instead of codebooks main page.