### PR TITLE
260 unify frontend UI

### DIFF
--- a/Frontend/tests/test_codebook_controller.py
+++ b/Frontend/tests/test_codebook_controller.py
@@ -86,7 +86,7 @@ def test_list_codebooks_renders_empty_state(client, fake_codebook_backend):
     fake_codebook_backend.list_codebooks_result = []
     resp = client.get("/codebooks/test-corpus-id/")
     assert resp.status_code == 200
-    assert b"No codebooks found" in resp.data
+    assert b"No codebooks created yet" in resp.data
 
 
 def test_list_codebooks_renders_saved_entries(client, fake_codebook_backend):
@@ -100,7 +100,7 @@ def test_list_codebooks_renders_saved_entries(client, fake_codebook_backend):
     assert resp.status_code == 200
     assert b"Interview Framework" in resp.data
     assert b"Health Study" in resp.data
-    assert b"No codebooks found" not in resp.data
+    assert b"No codebooks" not in resp.data
 
 
 def test_list_codebooks_surfaces_backend_error(client, fake_codebook_backend):

--- a/Frontend/tests/test_codebooks.py
+++ b/Frontend/tests/test_codebooks.py
@@ -57,7 +57,9 @@ def test_codebook_list_renders_empty_state(client, fake_backend):
     fake_backend.codebooks = []
     resp = client.get("/codebooks/", follow_redirects=True)
     assert resp.status_code == 200
-    assert b"No codebooks found" in resp.data
+    assert b"No codebooks created yet" in resp.data
+    # Same empty-state pattern as Transcripts/Demographic: message + action link.
+    assert b"Create a codebook" in resp.data
 
 
 # The "Create New Codebook" button is the wizard entry point. It lives in the
@@ -152,7 +154,7 @@ def test_codebook_list_shows_unavailable_message_when_backend_down(client, fake_
     # HTML-escapes to "can&#39;t" when rendering the flash message.
     assert b"reach the analysis service" in resp.data
     # Empty-state line must NOT appear alongside the error.
-    assert b"No codebooks found" not in resp.data
+    assert b"No codebooks" not in resp.data
 
 
 def test_codebook_list_shows_error_when_requested_corpus_missing(client, fake_backend):
@@ -160,7 +162,7 @@ def test_codebook_list_shows_error_when_requested_corpus_missing(client, fake_ba
     resp = client.get("/codebooks/missing-corpus/", follow_redirects=True)
     assert resp.status_code == 200
     assert b"selected corpus couldn" in resp.data
-    assert b"No codebooks found" not in resp.data
+    assert b"No codebooks" not in resp.data
 
 
 # GET /codebooks/<id>/themes
@@ -184,7 +186,10 @@ def test_codebook_themes_renders_frequency_and_tree(client, fake_backend):
     resp = client.get("/codebooks/test-corpus-id/cb-1/themes", follow_redirects=True)
     assert resp.status_code == 200
     assert b"Work-Life Balance" in resp.data
-    assert b'id="global-corpus-select"' in resp.data
+    # Detail page: no corpus switcher here — it would navigate away to another
+    # corpus's codebook list, not re-scope this page. The hero + breadcrumb
+    # carry the context.
+    assert b'id="global-corpus-select"' not in resp.data
 
 
 def test_codebook_themes_highlights_analysis_nav_tab(client, fake_backend):

--- a/Frontend/web/static/css/main.css
+++ b/Frontend/web/static/css/main.css
@@ -1,4 +1,6 @@
-/* Project-specific overrides — Bootstrap handles the foundation. */
+/* Project-specific overrides — Bootstrap handles the foundation.
+   All colors come from tokens.css (issue #260). Do not add raw hex values
+   here; add or reuse a token instead. */
 
 /* ── Shared selectable lists ─────────────────────────────────────────────── */
 .ata-selectable-list {
@@ -11,8 +13,8 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid #e5e7eb;
-    background: #f8fafc;
+    border-bottom: 1px solid var(--ata-line);
+    background: var(--ata-surface-muted);
 }
 
 .ata-selectable-list__selection,
@@ -27,13 +29,13 @@
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    color: #111827;
+    color: var(--ata-ink-900);
     font-weight: 600;
     line-height: 1.2;
 }
 
 .ata-selectable-list__selected-count {
-    color: #4b5563;
+    color: var(--ata-ink-600);
     font-size: 0.88rem;
     font-weight: 500;
 }
@@ -48,7 +50,7 @@
 }
 
 .ata-selectable-list__row--selected > * {
-    background-color: #eef2ff !important;
+    background-color: var(--ata-primary-050) !important;
 }
 
 @media (max-width: 575.98px) {
@@ -63,13 +65,159 @@
     }
 }
 
-/* ── Theme browser page header ─────────────────────────────────────────────── */
-.theme-page-header {
-    background: linear-gradient(135deg, #3730a3 0%, #4f46e5 55%, #6366f1 100%);
+/* ── Hover-lift affordance ───────────────────────────────────────────────────
+   Same motion recipe as .upload-card. Used by the Home category cards
+   (buttons remain the click target there, per PO) and the codebook mode
+   cards (fully clickable labels). */
+.hover-lift {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.hover-lift:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 14px 28px -12px rgba(15, 23, 42, 0.18);
+}
+
+.hover-lift:active {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px -8px rgba(15, 23, 42, 0.18);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hover-lift,
+    .hover-lift:hover,
+    .hover-lift:active {
+        transition: none;
+        transform: none;
+    }
+}
+
+/* The mode cards are <label>s wrapping a radio — clickable everywhere, so
+   they should look it. */
+.mode-card { cursor: pointer; }
+
+/* ── Corpus toolbar (shared partial _corpus_select.html) ─────────────────────
+   One slim bar: label + compact select on the left, New/Delete actions on the
+   right. Replaces the old full-size card so list pages lead with content. */
+.corpus-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.6rem 0.9rem;
+    background: var(--ata-surface-muted);
+    border: 1px solid var(--ata-line);
+    border-radius: var(--ata-radius-control);
+}
+
+.corpus-bar-main {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.corpus-bar-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    font-size: 0.74rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ata-ink-500);
+    white-space: nowrap;
+}
+
+.corpus-bar-label .bi {
+    color: var(--ata-primary-500);
+    font-size: 1rem;
+}
+
+.corpus-bar-select {
+    flex: 0 1 auto;
+    min-width: 200px;
+    max-width: 340px;
+    background-color: #fff;
+    font-weight: 500;
+}
+
+.corpus-bar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
+.corpus-bar-hint {
+    font-size: 0.78rem;
+    color: var(--ata-ink-500);
+}
+
+@media (max-width: 575.98px) {
+    .corpus-bar-select { max-width: 100%; flex: 1 1 100%; }
+    .corpus-bar-actions { margin-left: 0; }
+}
+
+/* Scope variant — a full-width one-line strip directly under the page title:
+   labelled corpus select + helper caption, closed by a hairline so the
+   context reads separately from both the title actions and the content. */
+.corpus-scope {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--ata-line);
+}
+
+.corpus-scope-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0;
+    font-size: 0.74rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ata-ink-500);
+    white-space: nowrap;
+}
+
+.corpus-scope-label .bi {
+    color: var(--ata-primary-500);
+    font-size: 1rem;
+}
+
+.corpus-scope-select {
+    width: auto;
+    min-width: 200px;
+    max-width: 320px;
+    background-color: #fff;
+    font-weight: 500;
+}
+
+.corpus-scope-hint {
+    font-size: 0.8rem;
+    color: var(--ata-ink-500);
+}
+
+@media (max-width: 575.98px) {
+    .corpus-scope-select { max-width: 100%; flex: 1 1 100%; }
+}
+
+/* ── Theme browser page header ─────────────────────────────────────────────── */
+.theme-page-header {
+    background: var(--ata-gradient-hero);
+}
+
+/* Analysis-run context row INSIDE the hero — a translucent divider separates
+   it from the title row (was a second stacked gradient banner, which read as
+   two competing page headers). */
 .analysis-run-bar {
-    background: linear-gradient(135deg, #3730a3 0%, #4f46e5 55%, #6366f1 100%);
+    border-top: 1px solid rgba(255, 255, 255, 0.28);
+    margin-top: 1rem;
+    padding-top: 1rem;
 }
 
 .analysis-run-badge {
@@ -133,16 +281,16 @@
     line-height: 1;
 }
 
-.metric-card--indigo { background: linear-gradient(135deg, #4338ca, #6366f1); }
-.metric-card--cyan   { background: linear-gradient(135deg, #0e7490, #06b6d4); }
-.metric-card--teal   { background: linear-gradient(135deg, #0f766e, #14b8a6); }
+.metric-card--indigo { background: var(--ata-gradient-primary); }
+.metric-card--cyan   { background: var(--ata-gradient-cyan); }
+.metric-card--teal   { background: var(--ata-gradient-teal); }
 
 /* ── Panel section titles ───────────────────────────────────────────────────── */
 .panel-title {
     font-weight: 600;
-    color: #1e1b4b;
+    color: var(--ata-primary-950);
     padding-left: 10px;
-    border-left: 3px solid #4f46e5;
+    border-left: 3px solid var(--ata-primary-500);
     margin-bottom: 1rem;
 }
 
@@ -152,17 +300,17 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: #6b7280;
-    border-bottom: 2px solid #e5e7eb;
+    color: var(--ata-ink-500);
+    border-bottom: 2px solid var(--ata-line);
     background: transparent;
     padding-top: 0;
 }
 
 .theme-row-selectable { cursor: pointer; }
 
-.theme-row-selected td { background-color: #eef2ff !important; }
+.theme-row-selected td { background-color: var(--ata-primary-050) !important; }
 
-.theme-zero { color: #9ca3af; }
+.theme-zero { color: var(--ata-ink-400); }
 
 /* ── Researcher-topic highlighting (amber, distinct from indigo selection) ── */
 .theme-topic-badge {
@@ -171,9 +319,9 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: #92400e;
-    background: #fef3c7;
-    border: 1px solid #fde68a;
+    color: var(--ata-warning-ink);
+    background: var(--ata-warning-bg);
+    border: 1px solid var(--ata-warning-line);
     border-radius: 10px;
     padding: 1px 8px;
     margin-left: 6px;
@@ -196,7 +344,7 @@
 .theme-progress {
     height: 6px;
     border-radius: 10px;
-    background: #e0e7ff;
+    background: var(--ata-primary-100);
     flex: 1;
     overflow: hidden;
 }
@@ -209,7 +357,7 @@
     /* One neutral indigo for every coverage level (issue #261) — low coverage
        isn't "bad", so no traffic-light colors. Same gradient as .breakdown-bar
        and the page headers, on the indigo-100 track above. */
-    background: linear-gradient(90deg, #4338ca, #6366f1);
+    background: var(--ata-gradient-bar);
 }
 
 /* ── Demographic breakdown (UC 3.6) ─────────────────────────────────────────── */
@@ -221,7 +369,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: #4f46e5;
+    color: var(--ata-primary-500);
     margin-bottom: 0.6rem;
 }
 
@@ -239,7 +387,7 @@
 
 .breakdown-row-label {
     font-size: 0.82rem;
-    color: #374151;
+    color: var(--ata-ink-700);
     text-align: left;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -249,7 +397,7 @@
 .breakdown-track {
     position: relative;
     height: 20px;
-    background: #eef2ff;
+    background: var(--ata-primary-050);
     border-radius: 6px;
     overflow: hidden;
 }
@@ -257,21 +405,21 @@
 .breakdown-bar {
     height: 100%;
     border-radius: 6px;
-    background: linear-gradient(90deg, #4338ca, #6366f1);
+    background: var(--ata-gradient-bar);
     transition: width 0.4s ease;
     min-width: 2px;
 }
 
 .breakdown-bar-pct {
     font-size: 0.75rem;
-    color: #1e1b4b;
+    color: var(--ata-primary-950);
     text-align: right;
     white-space: nowrap;
 }
 
 .breakdown-bar-count {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--ata-ink-500);
     white-space: nowrap;
 }
 
@@ -280,7 +428,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: #6b7280;
+    color: var(--ata-ink-500);
 }
 
 .breakdown-small-sample {
@@ -289,9 +437,9 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    color: #92400e;
-    background: #fef3c7;
-    border: 1px solid #fde68a;
+    color: var(--ata-warning-ink);
+    background: var(--ata-warning-bg);
+    border: 1px solid var(--ata-warning-line);
     border-radius: 10px;
     padding: 1px 7px;
     margin-left: 6px;
@@ -323,12 +471,12 @@
     height: 0;
     border-style: solid;
     border-width: 4px 0 4px 6px;
-    border-color: transparent transparent transparent #9ca3af;
+    border-color: transparent transparent transparent var(--ata-ink-400);
     transition: transform 0.18s ease;
 }
 .tree-toggle[aria-expanded="true"]::before { transform: rotate(90deg); }
 .theme-row-selected .tree-toggle::before {
-    border-color: transparent transparent transparent #1d4ed8;
+    border-color: transparent transparent transparent var(--ata-primary-600);
 }
 
 /* Alignment spacer for leaf rows (same footprint as the chevron). */
@@ -356,24 +504,24 @@
     margin-bottom: -0.25rem;
 }
 .tree-indent--line {
-    background: linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 100%;
+    background: linear-gradient(var(--ata-ink-300), var(--ata-ink-300)) no-repeat center top / 1.5px 100%;
 }
 .tree-indent--tee {
     background:
-        linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 100%,
-        linear-gradient(#d1d5db, #d1d5db) no-repeat right center / 50% 1.5px;
+        linear-gradient(var(--ata-ink-300), var(--ata-ink-300)) no-repeat center top / 1.5px 100%,
+        linear-gradient(var(--ata-ink-300), var(--ata-ink-300)) no-repeat right center / 50% 1.5px;
 }
 .tree-indent--elbow {
     background:
-        linear-gradient(#d1d5db, #d1d5db) no-repeat center top / 1.5px 50%,
-        linear-gradient(#d1d5db, #d1d5db) no-repeat right center / 50% 1.5px;
+        linear-gradient(var(--ata-ink-300), var(--ata-ink-300)) no-repeat center top / 1.5px 50%,
+        linear-gradient(var(--ata-ink-300), var(--ata-ink-300)) no-repeat right center / 50% 1.5px;
 }
 
 /* Divider between the themes table and the quotes panel inside the merged
    box: a vertical rule when the columns sit side by side (xl+), a horizontal
    rule when they stack on smaller screens. */
 .quotes-panel {
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--ata-line);
     padding-top: 1rem;
 }
 
@@ -396,14 +544,14 @@
     background: #fff;
     z-index: 1;
     /* border-bottom doesn't travel with sticky cells; draw it as a shadow. */
-    box-shadow: inset 0 -2px 0 #e5e7eb;
+    box-shadow: inset 0 -2px 0 var(--ata-line);
     border-bottom: 0;
 }
 @media (min-width: 1200px) {
     .quotes-panel {
         border-top: 0;
         padding-top: 0;
-        border-left: 1px solid #e5e7eb;
+        border-left: 1px solid var(--ata-line);
         padding-left: 1.5rem;
     }
 }
@@ -412,7 +560,7 @@
 .td-name {
     font-size: 1.35rem;
     font-weight: 700;
-    color: #1e1b4b;
+    color: var(--ata-primary-950);
     line-height: 1.25;
 }
 
@@ -420,9 +568,9 @@
     display: inline-block;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.72rem;
-    color: #6b7280;
-    background: #f3f4f6;
-    border: 1px solid #e5e7eb;
+    color: var(--ata-ink-500);
+    background: var(--ata-surface-subtle);
+    border: 1px solid var(--ata-line);
     border-radius: 6px;
     padding: 3px 8px;
     word-break: break-all;
@@ -436,7 +584,7 @@
 .td-stat-number {
     font-size: 2rem;
     font-weight: 700;
-    color: #4f46e5;
+    color: var(--ata-primary-500);
     line-height: 1;
 }
 
@@ -445,7 +593,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.07em;
-    color: #374151;
+    color: var(--ata-ink-700);
     margin-top: 0.3rem;
 }
 
@@ -478,9 +626,9 @@
 /* ── Site footer ────────────────────────────────────────────────────────────── */
 .site-footer {
     flex-shrink: 0;
-    background: #f8f9fb;
-    border-top: 3px solid #4f46e5;
-    color: #374151;
+    background: var(--ata-surface-muted);
+    border-top: 3px solid var(--ata-primary-500);
+    color: var(--ata-ink-700);
 }
 
 .footer-logo {
@@ -490,14 +638,14 @@
 
 .footer-project-name {
     font-weight: 600;
-    color: #1e1b4b;
+    color: var(--ata-primary-950);
     font-size: 0.9rem;
     line-height: 1.2;
 }
 
 .footer-project-sub {
     font-size: 0.75rem;
-    color: #6b7280;
+    color: var(--ata-ink-500);
     line-height: 1.2;
 }
 
@@ -506,20 +654,20 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #4f46e5;
+    color: var(--ata-primary-500);
     line-height: 1.2;
 }
 
 .footer-partner-name {
     font-weight: 600;
-    color: #1f2937;
+    color: var(--ata-ink-800);
     font-size: 0.85rem;
     line-height: 1.25;
 }
 
 .footer-partner-tag {
     font-size: 0.76rem;
-    color: #6b7280;
+    color: var(--ata-ink-500);
     font-style: italic;
     line-height: 1.2;
 }
@@ -527,19 +675,19 @@
 .footer-link {
     font-size: 0.78rem;
     font-weight: 500;
-    color: #4f46e5;
+    color: var(--ata-primary-500);
     text-decoration: none;
 }
 
 .footer-link:hover {
-    color: #3730a3;
+    color: var(--ata-primary-700);
     text-decoration: underline;
 }
 
 .footer-bottom {
-    border-top: 1px solid #e5e7eb;
-    background: #f3f4f6;
-    color: #6b7280;
+    border-top: 1px solid var(--ata-line);
+    background: var(--ata-surface-subtle);
+    color: var(--ata-ink-500);
     font-size: 0.78rem;
 }
 
@@ -561,22 +709,19 @@
 }
 
 /* ── Upload cards (Uploads page two-card side-by-side layout) ───────────────
-   Reuses the indigo/teal gradient palette from the theme-browser metric cards
-   so the Uploads page visually belongs to the same design system. Cards lift
+   Indigo marks the primary card (transcripts); teal marks the supporting,
+   optional cards (demographics, codebook). The former cyan variant is an
+   alias of teal so the page uses exactly two accents (issue #260). Cards lift
    on hover (translateY + shadow) for a clear tactile affordance.
 */
 
-/* Soft max-width cap keeps the cards from sprawling across 1920px+ monitors
-   without making them awkwardly narrow on medium screens. */
-.upload-row {
-    max-width: 1080px;
-    margin-left: auto;
-    margin-right: auto;
-}
+/* The card row spans the full container width so it lines up with the corpus
+   toolbar above it (previously capped at 1080px, which left the cards
+   visually narrower than every other component on the page). */
 
 .upload-card {
     background: #fff;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--ata-line);
     border-radius: 14px;
     overflow: hidden;
     display: flex;
@@ -600,19 +745,19 @@
 }
 
 .upload-card--indigo .upload-card-header {
-    background: linear-gradient(135deg, #4338ca, #6366f1);
+    background: var(--ata-gradient-primary);
 }
-.upload-card--indigo:hover { border-color: #6366f1; }
+.upload-card--indigo:hover { border-color: var(--ata-primary-400); }
 
 .upload-card--teal .upload-card-header {
-    background: linear-gradient(135deg, #0f766e, #14b8a6);
+    background: var(--ata-gradient-teal);
 }
-.upload-card--teal:hover { border-color: #14b8a6; }
+.upload-card--teal:hover { border-color: var(--ata-teal-500); }
 
 .upload-card--cyan .upload-card-header {
-    background: linear-gradient(135deg, #0e7490, #06b6d4);
+    background: var(--ata-gradient-cyan);
 }
-.upload-card--cyan:hover { border-color: #06b6d4; }
+.upload-card--cyan:hover { border-color: var(--ata-cyan-500); }
 
 .upload-card--dimmed {
     opacity: 0.35;
@@ -661,7 +806,8 @@
 
 /* ── Theme-coloured submit buttons (match each card's gradient header) ───── */
 .btn-indigo,
-.btn-teal {
+.btn-teal,
+.btn-cyan {
     color: #fff;
     border: 1px solid transparent;
     font-weight: 500;
@@ -674,11 +820,11 @@
        .upload-card--indigo header gradient. A small button can't render the
        header's 135deg gradient meaningfully — the colour just looks washed
        out — so a solid pull from the same palette reads as "same family". */
-    background: #4338ca;
+    background: var(--ata-primary-600);
 }
 .btn-indigo:hover,
 .btn-indigo:focus {
-    background: #3730a3;
+    background: var(--ata-primary-700);
     color: #fff;
     box-shadow: 0 6px 14px -6px rgba(67, 56, 202, 0.45);
 }
@@ -688,8 +834,8 @@
 }
 .btn-indigo:disabled,
 .btn-indigo.disabled {
-    background: #c7d2fe;
-    color: #eef2ff;
+    background: var(--ata-primary-200);
+    color: var(--ata-primary-050);
     opacity: 0.85;
     cursor: not-allowed;
     /* Bootstrap's .btn:disabled sets pointer-events: none, which makes the
@@ -701,11 +847,11 @@
 }
 
 .btn-teal {
-    background: #0d9488;
+    background: var(--ata-teal-600);
 }
 .btn-teal:hover,
 .btn-teal:focus {
-    background: #0f766e;
+    background: var(--ata-teal-700);
     color: #fff;
     box-shadow: 0 6px 14px -6px rgba(13, 148, 136, 0.45);
 }
@@ -715,26 +861,21 @@
 }
 .btn-teal:disabled,
 .btn-teal.disabled {
-    background: #dcfce7;
-    color: #f0fdf4;
+    background: var(--ata-teal-100);
+    color: var(--ata-teal-050);
     opacity: 0.85;
     cursor: not-allowed;
     pointer-events: auto;     /* see .btn-indigo:disabled for rationale */
     box-shadow: none;
 }
 
-/* Cyan variant: used for demographic upload card */
+/* Cyan variant: used for the demographic upload card */
 .btn-cyan {
-    color: #fff;
-    border: 1px solid transparent;
-    font-weight: 500;
-    padding: 0.45rem 1.1rem;
-    transition: background 0.18s ease, transform 0.12s ease, box-shadow 0.18s ease;
-    background: #0e7490;
+    background: var(--ata-cyan-700);
 }
 .btn-cyan:hover,
 .btn-cyan:focus {
-    background: #075985;
+    background: var(--ata-cyan-800);
     color: #fff;
     box-shadow: 0 6px 14px -6px rgba(14, 116, 144, 0.45);
 }
@@ -744,11 +885,11 @@
 }
 .btn-cyan:disabled,
 .btn-cyan.disabled {
-    background: #cffafe;
-    color: #ecfeff;
+    background: var(--ata-cyan-100);
+    color: var(--ata-cyan-050);
     opacity: 0.85;
     cursor: not-allowed;
-    pointer-events: auto;
+    pointer-events: auto;     /* see .btn-indigo:disabled for rationale */
     box-shadow: none;
 }
 
@@ -763,14 +904,14 @@
     margin-top: 2px;
 }
 .file-list-item:hover {
-    background: #f3f4f6;
+    background: var(--ata-surface-subtle);
 }
 .file-list-item.is-oversize {
-    background: #fef2f2;
-    color: #991b1b;
+    background: var(--ata-danger-bg);
+    color: var(--ata-danger-700);
 }
 .file-list-item.is-oversize:hover {
-    background: #fee2e2;
+    background: var(--ata-danger-100);
 }
 
 .file-list-remove {
@@ -778,7 +919,7 @@
     height: 26px;
     padding: 0;
     border-radius: 50%;
-    color: #6b7280;
+    color: var(--ata-ink-500);
     background: transparent;
     border: 1px solid transparent;
     display: inline-flex;
@@ -788,10 +929,14 @@
 }
 .file-list-remove:hover,
 .file-list-remove:focus {
-    background: #fee2e2;
-    color: #b91c1c;
-    border-color: #fecaca;
+    background: var(--ata-danger-100);
+    color: var(--ata-danger-700);
+    border-color: var(--ata-danger-200);
+}
+/* Keep a visible ring for keyboard users (a11y — do not remove). */
+.file-list-remove:focus-visible {
     outline: none;
+    box-shadow: var(--ata-focus-ring);
 }
 .file-list-remove svg {
     width: 13px;
@@ -812,34 +957,34 @@
 .ata-toast {
   position: relative;
   background: #fff;
-  border: 1px solid #dee2e6;
-  border-left: 4px solid #6c757d;
+  border: 1px solid var(--ata-line);
+  border-left: 4px solid var(--ata-ink-500);
   border-radius: .5rem;
   padding: .85rem 2.25rem .85rem 1rem;
   box-shadow: 0 6px 16px rgba(0, 0, 0, .12);
   font-size: .95rem;
 }
-.ata-toast-success { border-left-color: var(--bs-success, #198754); }
-.ata-toast-danger  { border-left-color: var(--bs-danger,  #dc3545); }
-.ata-toast-warning { border-left-color: var(--bs-warning, #ffc107); }
+.ata-toast-success { border-left-color: var(--ata-success); }
+.ata-toast-danger  { border-left-color: var(--ata-danger); }
+.ata-toast-warning { border-left-color: var(--ata-warning-ink); }
 .ata-toast-clickable { cursor: pointer; }
-.ata-toast-clickable:hover { background: #f8f9fa; }
+.ata-toast-clickable:hover { background: var(--ata-surface-muted); }
 .ata-toast .btn-close {
   position: absolute;
   top: .55rem;
   right: .55rem;
 }
 .ata-toast-title { font-weight: 600; margin-bottom: .2rem; }
-.ata-toast-body  { color: #495057; }
+.ata-toast-body  { color: var(--ata-ink-700); }
 
 /* ── Codebook "saved" confirmation ──────────────────────────────────────── */
 .success-check {
     width: 72px;
     height: 72px;
     border-radius: 50%;
-    background: #ecfdf5;
-    border: 2px solid #a7f3d0;
-    color: #10b981;
+    background: var(--ata-success-bg);
+    border: 2px solid var(--ata-success-200);
+    color: var(--ata-success);
     font-size: 2.25rem;
     line-height: 1;
     display: flex;
@@ -854,18 +999,18 @@
 }
 .ata-link-card[data-transcript-card] { cursor: grab; }
 .ata-link-card[data-transcript-card]:focus-visible {
-  outline: 2px solid var(--bs-primary, #0d6efd);
+  outline: 2px solid var(--ata-primary-500);
   outline-offset: 2px;
 }
 .ata-link-card--dragging { opacity: .5; cursor: grabbing; }
 .ata-link-card--selected {
-  border-color: var(--bs-primary, #0d6efd);
-  box-shadow: 0 0 0 .15rem rgba(13, 110, 253, .25);
+  border-color: var(--ata-primary-500);
+  box-shadow: var(--ata-focus-ring);
 }
-.ata-link-card--linked { border-color: var(--bs-success, #198754); }
+.ata-link-card--linked { border-color: var(--ata-success); }
 .ata-link-dropzone--over {
-  border-color: var(--bs-primary, #0d6efd);
-  background: rgba(13, 110, 253, .08);
+  border-color: var(--ata-primary-500);
+  background: rgba(79, 70, 229, .08);
 }
 .ata-linking-board [data-transcripts-column],
 .ata-linking-board [data-demographic-column] {
@@ -877,15 +1022,15 @@
    Teal family — matches .btn-teal / .metric-card--teal — so the trigger and
    modal read as their own feature, distinct from the indigo View Analysis. */
 .btn-outline-teal {
-    color: #0d9488;
-    border: 1px solid #0d9488;
+    color: var(--ata-teal-600);
+    border: 1px solid var(--ata-teal-600);
     background: transparent;
     font-weight: 500;
     transition: background 0.15s ease, color 0.15s ease, box-shadow 0.18s ease;
 }
 .btn-outline-teal:hover,
 .btn-outline-teal:focus {
-    background: #0d9488;
+    background: var(--ata-teal-600);
     color: #fff;
     box-shadow: 0 6px 14px -6px rgba(13, 148, 136, 0.45);
 }
@@ -895,7 +1040,7 @@
 }
 
 .transcripts-modal-header {
-    background: linear-gradient(135deg, #0f766e, #14b8a6);
+    background: var(--ata-gradient-teal);
     border-bottom: 0;
 }
 .transcripts-modal-header .modal-title { color: #fff; }
@@ -925,9 +1070,9 @@
 .transcript-link {
     display: block;
     padding: 0.5rem 0.75rem;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--ata-line);
     border-radius: 0.5rem;
-    color: #334155;
+    color: var(--ata-ink-700);
     background: #fff;
     text-decoration: none;
     transition: background 0.15s ease, border-color 0.15s ease,
@@ -935,13 +1080,14 @@
 }
 .transcript-link:hover,
 .transcript-link:focus {
-    background: #f0fdfa;
-    border-color: #99f6e4;
-    color: #0f766e;
+    background: var(--ata-teal-050);
+    border-color: var(--ata-teal-200);
+    color: var(--ata-teal-700);
     transform: translateX(2px);
 }
 
-/* Pipeline Stepper */
+/* Pipeline Stepper — active steps use the brand primary, terminal states use
+   the shared status tokens (was a third, off-palette blue/emerald family). */
 .pipeline-stepper {
     display: flex;
     flex-direction: column;
@@ -966,7 +1112,7 @@
     top: 1.6rem;
     bottom: 0;
     width: 2px;
-    background-color: #e5e7eb;
+    background-color: var(--ata-line);
 }
 
 .pipeline-step:last-child::before {
@@ -981,8 +1127,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: #f3f4f6;
-    color: #9ca3af;
+    background-color: var(--ata-surface-subtle);
+    color: var(--ata-ink-400);
     z-index: 1;
     font-size: 0.85rem;
     border: 2px solid white;
@@ -997,62 +1143,62 @@
 .pipeline-step-title {
     font-size: 0.95rem;
     font-weight: 500;
-    color: #4b5563;
+    color: var(--ata-ink-600);
 }
 
 .pipeline-step-subtitle {
     font-size: 0.85rem;
-    color: #6b7280;
+    color: var(--ata-ink-500);
     margin-top: 0.25rem;
 }
 
 /* States */
 .pipeline-step-active .pipeline-step-icon {
-    background-color: #eff6ff;
-    color: #3b82f6;
+    background-color: var(--ata-primary-050);
+    color: var(--ata-primary-500);
 }
 .pipeline-step-active .pipeline-step-title {
-    color: #1f2937;
+    color: var(--ata-ink-800);
     font-weight: 600;
 }
 .pipeline-step-active::before {
-    background-color: #bfdbfe;
+    background-color: var(--ata-primary-200);
 }
 
 .pipeline-step-completed .pipeline-step-icon {
-    background-color: #ecfdf5;
-    color: #10b981;
+    background-color: var(--ata-success-bg);
+    color: var(--ata-success);
 }
 .pipeline-step-completed .pipeline-step-title {
-    color: #111827;
+    color: var(--ata-ink-900);
 }
 .pipeline-step-completed::before {
-    background-color: #10b981;
+    background-color: var(--ata-success);
 }
 
 .pipeline-step-failed .pipeline-step-icon {
-    background-color: #fef2f2;
-    color: #ef4444;
+    background-color: var(--ata-danger-bg);
+    color: var(--ata-danger);
 }
 .pipeline-step-failed .pipeline-step-title {
-    color: #b91c1c;
+    color: var(--ata-danger-700);
 }
 
 .pipeline-step-progress {
     height: 6px;
     border-radius: 4px;
-    background-color: #f3f4f6;
+    background-color: var(--ata-surface-subtle);
     overflow: hidden;
     margin-top: 0.5rem;
 }
 
 .pipeline-step-progress-bar {
     height: 100%;
-    background-color: #3b82f6;
+    background-color: var(--ata-primary-500);
     transition: width 0.3s ease;
 }
 .pipeline-step-failed .pipeline-step-progress-bar {
-    background-color: #ef4444;
+    background-color: var(--ata-danger);
 }
 
 .copy-error-btn {
@@ -1060,11 +1206,11 @@
     padding: 0.2rem 0.5rem;
     border-radius: 4px;
     background: transparent;
-    border: 1px solid #f87171;
-    color: #b91c1c;
+    border: 1px solid var(--ata-danger-300);
+    color: var(--ata-danger-700);
     cursor: pointer;
     transition: all 0.2s ease;
 }
 .copy-error-btn:hover {
-    background: #fef2f2;
+    background: var(--ata-danger-bg);
 }

--- a/Frontend/web/static/css/tokens.css
+++ b/Frontend/web/static/css/tokens.css
@@ -1,0 +1,163 @@
+/* ─────────────────────────────────────────────────────────────────────────────
+   Design tokens — single source of truth for every color, radius, shadow and
+   focus style in the frontend (issue #260, "Unify the whole frontend").
+
+   Rules:
+   - Raw hex values may ONLY appear in this file. Everything in main.css and
+     the templates must reference a token (or a Bootstrap variable that is
+     mapped to a token below).
+   - Brand primary is the indigo family already used by the logo, footer,
+     Theme Browser and Upload page. Teal is the ONE secondary accent, reserved
+     for "optional / supporting" surfaces (demographic & codebook upload cards,
+     interviewee speaker badges) — never for primary actions.
+   - Status colors match Bootstrap's contextual classes (text-bg-success etc.)
+     so templates that still use those classes stay consistent.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Brand (indigo) ────────────────────────────────────────────────────── */
+  --ata-primary-950: #1e1b4b;
+  --ata-primary-700: #3730a3;   /* hover / active, gradient start */
+  --ata-primary-600: #4338ca;   /* buttons, links (7.3:1 on white) */
+  --ata-primary-500: #4f46e5;   /* accents, borders, gradient mid  */
+  --ata-primary-400: #6366f1;   /* gradient end */
+  --ata-primary-200: #c7d2fe;   /* disabled fills */
+  --ata-primary-100: #e0e7ff;   /* progress tracks */
+  --ata-primary-050: #eef2ff;   /* selected-row tint */
+
+  /* ── Secondary accent (teal) — supporting/optional surfaces only ───────── */
+  --ata-teal-700: #0f766e;
+  --ata-teal-600: #0d9488;
+  --ata-teal-500: #14b8a6;
+  --ata-teal-200: #99f6e4;
+  --ata-teal-100: #ccfbf1;
+  --ata-teal-050: #f0fdfa;
+
+  /* ── Tertiary accent (cyan) — demographic upload card only ─────────────── */
+  --ata-cyan-800: #075985;
+  --ata-cyan-700: #0e7490;
+  --ata-cyan-500: #06b6d4;
+  --ata-cyan-100: #cffafe;
+  --ata-cyan-050: #ecfeff;
+
+  /* ── Neutrals (gray family already dominant in main.css) ───────────────── */
+  --ata-ink-900: #111827;
+  --ata-ink-800: #1f2937;
+  --ata-ink-700: #374151;
+  --ata-ink-600: #4b5563;
+  --ata-ink-500: #6b7280;
+  --ata-ink-400: #9ca3af;
+  --ata-ink-300: #d1d5db;
+  --ata-line: #e5e7eb;
+  --ata-surface-subtle: #f3f4f6;
+  --ata-surface-muted: #f8fafc;
+
+  /* ── Status — one set for badges, stepper, toasts, table rows ──────────── */
+  --ata-success: #198754;
+  --ata-success-200: #a7f3d0;
+  --ata-success-bg: #ecfdf5;
+
+  --ata-warning-ink: #92400e;
+  --ata-warning-line: #fde68a;
+  --ata-warning-bg: #fef3c7;
+
+  --ata-danger: #dc3545;
+  --ata-danger-700: #b91c1c;
+  --ata-danger-300: #f87171;
+  --ata-danger-200: #fecaca;
+  --ata-danger-100: #fee2e2;
+  --ata-danger-bg: #fef2f2;
+
+  /* ── Shared gradients ───────────────────────────────────────────────────── */
+  --ata-gradient-hero: linear-gradient(135deg, var(--ata-primary-700) 0%, var(--ata-primary-500) 55%, var(--ata-primary-400) 100%);
+  --ata-gradient-bar: linear-gradient(90deg, var(--ata-primary-600), var(--ata-primary-400));
+  --ata-gradient-primary: linear-gradient(135deg, var(--ata-primary-600), var(--ata-primary-400));
+  --ata-gradient-teal: linear-gradient(135deg, var(--ata-teal-700), var(--ata-teal-500));
+  --ata-gradient-cyan: linear-gradient(135deg, var(--ata-cyan-700), var(--ata-cyan-500));
+
+  /* ── Shape, elevation, focus ────────────────────────────────────────────── */
+  --ata-radius-control: 0.5rem;
+  --ata-radius-surface: 0.75rem;
+  --ata-shadow-raise: 0 6px 16px -8px rgba(15, 23, 42, 0.18);
+  --ata-focus-ring: 0 0 0 0.2rem rgba(79, 70, 229, 0.35);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Bootstrap 5.3 mapping — repaints stock components (buttons, links, badges,
+   pagination, forms, spinners) to the brand without touching any template.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  --bs-primary: var(--ata-primary-600);
+  --bs-primary-rgb: 67, 56, 202;              /* #4338ca */
+  --bs-link-color: var(--ata-primary-600);
+  --bs-link-color-rgb: 67, 56, 202;
+  --bs-link-hover-color: var(--ata-primary-700);
+  --bs-link-hover-color-rgb: 55, 48, 163;     /* #3730a3 */
+}
+
+.btn-primary {
+  --bs-btn-bg: var(--ata-primary-600);
+  --bs-btn-border-color: var(--ata-primary-600);
+  --bs-btn-hover-bg: var(--ata-primary-700);
+  --bs-btn-hover-border-color: var(--ata-primary-700);
+  --bs-btn-active-bg: var(--ata-primary-700);
+  --bs-btn-active-border-color: var(--ata-primary-700);
+  --bs-btn-disabled-bg: var(--ata-primary-200);
+  --bs-btn-disabled-border-color: var(--ata-primary-200);
+  --bs-btn-focus-shadow-rgb: 79, 70, 229;
+}
+
+.btn-outline-primary {
+  --bs-btn-color: var(--ata-primary-600);
+  --bs-btn-border-color: var(--ata-primary-600);
+  --bs-btn-hover-bg: var(--ata-primary-600);
+  --bs-btn-hover-border-color: var(--ata-primary-600);
+  --bs-btn-active-bg: var(--ata-primary-700);
+  --bs-btn-active-border-color: var(--ata-primary-700);
+  --bs-btn-disabled-color: var(--ata-primary-400);
+  --bs-btn-disabled-border-color: var(--ata-primary-200);
+  --bs-btn-focus-shadow-rgb: 79, 70, 229;
+}
+
+.btn-link { --bs-btn-color: var(--ata-primary-600); --bs-btn-hover-color: var(--ata-primary-700); }
+
+.pagination {
+  --bs-pagination-active-bg: var(--ata-primary-600);
+  --bs-pagination-active-border-color: var(--ata-primary-600);
+  --bs-pagination-focus-box-shadow: var(--ata-focus-ring);
+}
+
+.progress { --bs-progress-bar-bg: var(--ata-primary-600); }
+
+.accordion {
+  --bs-accordion-active-bg: var(--ata-primary-050);
+  --bs-accordion-active-color: var(--ata-primary-700);
+  --bs-accordion-btn-focus-box-shadow: var(--ata-focus-ring);
+}
+
+.breadcrumb { --bs-breadcrumb-item-active-color: var(--ata-ink-500); }
+
+/* Compiled Bootstrap hardcodes the blue focus/checked styles on form controls
+   (they don't read --bs-primary), so they need explicit overrides. */
+.form-control:focus,
+.form-select:focus {
+  border-color: var(--ata-primary-400);
+  box-shadow: var(--ata-focus-ring);
+}
+.form-check-input:checked {
+  background-color: var(--ata-primary-600);
+  border-color: var(--ata-primary-600);
+}
+.form-check-input:focus {
+  border-color: var(--ata-primary-400);
+  box-shadow: var(--ata-focus-ring);
+}
+.btn-close:focus { box-shadow: var(--ata-focus-ring); }
+
+/* A11y: `.shadow-none` on the corpus selector kills Bootstrap's focus ring
+   (box-shadow: none !important). Restore a visible ring for keyboard users. */
+.form-control.shadow-none:focus,
+.form-select.shadow-none:focus {
+  box-shadow: var(--ata-focus-ring) !important;
+}

--- a/Frontend/web/templates/_analysis_delete_confirm_modal.html
+++ b/Frontend/web/templates/_analysis_delete_confirm_modal.html
@@ -25,7 +25,7 @@
             {% endfor %}
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
             <button type="submit" class="btn btn-danger">
               {{ pending_analysis_delete.confirm_label }}
             </button>

--- a/Frontend/web/templates/_corpus_select.html
+++ b/Frontend/web/templates/_corpus_select.html
@@ -1,13 +1,46 @@
-<div class="card border-0 shadow-sm rounded-4 mb-4">
-  <div class="card-body p-4">
-    <label for="global-corpus-select" class="form-label fw-semibold text-secondary mb-3">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-folder2-open me-2" viewBox="0 0 16 16">
-        <path d="M1 3.5A1.5 1.5 0 0 1 2.5 2h2.764c.958 0 1.76.56 2.311 1.184C7.985 3.648 8.48 4 9 4h4.5A1.5 1.5 0 0 1 15 5.5v.64c.57.265.94.876.856 1.546l-.64 5.124A2.5 2.5 0 0 1 12.733 15H3.266a2.5 2.5 0 0 1-2.481-2.19l-.64-5.124A1.5 1.5 0 0 1 1 6.14V3.5zM2 6h12v-.5a.5.5 0 0 0-.5-.5H9c-.964 0-1.71-.629-2.174-1.154C6.374 3.334 5.82 3 5.264 3H2.5a.5.5 0 0 0-.5.5V6zm-.367 1a.5.5 0 0 0-.496.562l.64 5.124A1.5 1.5 0 0 0 3.266 14h9.468a1.5 1.5 0 0 0 1.489-1.314l.64-5.124A.5.5 0 0 0 14.367 7H1.633z"/>
-      </svg>
-      Upload target corpus
+{# Corpus selector (issue #260) — two variants, one partial:
+
+   - "bar" (default): full-width toolbar with New corpus / Delete actions and
+     a helper line. Used on the Upload page, where the corpus is a decision
+     (upload target) and management actions belong.
+   - "scope": full-width one-line strip under the page title — visible
+     "Corpus" label + compact select + per-page helper text, closed by a
+     hairline. Says WHAT the control is and WHAT it scopes, while staying
+     clearly separate from the page's action buttons.
+
+   Context variables:
+   - switch_template_url (required), active_corpus_id, corpus_options
+   - corpus_select_variant: 'bar' (default) | 'scope'
+   - helper_text: caption explaining the scope (both variants)
+   - bar only: corpus_select_label, show_create_form, show_delete_corpus #}
+{% set _corpus_variant = corpus_select_variant | default('bar') %}
+
+{% if _corpus_variant == 'scope' %}
+  <div class="corpus-scope mb-4">
+    <label for="global-corpus-select" class="corpus-scope-label">
+      <i class="bi bi-folder2-open" aria-hidden="true"></i>
+      Corpus
     </label>
-    <div class="input-group input-group-lg">
-      <select id="global-corpus-select" class="form-select shadow-none bg-light"
+    <select id="global-corpus-select" class="form-select form-select-sm corpus-scope-select"
+            data-switch-template="{{ switch_template_url }}">
+      {% for corpus in corpus_options %}
+        <option value="{{ corpus.id }}" {% if corpus.id == active_corpus_id %}selected{% endif %}>
+          {{ corpus.name }}
+        </option>
+      {% endfor %}
+    </select>
+    {% if helper_text %}
+      <span class="corpus-scope-hint">{{ helper_text }}</span>
+    {% endif %}
+  </div>
+{% else %}
+  <div class="corpus-bar mb-4">
+    <div class="corpus-bar-main">
+      <label for="global-corpus-select" class="corpus-bar-label">
+        <i class="bi bi-folder2-open" aria-hidden="true"></i>
+        {{ corpus_select_label | default('Corpus') }}
+      </label>
+      <select id="global-corpus-select" class="form-select form-select-sm corpus-bar-select"
             data-switch-template="{{ switch_template_url }}">
         {% for corpus in corpus_options %}
           <option value="{{ corpus.id }}" {% if corpus.id == active_corpus_id %}selected{% endif %}>
@@ -15,69 +48,93 @@
           </option>
         {% endfor %}
       </select>
-      {% if active_corpus_id and show_delete_corpus %}
-      <button type="button" class="btn btn-outline-danger shadow-none" data-bs-toggle="modal" data-bs-target="#deleteCorpusModal-{{ active_corpus_id }}">
-        <i class="bi bi-trash"></i> Delete
-      </button>
+
+      {% if show_create_form or (active_corpus_id and show_delete_corpus) %}
+        <div class="corpus-bar-actions">
+          {% if show_create_form %}
+            <button type="button" class="btn btn-sm btn-outline-primary"
+                    data-bs-toggle="modal" data-bs-target="#createCorpusModal">
+              <i class="bi bi-plus-lg" aria-hidden="true"></i> New corpus
+            </button>
+          {% endif %}
+          {% if active_corpus_id and show_delete_corpus %}
+            <button type="button" class="btn btn-sm btn-outline-danger"
+                    data-bs-toggle="modal" data-bs-target="#deleteCorpusModal-{{ active_corpus_id }}"
+                    aria-label="Delete this corpus" title="Delete this corpus">
+              <i class="bi bi-trash" aria-hidden="true"></i>
+            </button>
+          {% endif %}
+        </div>
       {% endif %}
     </div>
-    <div class="form-text mt-2 text-muted mb-0">
-      {{ helper_text }}
-    </div>
-
-    {% if active_corpus_id %}
-    <!-- Delete Corpus Modal -->
-    <div class="modal fade text-start" id="deleteCorpusModal-{{ active_corpus_id }}" tabindex="-1" aria-labelledby="deleteCorpusModalLabel-{{ active_corpus_id }}" aria-hidden="true">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <form method="POST" action="{{ url_for('ingestion.delete_corpus_submit', corpus_id=active_corpus_id) }}">
-            <div class="modal-header text-danger">
-              <h5 class="modal-title" id="deleteCorpusModalLabel-{{ active_corpus_id }}">
-                <i class="bi bi-exclamation-triangle-fill me-2"></i>Delete Corpus
-              </h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-              <p>Are you sure you want to permanently delete this corpus?</p>
-              <p class="text-muted small mb-0"><strong>Warning:</strong> This action cannot be undone. All associated transcripts, codebooks, and demographic data will be permanently deleted.</p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-              <button type="submit" class="btn btn-danger">Yes, Delete Corpus</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-    {% endif %}
-
-    {% if show_create_form %}
-      <hr class="my-4 text-muted border-secondary opacity-25">
-      <form id="create-corpus-form"
-            method="post"
-            action="{{ url_for('ingestion.create_corpus_submit') }}">
-        <input type="hidden" id="current_corpus_id" name="current_corpus_id" value="{{ active_corpus_id }}">
-        <label for="new_corpus_name" class="form-label fw-semibold text-secondary mb-2">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle me-1 mb-1" viewBox="0 0 16 16">
-            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-            <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
-          </svg>
-          Create new corpus
-        </label>
-        <div class="input-group input-group-lg">
-          <input type="text"
-                 id="new_corpus_name"
-                 name="name"
-                 class="form-control rounded-start-3 shadow-none bg-light"
-                 maxlength="255"
-                 placeholder="Enter corpus name"
-                 required>
-          <button type="submit" class="btn btn-outline-secondary rounded-end-3 px-4 fw-medium">Create</button>
-        </div>
-      </form>
+    {% if helper_text %}
+      <p class="corpus-bar-hint mb-0">{{ helper_text }}</p>
     {% endif %}
   </div>
-</div>
+
+  {% if active_corpus_id and show_delete_corpus %}
+  <!-- Delete Corpus Modal -->
+  <div class="modal fade text-start" id="deleteCorpusModal-{{ active_corpus_id }}" tabindex="-1" aria-labelledby="deleteCorpusModalLabel-{{ active_corpus_id }}" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="POST" action="{{ url_for('ingestion.delete_corpus_submit', corpus_id=active_corpus_id) }}">
+          <div class="modal-header text-danger">
+            <h5 class="modal-title" id="deleteCorpusModalLabel-{{ active_corpus_id }}">
+              <i class="bi bi-exclamation-triangle-fill me-2"></i>Delete Corpus
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>Are you sure you want to permanently delete this corpus?</p>
+            <p class="text-secondary small mb-0"><strong>Warning:</strong> This action cannot be undone. All associated transcripts, codebooks, and demographic data will be permanently deleted.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-danger">Yes, Delete Corpus</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if show_create_form %}
+  <!-- Create Corpus Modal -->
+  <div class="modal fade text-start" id="createCorpusModal" tabindex="-1"
+       aria-labelledby="createCorpusModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="create-corpus-form"
+              method="post"
+              action="{{ url_for('ingestion.create_corpus_submit') }}">
+          <input type="hidden" id="current_corpus_id" name="current_corpus_id" value="{{ active_corpus_id }}">
+          <div class="modal-header">
+            <h5 class="modal-title" id="createCorpusModalLabel">
+              <i class="bi bi-plus-circle me-2" aria-hidden="true"></i>Create New Corpus
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <label for="new_corpus_name" class="form-label fw-semibold">Corpus name</label>
+            <input type="text"
+                   id="new_corpus_name"
+                   name="name"
+                   class="form-control"
+                   maxlength="255"
+                   placeholder="Enter corpus name"
+                   required>
+            <div class="form-text">A corpus groups transcripts, demographic data and codebooks that belong together.</div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+{% endif %}
 
 <script>
   (() => {
@@ -90,5 +147,13 @@
       const target = template.replace("__CORPUS_ID__", encodeURIComponent(selector.value));
       window.location.href = target;
     });
+
+    // Focus the name field when the create-corpus modal opens (bar variant).
+    const createModal = document.getElementById("createCorpusModal");
+    if (createModal) {
+      createModal.addEventListener("shown.bs.modal", () => {
+        createModal.querySelector("#new_corpus_name")?.focus();
+      });
+    }
   })();
 </script>

--- a/Frontend/web/templates/_delete_modal.html
+++ b/Frontend/web/templates/_delete_modal.html
@@ -20,7 +20,7 @@
         </p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
         <form action="{{ form_action }}" method="POST" class="d-inline">
           <button type="submit" class="btn btn-danger">Delete</button>
         </form>

--- a/Frontend/web/templates/_selectable_list_toolbar.html
+++ b/Frontend/web/templates/_selectable_list_toolbar.html
@@ -125,7 +125,7 @@
                    required>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
             <button type="submit" class="btn btn-primary">Create</button>
           </div>
         </form>
@@ -156,7 +156,7 @@
             <p>{{ selectable_list_delete_message | default('Are you sure you want to delete the selected items? This action cannot be undone.') | safe }}</p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
             <button type="submit" class="btn btn-danger">
               {{ selectable_list_delete_confirm_label | default('Delete') }}
             </button>

--- a/Frontend/web/templates/analysis/index.html
+++ b/Frontend/web/templates/analysis/index.html
@@ -3,16 +3,17 @@
 {% block title %}Trigger Analysis{% endblock %}
 
 {% block content %}
-<div class="row mb-4 align-items-center">
-  <div class="col-md-8">
-    <h1 class="h3 mb-0">Trigger Analysis</h1>
-    <p class="text-secondary mt-1 mb-0">Apply your codebook to the corpus to discover thematic patterns.</p>
-  </div>
-  <div class="col-md-4 text-md-end mt-3 mt-md-0">
-    {% set switch_template_url = url_for('analysis.index', corpus_id='__CORPUS_ID__') %}
-    {% include "_corpus_select.html" %}
-  </div>
+<div class="mb-3">
+  <h1 class="h3 mb-0">Trigger Analysis</h1>
+  <p class="text-secondary mt-1 mb-0">Apply your codebook to the corpus to discover thematic patterns.</p>
 </div>
+
+{% if corpus_options %}
+  {% set switch_template_url = url_for('analysis.index', corpus_id='__CORPUS_ID__') %}
+  {% set corpus_select_variant = 'scope' %}
+  {% set helper_text = 'Analysis runs and results are scoped to this corpus.' %}
+  {% include "_corpus_select.html" %}
+{% endif %}
 
 <div class="card shadow-sm border-0 mb-4">
   <div class="card-body p-4">
@@ -300,7 +301,7 @@
                 </div>
               </div>
               <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="submit" class="btn btn-primary">Download ZIP</button>
               </div>
             </form>
@@ -328,7 +329,7 @@
         An analysis run with this Codebook and set of Transcripts already exists for this corpus. Are you sure you want to run it again?
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-warning" id="confirmSubmitBtn">Proceed Anyway</button>
       </div>
     </div>
@@ -361,7 +362,7 @@
         </p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/Frontend/web/templates/base.html
+++ b/Frontend/web/templates/base.html
@@ -10,6 +10,7 @@
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/tokens.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
   {% block head_extra %}{% endblock %}
 </head>

--- a/Frontend/web/templates/codebooks/list.html
+++ b/Frontend/web/templates/codebooks/list.html
@@ -1,15 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Codebooks{% endblock %}
 {% block content %}
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('codebooks.list_codebooks_for_corpus', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Showing codebooks for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
-  <div class="d-flex justify-content-between align-items-baseline mb-4">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-3">
     <h1 class="h3 mb-0">Codebooks</h1>
     <a class="btn btn-primary"
        id="new-codebook-btn"
@@ -17,6 +9,14 @@
       Create New Codebook
     </a>
   </div>
+
+  {% if corpus_id and corpus_options %}
+    {% set active_corpus_id = corpus_id %}
+    {% set switch_template_url = url_for('codebooks.list_codebooks_for_corpus', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
+    {% set helper_text = 'Showing codebooks for this corpus.' %}
+    {% include "_corpus_select.html" %}
+  {% endif %}
 
   {% include "_analysis_delete_confirm_modal.html" %}
 
@@ -131,8 +131,13 @@
         </table>
       </div>
     </div>
+  {% elif corpus_id %}
+    <p class="text-secondary" id="empty-state">
+      No codebooks created yet.
+      <a href="{{ url_for('codebooks.new_codebook_mode_select', corpus_id=corpus_id) }}">Create a codebook</a>
+    </p>
   {% else %}
-    <p class="text-secondary">No codebooks found.</p>
+    <p class="text-secondary">No codebooks to show.</p>
   {% endif %}
 {% endblock %}
 {% block scripts %}

--- a/Frontend/web/templates/codebooks/new/mode_select.html
+++ b/Frontend/web/templates/codebooks/new/mode_select.html
@@ -19,7 +19,7 @@
       ] %}
       {% for value, title, description in modes %}
         <div class="col-md-4">
-          <label class="mode-card bg-white border rounded-2 p-4 h-100 d-flex flex-column gap-2 {% if selected == value %}border-primary border-2 shadow-sm{% endif %}"
+          <label class="mode-card hover-lift bg-white border rounded-2 p-4 h-100 d-flex flex-column gap-2 {% if selected == value %}border-primary border-2 shadow-sm{% endif %}"
                  data-mode-card="{{ value }}">
             <input class="visually-hidden mode-radio"
                    type="radio"

--- a/Frontend/web/templates/codebooks/themes.html
+++ b/Frontend/web/templates/codebooks/themes.html
@@ -15,14 +15,6 @@
      data-breakdown-url-template="{{ url_for('codebooks.theme_demographic_breakdown_json', corpus_id=corpus_id, codebook_id=codebook_id, theme_id='__THEME__') }}"
      data-read-url-template="{{ url_for('ingestion.read_transcript', corpus_id=corpus_id, document_id='__DOC__', run_id='__RUN__') }}">
 
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('codebooks.list_codebooks_for_corpus', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Showing themes for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
   {# Breadcrumb #}
   <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb mb-0">
@@ -35,12 +27,18 @@
     </ol>
   </nav>
 
+  {# No corpus scope line here: this is a detail page for one codebook/run
+     (identity shown in the hero), and "switching corpus" would actually
+     navigate away to another corpus's codebook LIST — a trap, not a filter.
+     The breadcrumb is the way back. #}
   {% if error %}
   <p class="text-secondary">Couldn't load themes for this codebook right now.</p>
   {% elif frequencies or tree or codes %}
 
-  {# Gradient page header #}
-  <div class="theme-page-header rounded-3 mb-3 p-4">
+  {# Gradient page hero — one banner per page: codebook identity on top,
+     analysis-run context as a second row inside the same hero, separated by
+     a translucent divider (previously two stacked same-color banners). #}
+  <div class="theme-page-header rounded-3 mb-4 p-4">
     <div class="d-flex align-items-start justify-content-between flex-wrap gap-2">
       <div>
         <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Theme Browser</p>
@@ -59,9 +57,8 @@
         </a>
       </div>
     </div>
-  </div>
 
-  <div class="analysis-run-bar rounded-3 mb-4 p-4">
+    <div class="analysis-run-bar">
     <div class="d-flex align-items-start flex-wrap gap-3">
       <div>
         <p class="text-white-50 small mb-1 text-uppercase fw-semibold" style="letter-spacing:.07em">Analysis Run</p>
@@ -113,6 +110,7 @@
           <p class="analysis-run-message mb-0">No analysis runs for this codebook.</p>
         {% endif %}
       </div>
+    </div>
     </div>
   </div>
 

--- a/Frontend/web/templates/demographic/linking.html
+++ b/Frontend/web/templates/demographic/linking.html
@@ -1,18 +1,18 @@
 {% extends "base.html" %}
 {% block title %}Link Transcripts & Demographics{% endblock %}
 {% block content %}
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('demographic.linking_board', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Linking transcripts and demographic data for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
-  <div class="mb-2">
+  <div class="mb-3">
     <a class="text-decoration-none small"
        href="{{ url_for('demographic.list_files', corpus_id=corpus_id) }}">&larr; Back to demographic data</a>
   </div>
+
+  {% if corpus_id and corpus_options %}
+    {% set active_corpus_id = corpus_id %}
+    {% set switch_template_url = url_for('demographic.linking_board', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
+    {% set helper_text = 'Linking transcripts and demographic data for this corpus.' %}
+    {% include "_corpus_select.html" %}
+  {% endif %}
 
   <div class="d-flex justify-content-between align-items-start mb-3">
     <div>

--- a/Frontend/web/templates/demographic/list.html
+++ b/Frontend/web/templates/demographic/list.html
@@ -1,15 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Demographic Data{% endblock %}
 {% block content %}
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('demographic.list_files', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Showing demographics for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
-  <div class="d-flex justify-content-between align-items-center mb-4">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-3">
     <h1 class="h3 mb-0">Demographic Data</h1>
     {% if corpus_id %}
       <div class="d-flex gap-2">
@@ -26,6 +18,14 @@
       </div>
     {% endif %}
   </div>
+
+  {% if corpus_id and corpus_options %}
+    {% set active_corpus_id = corpus_id %}
+    {% set switch_template_url = url_for('demographic.list_files', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
+    {% set helper_text = 'Showing demographic data for this corpus.' %}
+    {% include "_corpus_select.html" %}
+  {% endif %}
 
   {% if error %}
     <p class="text-secondary">Couldn't load demographic data right now.</p>

--- a/Frontend/web/templates/demographic/view.html
+++ b/Frontend/web/templates/demographic/view.html
@@ -1,18 +1,18 @@
 {% extends "base.html" %}
 {% block title %}View — {{ file_info.name if file_info else 'Demographic Data' }}{% endblock %}
 {% block content %}
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('demographic.list_files', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Showing demographic view for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
-  <div class="mb-2">
+  <div class="mb-3">
     <a class="text-decoration-none small"
        href="{{ url_for('demographic.list_files', corpus_id=corpus_id) }}">&larr; Back to file list</a>
   </div>
+
+  {% if corpus_id and corpus_options %}
+    {% set active_corpus_id = corpus_id %}
+    {% set switch_template_url = url_for('demographic.list_files', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
+    {% set helper_text = 'Showing demographic data for this corpus.' %}
+    {% include "_corpus_select.html" %}
+  {% endif %}
 
   {% if error %}
     <h1 class="h3 mb-4">Demographic Data</h1>

--- a/Frontend/web/templates/index.html
+++ b/Frontend/web/templates/index.html
@@ -66,28 +66,28 @@
 
   <div class="row g-3">
     <div class="col-12 col-md-3">
-      <div class="bg-white border rounded-2 p-3 h-100">
+      <div class="bg-white border rounded-2 p-3 h-100 hover-lift">
         <h2 class="h6 mb-1">Transcripts</h2>
         <p class="text-secondary small mb-3">View and upload your interview documents.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('ingestion.transcripts_landing') }}">View transcripts</a>
       </div>
     </div>
     <div class="col-12 col-md-3">
-      <div class="bg-white border rounded-2 p-3 h-100">
+      <div class="bg-white border rounded-2 p-3 h-100 hover-lift">
         <h2 class="h6 mb-1">Demographic Data</h2>
         <p class="text-secondary small mb-3">Upload and view demographic data linked to interviews.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('demographic.demographic_landing') }}">View data</a>
       </div>
     </div>
     <div class="col-12 col-md-3">
-      <div class="bg-white border rounded-2 p-3 h-100">
+      <div class="bg-white border rounded-2 p-3 h-100 hover-lift">
         <h2 class="h6 mb-1">Codebooks</h2>
         <p class="text-secondary small mb-3">Browse available codebooks and explore theme hierarchies.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('codebooks.list_codebooks') }}">View codebooks</a>
       </div>
     </div>
     <div class="col-12 col-md-3">
-      <div class="bg-white border rounded-2 p-3 h-100">
+      <div class="bg-white border rounded-2 p-3 h-100 hover-lift">
         <h2 class="h6 mb-1">Analysis</h2>
         <p class="text-secondary small mb-3">Run thematic analysis on your corpus and review results.</p>
         <a class="btn btn-sm btn-outline-primary" href="{{ url_for('analysis.index') }}">View analysis</a>

--- a/Frontend/web/templates/ingestion/list.html
+++ b/Frontend/web/templates/ingestion/list.html
@@ -1,15 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Transcripts{% endblock %}
 {% block content %}
-  {% if corpus_id and corpus_options %}
-    {% set active_corpus_id = corpus_id %}
-    {% set switch_template_url = url_for('ingestion.list_transcripts', corpus_id='__CORPUS_ID__') %}
-    {% set helper_text = 'Showing transcripts for this corpus.' %}
-    {% set show_create_form = False %}
-    {% include "_corpus_select.html" %}
-  {% endif %}
-
-  <div class="d-flex justify-content-between align-items-center mb-4">
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-3">
     <h1 class="h3 mb-0">Uploaded Transcripts</h1>
     {% if corpus_id and documents %}
       <a class="btn btn-outline-primary"
@@ -19,6 +11,14 @@
       </a>
     {% endif %}
   </div>
+
+  {% if corpus_id and corpus_options %}
+    {% set active_corpus_id = corpus_id %}
+    {% set switch_template_url = url_for('ingestion.list_transcripts', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
+    {% set helper_text = 'Showing transcripts for this corpus.' %}
+    {% include "_corpus_select.html" %}
+  {% endif %}
 
   {% include "_analysis_delete_confirm_modal.html" %}
 

--- a/Frontend/web/templates/ingestion/results.html
+++ b/Frontend/web/templates/ingestion/results.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
 {% block title %}Upload Results{% endblock %}
 {% block content %}
+  <h1 class="h3 mb-3">Upload Results</h1>
+
   {% if corpus_id and corpus_options %}
     {% set active_corpus_id = corpus_id %}
     {% set switch_template_url = url_for('ingestion.upload_form', corpus_id='__CORPUS_ID__') %}
+    {% set corpus_select_variant = 'scope' %}
     {% set helper_text = 'Showing results for this corpus.' %}
-    {% set show_create_form = False %}
     {% include "_corpus_select.html" %}
   {% endif %}
-
-  <h1 class="h3 mb-4">Upload Results</h1>
 
   {% if results %}
     {% set succeeded = results | selectattr("success") | selectattr("documents_created") | list | length %}


### PR DESCRIPTION
Closes #260

## Summary

First implementation batch for **"Unify the whole frontend"**. The frontend had grown four independent style dialects (stock Bootstrap blue, an indigo/teal/cyan gradient system, a third blue/emerald palette on the pipeline stepper, and page-local styles). This PR introduces a **design-token layer** and unifies the most visible inconsistencies on top of it : colors, the corpus selector, page headers, modals, and empty states without touching any logic or backend calls.

## What changed

### 1. Design tokens (`web/static/css/tokens.css`, new)
- Single source of truth for every color, radius, shadow, and focus style. Raw hex values
  are only allowed in this file.
- Brand **indigo promoted to Bootstrap primary** (`--bs-primary`, links, buttons, badges,
  pagination, progress, accordion, form focus/checked states) — stock-Bootstrap pages
  (Home, Codebooks, Analysis, modals) repaint to the brand without template changes.
- One shared **status set** (success/warning/danger) used by badges, the pipeline stepper,
  toasts, and table rows; teal + cyan kept as scoped accents for the Upload cards.
- `main.css` fully tokenized: no raw hex left except `#fff`; the stepper's off-palette
  blue/emerald family is gone.
- **A11y:** visible keyboard focus rings restored on the corpus selector
  (`.shadow-none` was suppressing them) and the file-remove buttons; hover animations
  respect `prefers-reduced-motion`.

### 2. Corpus selector redesign (`_corpus_select.html`, two variants)
- **Upload page ("bar"):** one slim toolbar : CORPUS label + compact select, with
  "＋ New corpus" and delete moved into modals (the always-visible create form is gone).
- **Browsing pages ("scope"):** a labelled full-width scope line directly under the page
  title — folder icon + CORPUS label + select + per-page helper text ("Showing codebooks
  for this corpus."), closed by a hairline. Fixes the misleading hardcoded
  **"Upload target corpus"** label that appeared on every page, and keeps the control
  visually separate from page action buttons.
- **Theme Browser: removed entirely** : it's a detail page whose "switcher" actually
  navigated away to another corpus's codebook list; the hero + breadcrumb carry the context.

### 3. Theme Browser hero
- The two stacked same-indigo banners (codebook header + analysis-run bar) are merged into
  **one hero**: title row on top, run context as a translucent-divider row inside the same
  banner. One hero per page; ~40px vertical space reclaimed.

### 4. Consistency fixes
- All modal **Cancel/Close buttons** unified to `btn-outline-secondary` (solid = commit,
  outline = back out).
- Upload cards span the full container width, aligned with the toolbar above them.
- **Hover-lift** affordance (shared `.hover-lift` class, same motion as the Upload cards)
  on the Home category cards and the codebook mode-select cards (+ pointer cursor : they
  are fully clickable labels).
- **Codebooks empty state** added, matching Transcripts/Demographic:
  "No codebooks created yet. *Create a codebook*" plus a no-corpus fallback.


## Testing

- `uv run pytest` in `Frontend/`: **230 passed** at every step; assertions updated where
  copy intentionally changed (codebook empty state, themes-page corpus selector)
- Manual click-through on the running stack (docker compose): corpus switching on every
  browsing page, create/delete corpus modals, upload flows, codebook wizard + progress,
  analysis trigger + wait page, Theme Browser incl. the reported double-header URL.



